### PR TITLE
[TG Mirror] Wallmounts don't trigger mines [MDB IGNORE]

### DIFF
--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -65,6 +65,9 @@
 	if(triggered || !isturf(loc) || iseffect(on_who) || !armed)
 		return FALSE
 
+	if(on_who.anchored || HAS_TRAIT(on_who, TRAIT_WALLMOUNTED))
+		return FALSE
+
 	var/mob/living/living_mob
 	if(ismob(on_who))
 		if(!isliving(on_who)) //no ghosties.


### PR DESCRIPTION
Original PR: 91594
-----

## About The Pull Request

So there's this mine. It's on Nebulastation. It never goes off, because the light above it depresses it at roundstart, and never lets it go. The only time this bwoink mine goes off is if the wall next to it goes down or the light is broken.

![image](https://github.com/user-attachments/assets/83c84d56-82fd-4507-8152-cd625a934692)
## Why It's Good For The Game

Mines can now be placed in a more varied set of locations. Also applies to randomly spawned mines in deathmatch.
## Changelog
:cl: Rhials
fix: Mines will now properly behave when placed under lights or other wallmounts.
/:cl:
