### PR TITLE
[TG Mirror] Fix water vapor making no slip turfs wet [MDB IGNORE]

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -112,7 +112,8 @@
 			if(location?.freeze_turf())
 				consumed = MOLES_GAS_VISIBLE
 		if(WATER_VAPOR_DEPOSITION_POINT to WATER_VAPOR_CONDENSATION_POINT)
-			location.water_vapor_gas_act()
+			if(!isgroundlessturf(location) && !isnoslipturf(location))
+				location.water_vapor_gas_act()
 			consumed = MOLES_GAS_VISIBLE
 
 	if(consumed)


### PR DESCRIPTION
Original PR: 91685
-----

## About The Pull Request
- Fixes #91683

Water vapor on certain tiles like water turfs and turfs that should have no slip resistance (grass, dirt, etc.) will no longer get wet and slippery.

## Why It's Good For The Game
Water will behave as intended.

## Changelog
:cl:
fix: Fix water vapor making water tiles and no slip turfs wet
/:cl:
