### PR TITLE
[TG Mirror] Fixes xenomorphs being able to infinitely vomit out the same person [MDB IGNORE]

### DIFF
--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -192,6 +192,7 @@
 		RegisterSignal(thing, COMSIG_LIVING_DEATH, PROC_REF(content_died))
 
 /obj/item/organ/stomach/alien/content_moved(atom/movable/source)
+	. = ..()
 	if(source.loc == src || source.loc == owner)
 		return
 	UnregisterSignal(source, COMSIG_LIVING_DEATH)


### PR DESCRIPTION
Original PR: 91589
-----

## About The Pull Request

Didn't call parent, thus didn't unreg the mob.
Closes #91557

## Changelog
:cl:
fix: Fixed xenomorphs being able to infinitely vomit out the same person
/:cl:
