### PR TITLE
[TG Mirror] Fix cargo request console being able to shuttle loan [MDB IGNORE]

### DIFF
--- a/code/modules/cargo/orderconsole.dm
+++ b/code/modules/cargo/orderconsole.dm
@@ -95,6 +95,7 @@
 	data["loan_dispatched"] = SSshuttle.shuttle_loan && SSshuttle.shuttle_loan.dispatched
 	data["can_send"] = can_send
 	data["can_approve_requests"] = can_approve_requests
+	data["requestonly"] = requestonly
 	var/message = "Remember to stamp and send back the supply manifests."
 	if(SSshuttle.centcom_message)
 		message = SSshuttle.centcom_message


### PR DESCRIPTION
Original PR: 91597
-----
## About The Pull Request

The computer version doesn't pass `requestonly` in data

## Changelog

:cl: Melbert
fix: Cargo request consoles can't loan the shuttle
/:cl:
