### PR TITLE
[TG Mirror] Ghost lighting now updates prefs [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/observers.dm
+++ b/code/__DEFINES/observers.dm
@@ -10,3 +10,11 @@
 #define NOTIFY_CATEGORY_DEFAULT (GHOST_NOTIFY_FLASH_WINDOW | GHOST_NOTIFY_IGNORE_MAPLOAD | GHOST_NOTIFY_NOTIFY_SUICIDERS)
 /// The default set of flags, without the flash_window flag.
 #define NOTIFY_CATEGORY_NOFLASH (NOTIFY_CATEGORY_DEFAULT & ~GHOST_NOTIFY_FLASH_WINDOW)
+
+///Assoc List of types of ghost lightings & the player-facing name.
+GLOBAL_LIST_INIT(ghost_lightings, list(
+	"Normal" = LIGHTING_CUTOFF_VISIBLE,
+	"Darker" = LIGHTING_CUTOFF_MEDIUM,
+	"Night Vision" = LIGHTING_CUTOFF_HIGH,
+	"Fullbright" = LIGHTING_CUTOFF_FULLBRIGHT,
+))

--- a/code/modules/client/preferences/ghost_lighting.dm
+++ b/code/modules/client/preferences/ghost_lighting.dm
@@ -1,10 +1,3 @@
-GLOBAL_LIST_INIT(ghost_lighting_options, list(
-	"Fullbright" = LIGHTING_CUTOFF_FULLBRIGHT,
-	"Night Vision" = LIGHTING_CUTOFF_HIGH,
-	"Darker" = LIGHTING_CUTOFF_MEDIUM,
-	"Normal" = LIGHTING_CUTOFF_VISIBLE,
-))
-
 /// How bright a ghost's lighting plane is
 /datum/preference/choiced/ghost_lighting
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
@@ -16,7 +9,7 @@ GLOBAL_LIST_INIT(ghost_lighting_options, list(
 
 /datum/preference/choiced/ghost_lighting/init_possible_values()
 	var/list/values = list()
-	for(var/option_name in GLOB.ghost_lighting_options)
+	for(var/option_name in GLOB.ghost_lightings)
 		values += option_name
 	return values
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -986,8 +986,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/datum/preferences/prefs = client?.prefs
 	if(!prefs || (client?.combo_hud_enabled && prefs.toggles & COMBOHUD_LIGHTING))
 		return ..()
-	return GLOB.ghost_lighting_options[prefs.read_preference(/datum/preference/choiced/ghost_lighting)]
-
+	return GLOB.ghost_lightings[prefs.read_preference(/datum/preference/choiced/ghost_lighting)]
 
 /// Called when we exit the orbiting state
 /mob/dead/observer/proc/on_deorbit(datum/source)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -429,7 +429,7 @@
 
 /// Returns this mob's default lighting alpha
 /mob/proc/default_lighting_cutoff()
-	if(client?.combo_hud_enabled && client?.prefs?.toggles & COMBOHUD_LIGHTING)
+	if(client?.combo_hud_enabled && (client?.prefs?.toggles & COMBOHUD_LIGHTING))
 		return LIGHTING_CUTOFF_FULLBRIGHT
 	return initial(lighting_cutoff)
 


### PR DESCRIPTION
Original PR: 91592
-----
## About The Pull Request

Changing your ghost lighting in the observer menu now updates its respective preference, meaning it follows you through rounds. When I made the UI I wasn't aware that it was also a preference, and I'd assume many others think the same.

## Why It's Good For The Game

It's nice when things you do in game save between rounds without having to manually re-do it, for most of us who haven't scrolled through the long ass settings page through every setting.

## Changelog

:cl:
qol: Changing your ghost lighting in the ghost menu now saves between rounds.
/:cl: