### PR TITLE
[TG Mirror] Stacks check for invalid amounts [MDB IGNORE]

### DIFF
--- a/code/datums/components/cult_ritual_item.dm
+++ b/code/datums/components/cult_ritual_item.dm
@@ -181,7 +181,7 @@
 		span_warning("[cultist] strikes [cult_girder] with [parent]!"),
 		span_notice("You demolish [cult_girder].")
 		)
-	new /obj/item/stack/sheet/runed_metal(cult_girder.drop_location(), 1)
+	new /obj/item/stack/sheet/runed_metal(cult_girder.drop_location())
 	qdel(cult_girder)
 
 /*

--- a/code/game/machinery/computer/atmos_computers/_air_sensor.dm
+++ b/code/game/machinery/computer/atmos_computers/_air_sensor.dm
@@ -230,4 +230,4 @@
 
 /obj/item/air_sensor/atom_deconstruct(disassembled)
 	new /obj/item/analyzer(loc)
-	new /obj/item/stack/sheet/iron(loc, 1)
+	new /obj/item/stack/sheet/iron(loc)

--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -247,9 +247,10 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/defibrillator_mount, 28)
 	return TRUE
 
 /obj/machinery/defibrillator_mount/mobile/on_deconstruction(disassembled)
+	var/atom/drop = drop_location()
 	if(disassembled)
-		new /obj/item/stack/sheet/iron(drop_location(), 5)
-		new /obj/item/stack/sheet/mineral/silver(drop_location(), 1)
-		new /obj/item/stack/cable_coil(drop_location(), 15)
+		new /obj/item/stack/sheet/iron(drop, 5)
+		new /obj/item/stack/sheet/mineral/silver(drop)
+		new /obj/item/stack/cable_coil(drop, 15)
 	else
-		new /obj/item/stack/sheet/iron(drop_location(), 5)
+		new /obj/item/stack/sheet/iron(drop, 5)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -437,7 +437,7 @@
 	return ..()
 
 /obj/machinery/firealarm/on_deconstruction(disassembled)
-	new /obj/item/stack/sheet/iron(loc, 1)
+	new /obj/item/stack/sheet/iron(loc)
 	if(buildstage > FIRE_ALARM_BUILD_NO_CIRCUIT)
 		var/obj/item/item = new /obj/item/electronics/firealarm(loc)
 		if(!disassembled)

--- a/code/game/machinery/prisonlabor.dm
+++ b/code/game/machinery/prisonlabor.dm
@@ -65,4 +65,4 @@
 	QDEL_NULL(current_plate)
 	update_appearance()
 
-	new /obj/item/stack/license_plates/filled(drop_location(), 1)
+	new /obj/item/stack/license_plates/filled(drop_location())

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -93,7 +93,7 @@
 		push_over()
 
 /obj/item/cardboard_cutout/atom_deconstruct(disassembled)
-	new /obj/item/stack/sheet/cardboard(loc, 1)
+	new /obj/item/stack/sheet/cardboard(loc)
 
 /proc/get_cardboard_cutout_instance(datum/cardboard_cutout/cardboard_cutout)
 	ASSERT(ispath(cardboard_cutout), "[cardboard_cutout] is not a path of /datum/cardboard_cutout")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -750,7 +750,7 @@
 	if(flags_1 & HOLOGRAM_1)
 		return
 
-	var/obj/item/stack/sheet/cardboard/cardboard = new /obj/item/stack/sheet/cardboard(user.drop_location())
+	var/obj/item/stack/sheet/cardboard/cardboard = new (user.drop_location())
 	to_chat(user, span_notice("You fold the [src] into cardboard."))
 	user.put_in_active_hand(cardboard)
 	qdel(src)

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -82,7 +82,7 @@ GLOBAL_LIST_INIT(sandbag_recipes, list ( \
 	if(istype(W, /obj/item/stack/ore/glass))
 		var/obj/item/stack/ore/glass/G = W
 		to_chat(user, span_notice("You fill the sandbag."))
-		var/obj/item/stack/sheet/mineral/sandbags/I = new /obj/item/stack/sheet/mineral/sandbags(drop_location())
+		var/obj/item/stack/sheet/mineral/sandbags/I = new (drop_location())
 		qdel(src)
 		if (Adjacent(user) && !issilicon(user))
 			user.put_in_hands(I)

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -16,7 +16,9 @@
 	table_type = /obj/structure/table/greyscale
 	pickup_sound = 'sound/items/handling/materials/metal_pick_up.ogg'
 	drop_sound = 'sound/items/handling/materials/metal_drop.ogg'
-	var/sheettype = null //this is used for girders in the creation of walls/false walls
+	sound_vary = TRUE
+	/// this is used for girders in the creation of walls/false walls
+	var/sheettype = null
 	///If true, this is worth points in the gulag labour stacker
 	var/gulag_valid = FALSE
 	///Set to true if this is vended from a material storage
@@ -25,8 +27,6 @@
 	var/walltype
 	/// whether this sheet can be sniffed by the material sniffer
 	var/sniffable = FALSE
-	/// this makes pickup and drop sounds vary
-	sound_vary = TRUE
 
 /obj/item/stack/sheet/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)
 	. = ..()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -72,9 +72,11 @@
 	/// or until the cut heals, whichever comes first
 	var/absorption_rate
 
-/obj/item/stack/Initialize(mapload, new_amount, merge = TRUE, list/mat_override=null, mat_amt=1)
-	if(new_amount != null)
-		amount = new_amount
+/obj/item/stack/Initialize(mapload, new_amount = amount, merge = TRUE, list/mat_override=null, mat_amt=1)
+	amount = new_amount
+	if(amount <= 0)
+		stack_trace("invalid amount [amount]!")
+		return INITIALIZE_HINT_QDEL
 	while(amount > max_amount)
 		amount -= max_amount
 		new type(loc, max_amount, FALSE, mat_override, mat_amt)

--- a/code/game/objects/structures/bonfire.dm
+++ b/code/game/objects/structures/bonfire.dm
@@ -90,7 +90,7 @@
 			bonfire_log.pixel_x += rand(1,4)
 			bonfire_log.pixel_y += rand(1,4)
 		if(can_buckle || grill)
-			new /obj/item/stack/rods(loc, 1)
+			new /obj/item/stack/rods(loc)
 		qdel(src)
 		return
 

--- a/code/game/objects/structures/curtains.dm
+++ b/code/game/objects/structures/curtains.dm
@@ -76,7 +76,7 @@
 /obj/structure/curtain/atom_deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/cloth (loc, 2)
 	new /obj/item/stack/sheet/plastic (loc, 2)
-	new /obj/item/stack/rods (loc, 1)
+	new /obj/item/stack/rods (loc)
 
 /obj/structure/curtain/play_attack_sound(damage_amount, damage_type = BRUTE, damage_flag = 0)
 	switch(damage_type)
@@ -110,7 +110,7 @@
 
 /obj/structure/curtain/cloth/atom_deconstruct(disassembled = TRUE)
 	new /obj/item/stack/sheet/cloth (loc, 4)
-	new /obj/item/stack/rods (loc, 1)
+	new /obj/item/stack/rods (loc)
 
 /obj/structure/curtain/cloth/fancy
 	icon_type = "cur_fancy"

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -478,7 +478,7 @@
 	return
 
 /obj/structure/girder/cult/atom_deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/runed_metal(drop_location(), 1)
+	new /obj/item/stack/sheet/runed_metal(drop_location())
 
 /obj/structure/girder/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	switch(the_rcd.mode)

--- a/code/game/objects/structures/maintenance.dm
+++ b/code/game/objects/structures/maintenance.dm
@@ -303,7 +303,7 @@ at the cost of risking a vicious bite.**/
 		return TRUE
 
 /obj/structure/steam_vent/atom_deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/iron(loc, 1)
+	new /obj/item/stack/sheet/iron(loc)
 	new /obj/item/stock_parts/water_recycler(loc, 1)
 
 /**

--- a/code/modules/bitrunning/objects/loot_crate.dm
+++ b/code/modules/bitrunning/objects/loot_crate.dm
@@ -66,9 +66,11 @@
 
 /// Handles generating random numbers & calculating loot totals
 /obj/structure/closet/crate/secure/bitrunning/decrypted/proc/calculate_loot(reward_points, rewards_multiplier, ore_multiplier)
+	PRIVATE_PROC(TRUE)
+
 	var/base = rewards_multiplier + reward_points
 	var/random_sum = (rand() + 0.5) * base
-	return ROUND_UP(random_sum * ore_multiplier)
+	return max(ROUND_UP(random_sum * ore_multiplier), 1)
 
 /// Handles spawning completion loot. This tries to handle bad flat and assoc lists
 /obj/structure/closet/crate/secure/bitrunning/decrypted/proc/spawn_loot(list/completion_loot)

--- a/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/elephantgraveyard.dm
@@ -77,11 +77,11 @@
 
 /turf/closed/mineral/strong/wasteland/drop_ores()
 	if(prob(10))
-		new /obj/item/stack/ore/iron(src, 1)
-		new /obj/item/stack/ore/glass(src, 1)
+		new /obj/item/stack/ore/iron(src)
+		new /obj/item/stack/ore/glass(src)
 		new /obj/effect/decal/remains/human(src, 1)
 	else
-		new /obj/item/stack/sheet/bone(src, 1)
+		new /obj/item/stack/sheet/bone(src)
 
 //***Oil well puddles.
 /obj/structure/sink/oil_well //You're not going to enjoy bathing in this...

--- a/code/modules/modular_computers/file_system/programs/arcade.dm
+++ b/code/modules/modular_computers/file_system/programs/arcade.dm
@@ -168,7 +168,7 @@
 			else
 				computer.visible_message(span_notice("\The [computer] prints out paper."))
 				if(ticket_count >= 1)
-					new /obj/item/stack/arcadeticket((get_turf(computer)), 1)
+					new /obj/item/stack/arcadeticket((get_turf(computer)))
 					to_chat(gamer, span_notice("[computer] dispenses a ticket!"))
 					ticket_count -= 1
 					computer.stored_paper -= 1

--- a/code/modules/reagents/chemistry/machinery/chem_separator.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_separator.dm
@@ -42,7 +42,7 @@
 /obj/structure/chem_separator/atom_deconstruct(disassembled)
 	var/atom/drop = drop_location()
 
-	new /obj/item/stack/sheet/mineral/wood(drop, 1)
+	new /obj/item/stack/sheet/mineral/wood(drop)
 
 	new /obj/item/thermometer(drop)
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -36,7 +36,7 @@
 		new /obj/effect/decal/cleanable/wrapping(turf_loc)
 	else
 		playsound(loc, 'sound/items/box_cut.ogg', 50, TRUE)
-		new /obj/item/stack/package_wrap(turf_loc, 1)
+		new /obj/item/stack/package_wrap(turf_loc)
 	for(var/atom/movable/movable_content as anything in contents)
 		movable_content.forceMove(turf_loc)
 

--- a/code/modules/transport/tram/tram_controller.dm
+++ b/code/modules/transport/tram/tram_controller.dm
@@ -946,7 +946,7 @@
 		new /obj/item/wallframe/tram/controller(drop_location)
 	else
 		new /obj/item/stack/sheet/mineral/titanium(drop_location, 2)
-		new /obj/item/stack/sheet/iron(drop_location, 1)
+		new /obj/item/stack/sheet/iron(drop_location)
 
 /**
  * Update the blinky lights based on the controller status, allowing to quickly check without opening up the cabinet.

--- a/code/modules/transport/tram/tram_displays.dm
+++ b/code/modules/transport/tram/tram_displays.dm
@@ -81,13 +81,14 @@
 		. += span_notice("It is secured to the tram wall with [EXAMINE_HINT("bolts.")]")
 
 /obj/machinery/transport/destination_sign/on_deconstruction(disassembled)
+	var/atom/drop = drop_location()
 	if(disassembled)
-		new /obj/item/wallframe/indicator_display(drop_location())
+		new /obj/item/wallframe/indicator_display(drop)
 	else
-		new /obj/item/stack/sheet/mineral/titanium(drop_location(), 2)
-		new /obj/item/stack/sheet/iron(drop_location(), 1)
-		new /obj/item/shard(drop_location())
-		new /obj/item/shard(drop_location())
+		new /obj/item/stack/sheet/mineral/titanium(drop, 2)
+		new /obj/item/stack/sheet/iron(drop)
+		new /obj/item/shard(drop)
+		new /obj/item/shard(drop)
 
 /obj/machinery/transport/destination_sign/indicator/wrench_act_secondary(mob/living/user, obj/item/tool)
 	. = ..()

--- a/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/other_tools.dm
@@ -385,7 +385,7 @@
 
 ///Introduces the actual fuel type to be used, as well as the starting amount of said fuel
 /obj/item/mecha_parts/mecha_equipment/generator/proc/generator_init()
-	fuel = new /obj/item/stack/sheet/mineral/plasma(src, 0)
+	fuel = new /obj/item/stack/sheet/mineral/plasma(src, 1)
 
 /////////////////////////////////////////// THRUSTERS /////////////////////////////////////////////
 

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -138,12 +138,14 @@
 	. = ..()
 	if (!disassembled)
 		return
-	new /obj/item/stack/rods(drop_location(), 2)
-	new /obj/item/stack/sheet/iron(drop_location(), 6)
+
+	var/atom/drop = drop_location()
+	new /obj/item/stack/rods(drop, 2)
+	new /obj/item/stack/sheet/iron(drop, 6)
 	for(var/datum/stock_part/part in component_parts)
-		new part.physical_object_type(drop_location())
+		new part.physical_object_type(drop)
 	if(!isnull(power_cell))
-		power_cell.forceMove(drop_location())
+		power_cell.forceMove(drop)
 		power_cell = null
 
 /obj/vehicle/ridden/wheelchair/motorized/screwdriver_act(mob/living/user, obj/item/tool)


### PR DESCRIPTION
Original PR: 91656
-----
## About The Pull Request
Alleviates #91603

As in it does not fix it because i have not been able to reproduce it. It now checks for invalid values and defaults to `amount`(which is 1) during `Initialize()` and not null so we don't have to pass the number `1` when creating a single sheet.
 
A stack trace is thrown for <= 0 sheet amounts so we can debug & fix stuff

## Changelog
:cl:
code: stacks error on invalid amounts, removed manual passing of number `1` when creating a single stack in many cases
/:cl:
