### PR TITLE
[TG Mirror] Makes it so henchmen jumpsuit can't be adjusted [MDB IGNORE]

### DIFF
--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -477,6 +477,7 @@
 	worn_icon = 'icons/mob/clothing/under/syndicate.dmi'
 	icon_state = "henchmen"
 	inhand_icon_state = null
+	can_adjust = FALSE
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS|HEAD
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEEARS|HIDEEYES|HIDEHAIR
 


### PR DESCRIPTION
Original PR: 91651
-----

## About The Pull Request
Makes it so henchmen jumpsuit can't be adjusted
## Why It's Good For The Game
Because there isn't a sprite for adjusted henchmen jumpsuit
## Changelog
:cl:
fix: henchmen jumpsuit no longer turns pink and black when u try to adjust it (you can't adjust it now)
/:cl:
