### PR TITLE
[TG Mirror] Make Autochangelog case-insensitive for tags [MDB IGNORE]

### DIFF
--- a/tools/pull_request_hooks/changelogParser.js
+++ b/tools/pull_request_hooks/changelogParser.js
@@ -39,7 +39,7 @@ function parseChangelogBody(lines, openTag) {
     if (match) {
       const [_, type, description] = match;
 
-      const entry = CHANGELOG_KEYS_TO_ENTRY[type];
+      const entry = CHANGELOG_KEYS_TO_ENTRY[type.toLowerCase()];
 
       if (!entry || entry.placeholders.includes(description)) {
         continue;

--- a/tools/pull_request_hooks/changelogParser.test.js
+++ b/tools/pull_request_hooks/changelogParser.test.js
@@ -14,6 +14,19 @@ assert.equal(basicChangelog.changes.length, 1);
 assert.equal(basicChangelog.changes[0].type.changelogKey, "rscadd");
 assert.equal(basicChangelog.changes[0].description, "Adds new stuff");
 
+// Case-insensitivity test
+const mixedCaseChangelog = parseChangelog(`
+    My cool PR!
+    :cl: DenverCoder9
+    Add: Adds new stuff
+    /:cl:
+`);
+
+assert.equal(mixedCaseChangelog.author, "DenverCoder9");
+assert.equal(mixedCaseChangelog.changes.length, 1);
+assert.equal(mixedCaseChangelog.changes[0].type.changelogKey, "rscadd");
+assert.equal(mixedCaseChangelog.changes[0].description, "Adds new stuff");
+
 // Multi-line test
 const multiLineChangelog = parseChangelog(`
 	My cool PR!


### PR DESCRIPTION
Original PR: 91678
-----
## About The Pull Request

Changes `changelogParser.js` so looking up the changelog entry type is case-insensitive e.g. `Fix: blahblah` is recognized. Also added a new test in `changelogParser.test.js` to test the functionality

## Why It's Good For The Game

I fucked this up once and I saw someone else fuck it up recently (in my case I backspaced the changelog cause I didn't think it needed one, then later decided it did but I capitalized the tag name and it caused there to be no changelog entry once merged) and it's a dead simple thing to account for

## Changelog
:cl:
code: Autochangelog no longer cares if your changelog entry tag has capital letters in it
/:cl:
