### PR TITLE
[TG Mirror] Change duffelbag update_desc() to examine() [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/storage/dufflebags.dm
+++ b/code/game/objects/items/storage/dufflebags.dm
@@ -25,9 +25,9 @@
 	set_zipper(TRUE)
 	RegisterSignal(src, COMSIG_SPEED_POTION_APPLIED, PROC_REF(on_speed_potioned))
 
-/obj/item/storage/backpack/duffelbag/update_desc(updates)
+/obj/item/storage/backpack/duffelbag/examine(mob/user)
 	. = ..()
-	desc = "[initial(desc)]<br>[zipped_up ? "It's zipped up, preventing you from accessing its contents." : "It's unzipped, and harder to move in."]"
+	. += "[zipped_up ? "It's zipped up, preventing you from accessing its contents." : "It's unzipped, and harder to move in."]"
 
 /obj/item/storage/backpack/duffelbag/attack_self(mob/user, modifiers)
 	if(loc != user) // God fuck TK


### PR DESCRIPTION
Original PR: 91669
-----

## About The Pull Request

Changes `/obj/item/storage/backpack/duffelbag/update_desc` to `/obj/item/storage/backpack/duffelbag/examine`

## Why It's Good For The Game

`examine` is cleaner for this, using `update_desc` also prevents dufflebags from being used as a `/datum/orderable_item` because they fail the unit test for having a dynamic description

## Changelog
:cl:
code: examine text for dufflebag zipper status uses examine proc instead of update_desc
/:cl:
