### PR TITLE
[TG Mirror] Brings back clean toolbox force [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/storage/toolboxes/mechanical.dm
+++ b/code/game/objects/items/storage/toolboxes/mechanical.dm
@@ -48,7 +48,7 @@
 /obj/item/storage/toolbox/mechanical/old/clean/proc/calc_damage()
 	var/power = 0
 	for (var/obj/item/stack/telecrystal/stored_crystals in get_all_contents())
-		power += (stored_crystals.amount / 2)
+		power += stored_crystals.amount
 	force = initial(force) + power
 	throwforce = initial(throwforce) + power
 


### PR DESCRIPTION
Original PR: 91641
-----
## About The Pull Request

Returns clean toolbox back to their original force upgrade of 1TC = 1 damage, rather than .5 - which was added because progtots had access to 'infinite' TC.

## Why It's Good For The Game

Progression traitor is dead

## Changelog

:cl:
balance: Assistant-only clean toolbox now does 1 damage per TC again.
/:cl: