### PR TITLE
[TG Mirror] Fix reloading of empty revolver [MDB IGNORE]

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/_cylinder.dm
@@ -44,9 +44,9 @@
 
 	for(var/i in 1 to stored_ammo.len)
 		var/obj/item/ammo_casing/bullet = stored_ammo[i]
-		if (!istype(bullet) || bullet.loaded_projectile)
+		if(bullet && (!istype(bullet) || bullet.loaded_projectile))
 			continue
-		// found a spent ammo
+		// empty or spent
 		stored_ammo[i] = R
 		R.forceMove(src)
 


### PR DESCRIPTION
Original PR: 91657
-----
## About The Pull Request
Fixes reloading of empty revolver
Fixes #91531

## Why It's Good For The Game
No way to reload a revolver after unloading it is sad

## Changelog

:cl:
fix: Empty revolvers can now be reloaded
/:cl: