### PR TITLE
[TG Mirror] Fix broken link to TGUI component documentation [MDB IGNORE]

### DIFF
--- a/tgui/README.md
+++ b/tgui/README.md
@@ -32,7 +32,7 @@ translate concepts between old and new tgui, read this
 
 ### Other Documentation
 
-- [Component Reference](docs/component-reference.md) - UI building blocks
+- [Component Reference](https://tgstation.github.io/tgui-core/?path=/docs/components-animatednumber--docs) - UI building blocks
 - [Tgui Core](https://github.com/tgstation/tgui-core) - The component library for tgui.
 - [Using TGUI and Byond API for custom HTML popups](docs/tgui-for-custom-html-popups.md)
 - [Chat Embedded Components](docs/chat-embedded-components.md)


### PR DESCRIPTION
Original PR: 91682
-----

## About The Pull Request
A few days ago TGUI was updated in:
- #91644

It removed the old component guide since it was out of date and replaced it with Storyboard. However it never updated the `README.md` and people are sent to a broken link to non-existing component guide.

## Why It's Good For The Game
Working documentation good.

## Changelog
N/A
