### PR TITLE
[TG Mirror] Fixes parallax breaking when culled [MDB IGNORE]

### DIFF
--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -84,6 +84,7 @@
 	. = ..()
 	if(offset != 0)
 		// You aren't the source? don't change yourself
+		critical = PLANE_CRITICAL_FUCKO_PARALLAX
 		return
 	RegisterSignal(SSmapping, COMSIG_PLANE_OFFSET_INCREASE, PROC_REF(on_offset_increase))
 	RegisterSignal(SSdcs, COMSIG_NARSIE_SUMMON_UPDATE, PROC_REF(narsie_modified))


### PR DESCRIPTION
Original PR: 91677
-----

## About The Pull Request

This has been broken for over 2 years at this point, when parallax children to which the "primary" (offset-0) plane renders itself got culled, it ended up rendering to nowhere aka master, aka showing through blackness.
Closes #73471

## Changelog
:cl:
fix: Maps with a large amount of Z levels should no longer randomly display space parallax to players with low multi-z culling settings.
/:cl:
