### PR TITLE
[TG Mirror] Adds a bit of runtime prevention to the base guncase [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/storage/toolboxes/weapons.dm
+++ b/code/game/objects/items/storage/toolboxes/weapons.dm
@@ -63,13 +63,17 @@
 	inhand_icon_state = "infiltrator_case"
 	has_latches = FALSE
 	storage_type = /datum/storage/toolbox/guncase
+	/// What weapon do we spawn in our case?
 	var/weapon_to_spawn = /obj/item/gun/ballistic/automatic/pistol
+	/// What magazine do we spawn in our case?
 	var/extra_to_spawn = /obj/item/ammo_box/magazine/m9mm
 
 /obj/item/storage/toolbox/guncase/PopulateContents()
-	new weapon_to_spawn (src)
-	for(var/i in 1 to 3)
-		new extra_to_spawn (src)
+	if(weapon_to_spawn)
+		new weapon_to_spawn (src)
+	if(extra_to_spawn)
+		for(var/iterate in 1 to 3)
+			new extra_to_spawn (src)
 
 /obj/item/storage/toolbox/guncase/traitor
 	name = "makarov gun case"


### PR DESCRIPTION
Original PR: 91642
-----

## About The Pull Request

Just makes sure the variables are actually filled before trying to spawn stuff, so it doesn't try to spawn `null` and runtime
## Why It's Good For The Game

Not entirely relevant here, but it came up downstream when trying to make one that starts empty. Ifever an empty guncase was wanted up here, it might prevent a runtime before it happens.
## Changelog
No player facing changes (am I using that right? There's zero change anybody could see ingame)
