### PR TITLE
[TG Mirror] Removes un-needed calls to `RefreshParts()` [MDB IGNORE]

### DIFF
--- a/code/game/machinery/dish_drive.dm
+++ b/code/game/machinery/dish_drive.dm
@@ -39,10 +39,6 @@
 
 	COOLDOWN_DECLARE(time_since_dishes)
 
-/obj/machinery/dish_drive/Initialize(mapload)
-	. = ..()
-	RefreshParts()
-
 /obj/machinery/dish_drive/examine(mob/user)
 	. = ..()
 	if(user.Adjacent(src))

--- a/code/game/machinery/medipen_refiller.dm
+++ b/code/game/machinery/medipen_refiller.dm
@@ -26,7 +26,6 @@
 	AddComponent(/datum/component/plumbing/simple_demand)
 	AddComponent(/datum/component/simple_rotation)
 	register_context()
-	RefreshParts()
 
 /obj/machinery/medipen_refiller/add_context(atom/source, list/context, obj/item/held_item, mob/user)
 	. = ..()

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -102,8 +102,7 @@
 
 /obj/machinery/teleport/hub/syndicate/Initialize(mapload)
 	. = ..()
-	var/obj/item/stock_parts/matter_bin/super/super_bin = new(src)
-	LAZYADD(component_parts, super_bin)
+	LAZYADD(component_parts, GLOB.stock_part_datums[/datum/stock_part/matter_bin/tier3])
 	RefreshParts()
 
 /obj/machinery/teleport/station

--- a/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/thermomachine.dm
@@ -42,7 +42,6 @@
 
 /obj/machinery/atmospherics/components/unary/thermomachine/Initialize(mapload)
 	. = ..()
-	RefreshParts()
 	update_appearance(UPDATE_ICON)
 	register_context()
 

--- a/code/modules/explorer_drone/scanner_array.dm
+++ b/code/modules/explorer_drone/scanner_array.dm
@@ -201,7 +201,6 @@ GLOBAL_LIST_INIT(scan_conditions,init_scan_conditions())
 	. = ..()
 	RegisterSignals(GLOB.exoscanner_controller,list(COMSIG_EXOSCAN_STARTED,COMSIG_EXOSCAN_FINISHED), PROC_REF(scan_change))
 	update_readiness()
-	RefreshParts()
 
 /obj/machinery/exoscanner/RefreshParts()
 	. = ..()

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -1047,9 +1047,6 @@
 				set_seed(null)
 			set_weedlevel(0) //Has a side effect of cleaning up those nasty weeds
 			return
-	else if(istype(O, /obj/item/storage/part_replacer))
-		RefreshParts()
-		return
 	else if(istype(O, /obj/item/gun/energy/floragun))
 		var/obj/item/gun/energy/floragun/flowergun = O
 		if(flowergun.cell.charge < flowergun.cell.maxcharge)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -124,7 +124,6 @@ GLOBAL_LIST_INIT(paper_blanks, init_paper_blanks())
 
 /obj/machinery/photocopier/Initialize(mapload)
 	. = ..()
-	RefreshParts()
 	setup_components()
 	AddElement(/datum/element/elevation, pixel_shift = 8) //enough to look like your bums are on the machine.
 	if(starting_paper)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -62,7 +62,6 @@
 	. = ..()
 	//Add to the early process queue to prioritize power draw
 	SSmachines.processing_early += src
-	RefreshParts()
 	set_wires(new /datum/wires/emitter(src))
 	if(welded)
 		if(!anchored)

--- a/code/modules/vehicles/mecha/mech_fabricator.dm
+++ b/code/modules/vehicles/mecha/mech_fabricator.dm
@@ -64,7 +64,6 @@
 	rmat = AddComponent(/datum/component/remote_materials, mapload && link_on_init)
 	cached_designs = list()
 	illegal_local_designs = list()
-	RefreshParts() //Recalculating local material sizes if the fab isn't linked
 	return ..()
 
 /obj/machinery/mecha_part_fabricator/Destroy()


### PR DESCRIPTION
Original PR: 91564
-----
## About The Pull Request
This is the chain of command
https://github.com/tgstation/tgstation/blob/a2596a4872fa58b771252cfbaa04d067fbaf0959/code/game/machinery/_machinery.dm#L169
https://github.com/tgstation/tgstation/blob/a2596a4872fa58b771252cfbaa04d067fbaf0959/code/game/objects/items/circuitboards/circuitboard.dm#L107

Meaning as long as the machine has a circuit board of type `obj/item/circuitboard/machine` it will call `RefreshParts()` for us on `Initialize()` so we don't have to. This is a heavy proc so let's not

## Changelog
:cl:
code: removes un-needed calls to `RefreshParts()`
/:cl:
