### PR TITLE
[TG Mirror] Heretic ritual peeve with stacks [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -28,7 +28,7 @@
 /obj/item/stack/spacecash/get_item_credit_value()
 	return (amount*value)
 
-/obj/item/stack/spacecash/merge(obj/item/stack/S)
+/obj/item/stack/spacecash/merge(obj/item/stack/target_stack, limit)
 	. = ..()
 	update_desc()
 

--- a/code/modules/antagonists/heretic/heretic_knowledge.dm
+++ b/code/modules/antagonists/heretic/heretic_knowledge.dm
@@ -163,21 +163,6 @@
 		if(isliving(sacrificed))
 			continue
 
-		if(isstack(sacrificed))
-			var/obj/item/stack/sac_stack = sacrificed
-			var/how_much_to_use = 0
-			for(var/requirement in required_atoms)
-				// If it's not requirement type and type is not a list, skip over this check
-				if(!istype(sacrificed, requirement) && !islist(requirement))
-					continue
-				// If requirement *is* a list and the stack *is* in the list, skip over this check
-				if(islist(requirement) && !is_type_in_list(sacrificed, requirement))
-					continue
-				how_much_to_use = min(required_atoms[requirement], sac_stack.amount)
-				break
-			sac_stack.use(how_much_to_use)
-			continue
-
 		selected_atoms -= sacrificed
 		qdel(sacrificed)
 


### PR DESCRIPTION
Original PR: 91001
-----
## About The Pull Request
When a ritual requires a stack, we shouldn't add the stack itself to the list of selected components, but rather split the req amount from the stack and add the resulting item from that proccall to said list instead.

Normally, this shouldn't be a problem, as cleaning up a selected stack is handled in its own way in `heretic_knowledge/cleanup_atoms()`, however some rituals may have a delay, which would make the original stack temporarily invisible. Kinda quirky. Also it's better to handle stack specific behavior in one proc than two.
In the case the ritual fails from missing components, nothing much happens anyway, because the split stack is dropped on the same turf of the original stack.

## Why It's Good For The Game

This probably fixes #90828 and it's a bit more elegant way to handle stacks imo.

## Changelog

:cl:
fix: Sundered blade ritual shouldn't delete more than one sheet of silver or titanium.
/:cl:
