### PR TITLE
[TG Mirror] Fixes critter crate elevation issues. [MDB IGNORE]

### DIFF
--- a/code/datums/elements/elevation.dm
+++ b/code/datums/elements/elevation.dm
@@ -25,6 +25,7 @@
 /datum/element/elevation/Detach(atom/movable/source)
 	unregister_turf(source, source.loc)
 	REMOVE_TRAIT(source, TRAIT_ELEVATING_OBJECT, ref(src))
+	UnregisterSignal(source, COMSIG_MOVABLE_MOVED)
 	return ..()
 
 /datum/element/elevation/proc/reset_elevation(turf/target)


### PR DESCRIPTION
Original PR: 91609
-----

## About The Pull Request

Very simply put, we weren't actually unregistering the `COMSIG_MOVABLE_MOVED` signal on detaching.
This was making it so that when you open a critter crate it doesn't actually unregister the signal, meaning that it re-attaches a lot of its effects to the turf the next time the crate moves. However, because it wasn't actually *properly* attached anymore, breaking the crate wouldn't unregister the turf.
So this was making it so that if you were to open a critter crate and then move it immediately after, it would regain its ability to elevate you as if it were closed, and this would linger even after it breaking.

This fixes that.
## Why It's Good For The Game

Fixes https://github.com/tgstation/tgstation/issues/91204.
## Changelog
:cl:
fix: Critter crates no longer re-attain their ability to lift you despite being open if you move one after opening it, and neither does this lifting field stay after you destroy it.
/:cl:
