### PR TITLE
[TG Mirror] Enabling throw mode while ejecting casings has you catch them (except for when you don't) [MDB IGNORE]

### DIFF
--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -42,6 +42,9 @@
 	///If set, this casing will damage any gun it's fired from by the specified amount
 	var/integrity_damage = 0
 
+	/// Set when this casing is fired. Only used for checking if it should burn a user's hand when caught from an ejection port.
+	var/shot_timestamp = 0
+
 /obj/item/ammo_casing/spent
 	name = "spent bullet casing"
 	loaded_projectile = null

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -30,7 +30,7 @@
 			var/throwtarget = get_step(fired_from, get_dir(target, fired_from))
 			firer.safe_throw_at(throwtarget, 1, 2)
 	update_appearance()
-
+	shot_timestamp = world.time
 	SEND_SIGNAL(src, COMSIG_FIRE_CASING, target, user, fired_from, randomspread, spread, zone_override, params, distro, thrown_proj)
 
 	return TRUE


### PR DESCRIPTION
Original PR: 91645
-----
## About The Pull Request
When racking a gun (e.g. pulling the slide on a pistol, racking a shotgun's pump, etc. etc), if you have throw mode enabled, you'll attempt to catch the ejected casing.
![image](https://github.com/user-attachments/assets/74a58d8f-d51b-4d86-b203-4695793d2728)

This can fail, though, which gives you a funny message under these circumstances:
- Your hands are full.
![image](https://github.com/user-attachments/assets/923f8162-b801-4862-a912-6b34018d800e)
- The casing was fired in the last 5 seconds, and you do not have the protection of hand required to remove a lightbulb.
![image](https://github.com/user-attachments/assets/bd19d705-ba29-4f20-94ab-149bf0a08e4e)
You catch it if you have the lightbulb remover trait/skillchip, though.
![image](https://github.com/user-attachments/assets/605a6436-f10c-41e5-a8ae-56d9837e1007)
-  You try to catch it while clumsy (e.g. being a clown). To add insult to injury, trying to catch a hot casing has it burn you even if you're wearing gloves. Don't think about that too hard.
![image](https://github.com/user-attachments/assets/3cca0147-1da3-4dda-995e-d1d2e2aa5f2e)

## Why It's Good For The Game
Changing shotgun ammo sucks less. Look cool to your friends while possibly wasting ammo. Feel like a doofus when you get the funny red text that says you dropped the casing because your hands were full. The possibilities are very limited but it seems like it'd be nice to not have to fumble for dropped casings all the time. (Now it's just most.)

## Changelog

:cl:
qol: Having throw mode enabled while racking the slide on a gun has you catch the ejected casing. Unless your hands are full, your hands are unprotected and the casing is recently fired, or you are clumsy (e.g. a clown), in which case you drop the casing and look silly.
/:cl: