### PR TITLE
[TG Mirror] [NO GBP] Fixes black character previews [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -59,15 +59,17 @@
 #define EMISSIVE_SPACE_LAYER 3
 #define EMISSIVE_WALL_LAYER 4
 
-#define EMISSIVE_BLOOM_PLATE 15
+#define EMISSIVE_BLOOM_MASK_PLATE 15
+#define EMISSIVE_BLOOM_MASK_TARGET "*EMISSIVE_BLOOM_MASK_PLATE"
+#define EMISSIVE_BLOOM_PLATE 16
 
 //-------------------- Game plane assembly ---------------------
 
-#define RENDER_PLANE_GAME 16
+#define RENDER_PLANE_GAME 17
 /// If fov is enabled we'll draw game to this and do shit to it
-#define RENDER_PLANE_GAME_MASKED 17
+#define RENDER_PLANE_GAME_MASKED 18
 /// The bit of the game plane that is let alone is sent here
-#define RENDER_PLANE_GAME_UNMASKED 18
+#define RENDER_PLANE_GAME_UNMASKED 19
 
 //-------------------- Lighting ---------------------
 

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -345,7 +345,8 @@
 	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_color = list(1,1,1,0, 1,1,1,0, 1,1,1,0, 0,0,0,1, 0,0,0,0))
 	/// But for the bloom plate we convert only the red color into full white, this way we can have emissives in green channel unaffected by bloom
 	/// which allows us to selectively bloom only a part of our emissives
-	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_PLATE, offset), relay_color = list(1,1,1,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0))
+	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_PLATE, offset), relay_color = list(255,255,255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0))
+	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_MASK_PLATE, offset), relay_color = list(1,1,1,1, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0))
 
 /atom/movable/screen/plane_master/pipecrawl
 	name = "Pipecrawl"

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -376,12 +376,20 @@
 	plane = RENDER_PLANE_NON_GAME
 	render_relay_planes = list(RENDER_PLANE_MASTER)
 
+/atom/movable/screen/plane_master/rendering_plate/emissive_bloom_mask
+	name = "Emissive bloom mask plate"
+	documentation = "A holder plate used purely as a way to full-white bloom emissives before applying them as a mask onto the emissive bloom plate."
+	plane = EMISSIVE_BLOOM_MASK_PLATE
+	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	render_relay_planes = list()
+	render_target = EMISSIVE_BLOOM_MASK_TARGET
+	critical = PLANE_CRITICAL_DISPLAY
+
 /atom/movable/screen/plane_master/rendering_plate/emissive_bloom
 	name = "Emissive bloom plate"
-	documentation = "Plate used to bloom emissives before adding them onto the overlay lighting plane. This relies on game rendering plate,\
-		which assembles all in-world planes affected by lighting, is above the emissive plane - which allows us to bypass having to fullbright\
-		the emissive plane on a separate plate before alpha masking the rendering plate copy via multiplying fullbright emissive created here\
-		with the game plate, which technically achieves the same effect. Odd, but it works, and is significantly graphically cheaper."
+	documentation = "Plate used to bloom emissives before adding them onto the overlay lighting plane. We do this by multiplying the game plate\
+		onto a fullbright emissive, then alpha masking it by emissive's color to solve the problem of blockers, both alone and covered by emissives."
 	plane = EMISSIVE_BLOOM_PLATE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
@@ -391,7 +399,8 @@
 
 /atom/movable/screen/plane_master/rendering_plate/emissive_bloom/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
-	add_filter("emissive_bloom", 1, bloom_filter(threshold = COLOR_BLACK, size = 2, offset = 1))
+	add_filter("emissive_mask", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(EMISSIVE_BLOOM_MASK_TARGET, offset)))
+	add_filter("emissive_bloom", 2, bloom_filter(threshold = COLOR_BLACK, size = 2, offset = 1))
 
 /atom/movable/screen/plane_master/rendering_plate/turf_lighting
 	name = "Turf lighting post-processing plate"


### PR DESCRIPTION
Original PR: 91616
-----

## About The Pull Request

Okay so in my rush for ~~perfection~~ pretty lighting I did not account for emissive blockers. More specifically the fact that A) emissive blockers draw their blackness onto the emissive plane and B) the fact that 200 alpha emissive on an empty space produces a (255, 255, 255, 200) color, while one drawn over an emissive blocker results in (200, 200, 200, 255). This may seem like it doesn't matter, but this ends up breaking overlay lighting because it ends up drawing blackness onto the lighting plane, even when there should be none. We fix this by adding a plate which converts red to alpha, and then masks the finalized bloomed emissive sprite, solving the blackness issue. To avoid "double dipping", all red is converted to full white regardless of potency (so we only carry over alpha in the multiplication step)
- Closes #91583

## Changelog
:cl:
fix: Fixed black character previews
/:cl:
