### PR TITLE
[TG Mirror] Rebalances wound determination values, wounding escalation and wound armor to hopefully be less explosive [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_main.dm
@@ -109,9 +109,9 @@
 /// allows you to add multiplicative damage modifiers to the damage mods argument to adjust incoming damage
 /// not sent if the apply damage call was forced
 #define COMSIG_MOB_APPLY_DAMAGE_MODIFIERS "mob_apply_damage_modifiers"
-/// from base of /mob/living/proc/apply_damage(): (damage, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item)
+/// from base of /mob/living/proc/apply_damage(): (damage, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item)
 #define COMSIG_MOB_APPLY_DAMAGE "mob_apply_damage"
-/// from /mob/living/proc/apply_damage(): (damage, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item)
+/// from /mob/living/proc/apply_damage(): (damage, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item)
 /// works like above but after the damage is actually inflicted
 #define COMSIG_MOB_AFTER_APPLY_DAMAGE "mob_after_apply_damage"
 

--- a/code/__DEFINES/wounds.dm
+++ b/code/__DEFINES/wounds.dm
@@ -1,14 +1,14 @@
 // ~wound damage/rolling defines
 /// the cornerstone of the wound threshold system, your base wound roll for any attack is rand(1, damage^this), after armor reduces said damage. See [/obj/item/bodypart/proc/check_wounding]
 #define WOUND_DAMAGE_EXPONENT 1.4
-/// any damage dealt over this is ignored for damage rolls unless the target has the frail quirk (35^1.4=145, for reference)
-#define WOUND_MAX_CONSIDERED_DAMAGE 35
+/// any damage dealt over this is ignored for damage rolls unless the target has the frail quirk (25^1.4=91, for reference)
+#define WOUND_MAX_CONSIDERED_DAMAGE 25
 /// an attack must do this much damage after armor in order to roll for being a wound (so pressure damage/being on fire doesn't proc it)
 #define WOUND_MINIMUM_DAMAGE 5
 /// an attack must do this much damage after armor in order to be eliigible to dismember a suitably mushed bodypart
 #define DISMEMBER_MINIMUM_DAMAGE 10
-/// If an attack rolls this high with their wound (including mods), we try to outright dismember the limb. Note 250 is high enough that with a perfect max roll of 145 (see max cons'd damage), you'd need +100 in mods to do this
-#define WOUND_DISMEMBER_OUTRIGHT_THRESH 250
+/// If an attack rolls this high with their wound (including mods), we try to outright dismember the limb. Note 250 is high enough that with a perfect max roll of 90 (see max cons'd damage), you'd need +60 in mods to do this
+#define WOUND_DISMEMBER_OUTRIGHT_THRESH 150
 /// set wound_bonus on an item or attack to this to disable checking wounding for the attack
 #define CANT_WOUND -100
 

--- a/code/__HELPERS/logging/attack.dm
+++ b/code/__HELPERS/logging/attack.dm
@@ -46,10 +46,10 @@
  * * suffered_wound- The wound, already applied, that we're logging. It has to already be attached so we can get the limb from it
  * * dealt_damage- How much damage is associated with the attack that dealt with this wound.
  * * dealt_wound_bonus- The wound_bonus, if one was specified, of the wounding attack
- * * dealt_bare_wound_bonus- The bare_wound_bonus, if one was specified *and applied*, of the wounding attack. Not shown if armor was present
- * * base_roll- Base wounding ability of an attack is a random number from 1 to (dealt_damage ** WOUND_DAMAGE_EXPONENT). This is the number that was rolled in there, before mods
+ * * dealt_exposed_wound_bonus- The exposed_wound_bonus, if one was specified *and applied*, of the wounding attack. Not shown if armor was present
+ * * base_roll- Base wounding ability of an attack is a random number from 1 to (dealt_damage * WOUND_DAMAGE_EXPONENT). This is the number that was rolled in there, before mods
  */
-/proc/log_wound(atom/victim, datum/wound/suffered_wound, dealt_damage, dealt_wound_bonus, dealt_bare_wound_bonus, base_roll)
+/proc/log_wound(atom/victim, datum/wound/suffered_wound, dealt_damage, dealt_wound_bonus, dealt_exposed_wound_bonus, base_roll)
 	if(QDELETED(victim) || !suffered_wound)
 		return
 	var/message = "suffered: [suffered_wound][suffered_wound.limb ? " to [suffered_wound.limb.plaintext_zone]" : null]"// maybe indicate if it's a promote/demote?
@@ -63,8 +63,8 @@
 	if(dealt_wound_bonus)
 		message += " | WB: [dealt_wound_bonus]"
 
-	if(dealt_bare_wound_bonus)
-		message += " | BWB: [dealt_bare_wound_bonus]"
+	if(dealt_exposed_wound_bonus)
+		message += " | BWB: [dealt_exposed_wound_bonus]"
 
 	victim.log_message(message, LOG_ATTACK, color="blue")
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -356,7 +356,7 @@
 		def_zone = targeting,
 		blocked = armor_block,
 		wound_bonus = wounding,
-		bare_wound_bonus = attacking_item.bare_wound_bonus,
+		exposed_wound_bonus = attacking_item.exposed_wound_bonus,
 		sharpness = attacking_item.get_sharpness(),
 		attack_direction = get_dir(user, src),
 		attacking_item = attacking_item,

--- a/code/datums/components/curse_of_hunger.dm
+++ b/code/datums/components/curse_of_hunger.dm
@@ -150,7 +150,7 @@
 
 	///no food found: it bites you and regains some health.
 	cursed.visible_message(span_danger("[cursed_item] bites [cursed]!"), span_userdanger("[cursed_item] bites you to sate [cursed_item.p_their()] hunger!"))
-	cursed.apply_damage(60, BRUTE, BODY_ZONE_CHEST, wound_bonus = -20, bare_wound_bonus = 20)
+	cursed.apply_damage(60, BRUTE, BODY_ZONE_CHEST, wound_bonus = -20, exposed_wound_bonus = 20)
 	current_health = min(current_health + 1, max_health)
 
 #undef HUNGER_THRESHOLD_WARNING

--- a/code/datums/components/dart_insert.dm
+++ b/code/datums/components/dart_insert.dm
@@ -81,7 +81,7 @@
 	RegisterSignal(dart_projectile, COMSIG_ATOM_UPDATE_OVERLAYS, PROC_REF(on_projectile_update_overlays))
 	RegisterSignals(dart_projectile, list(COMSIG_PROJECTILE_ON_SPAWN_DROP, COMSIG_PROJECTILE_ON_SPAWN_EMBEDDED), PROC_REF(on_spawn_drop))
 	apply_var_modifiers(dart_projectile)
-	dart.harmful = dart_projectile.damage > 0 || dart_projectile.wound_bonus > 0 || dart_projectile.bare_wound_bonus > 0
+	dart.harmful = dart_projectile.damage > 0 || dart_projectile.wound_bonus > 0 || dart_projectile.exposed_wound_bonus > 0
 	SEND_SIGNAL(parent, COMSIG_DART_INSERT_ADDED, dart)
 	dart.update_appearance()
 	dart_projectile.update_appearance()
@@ -99,7 +99,7 @@
 		remove_var_modifiers(projectile)
 		UnregisterSignal(projectile, list(COMSIG_PROJECTILE_ON_SPAWN_DROP, COMSIG_PROJECTILE_ON_SPAWN_EMBEDDED, COMSIG_ATOM_UPDATE_OVERLAYS))
 		if(dart?.loaded_projectile == projectile)
-			dart.harmful = projectile.damage > 0 || projectile.wound_bonus > 0 || projectile.bare_wound_bonus > 0
+			dart.harmful = projectile.damage > 0 || projectile.wound_bonus > 0 || projectile.exposed_wound_bonus > 0
 		projectile.update_appearance()
 	SEND_SIGNAL(parent, COMSIG_DART_INSERT_REMOVED, dart, projectile, user)
 	UnregisterSignal(parent, list(COMSIG_QDELETING, COMSIG_MOVABLE_MOVED))
@@ -140,7 +140,7 @@
 	projectile.speed += var_modifiers["speed"]
 	projectile.armour_penetration += var_modifiers["armour_penetration"]
 	projectile.wound_bonus += var_modifiers["wound_bonus"]
-	projectile.bare_wound_bonus += var_modifiers["bare_wound_bonus"]
+	projectile.exposed_wound_bonus += var_modifiers["exposed_wound_bonus"]
 	projectile.demolition_mod += var_modifiers["demolition_mod"]
 	if(var_modifiers["embedding"])
 		projectile.set_embed(var_modifiers["embedding"])
@@ -150,7 +150,7 @@
 	projectile.speed -= var_modifiers["speed"]
 	projectile.armour_penetration -= var_modifiers["armour_penetration"]
 	projectile.wound_bonus -= var_modifiers["wound_bonus"]
-	projectile.bare_wound_bonus -= var_modifiers["bare_wound_bonus"]
+	projectile.exposed_wound_bonus -= var_modifiers["exposed_wound_bonus"]
 	projectile.demolition_mod -= var_modifiers["demolition_mod"]
 	if(var_modifiers["embedding"])
 		projectile.set_embed(initial(projectile.embed_type))

--- a/code/datums/components/gunpoint.dm
+++ b/code/datums/components/gunpoint.dm
@@ -2,7 +2,7 @@
 #define GUNPOINT_DELAY_STAGE_2 (2.5 SECONDS)
 /// How long it takes from stage 2 starting to move up to stage 3
 #define GUNPOINT_DELAY_STAGE_3 (7.5 SECONDS)
-/// If the projectile doesn't have a wound_bonus of CANT_WOUND, we add (this * the stage mult) to their wound_bonus and bare_wound_bonus upon triggering
+/// If the projectile doesn't have a wound_bonus of CANT_WOUND, we add (this * the stage mult) to their wound_bonus and exposed_wound_bonus upon triggering
 #define GUNPOINT_BASE_WOUND_BONUS 5
 /// How much the damage and wound bonus mod is multiplied when you're on stage 1
 #define GUNPOINT_MULT_STAGE_1 1.25
@@ -165,14 +165,14 @@
 		weapon.chambered.loaded_projectile.damage *= damage_mult
 		if(weapon.chambered.loaded_projectile.wound_bonus != CANT_WOUND)
 			weapon.chambered.loaded_projectile.wound_bonus += damage_mult * GUNPOINT_BASE_WOUND_BONUS
-			weapon.chambered.loaded_projectile.bare_wound_bonus += damage_mult * GUNPOINT_BASE_WOUND_BONUS
+			weapon.chambered.loaded_projectile.exposed_wound_bonus += damage_mult * GUNPOINT_BASE_WOUND_BONUS
 
 	var/fired = weapon.fire_gun(target, shooter)
 	if(!fired && weapon.chambered?.loaded_projectile)
 		weapon.chambered.loaded_projectile.damage /= damage_mult
 		if(weapon.chambered.loaded_projectile.wound_bonus != CANT_WOUND)
 			weapon.chambered.loaded_projectile.wound_bonus -= damage_mult * GUNPOINT_BASE_WOUND_BONUS
-			weapon.chambered.loaded_projectile.bare_wound_bonus -= damage_mult * GUNPOINT_BASE_WOUND_BONUS
+			weapon.chambered.loaded_projectile.exposed_wound_bonus -= damage_mult * GUNPOINT_BASE_WOUND_BONUS
 
 	qdel(src)
 
@@ -187,7 +187,7 @@
 	qdel(src)
 
 ///If the shooter is hit by an attack, they have a 50% chance to flinch and fire. If it hit the arm holding the trigger, it's an 80% chance to fire instead
-/datum/component/gunpoint/proc/flinch(mob/living/source, damage_amount, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item)
+/datum/component/gunpoint/proc/flinch(mob/living/source, damage_amount, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item)
 	SIGNAL_HANDLER
 
 	if(!attack_direction) // No fliching from yourself

--- a/code/datums/components/holographic_nature.dm
+++ b/code/datums/components/holographic_nature.dm
@@ -26,7 +26,7 @@
 	if(isobj(atom_parent) && atom_parent.uses_integrity)
 		RegisterSignal(parent, COMSIG_ATOM_TAKE_DAMAGE, PROC_REF(on_object_damaged))
 
-/datum/component/holographic_nature/proc/on_mob_damaged(mob/living/source, damage_amount, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item)
+/datum/component/holographic_nature/proc/on_mob_damaged(mob/living/source, damage_amount, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item)
 	SIGNAL_HANDLER
 	if(damagetype == BURN || damagetype == BRUTE)
 		apply_effects()

--- a/code/datums/components/pellet_cloud.dm
+++ b/code/datums/components/pellet_cloud.dm
@@ -109,7 +109,7 @@
 	// things like mouth executions and gunpoints can multiply the damage and wounds of projectiles, so this makes sure those effects are applied to each pellet instead of just one
 	var/original_damage = shell.loaded_projectile.damage
 	var/original_wounds_bonus = shell.loaded_projectile.wound_bonus
-	var/original_bare_wounds_bonus = shell.loaded_projectile.bare_wound_bonus
+	var/original_bare_wounds_bonus = shell.loaded_projectile.exposed_wound_bonus
 	var/original_ignored_faction = shell.loaded_projectile.ignored_factions
 
 	for(var/i in 1 to num_pellets)
@@ -124,7 +124,7 @@
 		RegisterSignals(shell.loaded_projectile, list(COMSIG_PROJECTILE_RANGE_OUT, COMSIG_QDELETING), PROC_REF(pellet_range))
 		shell.loaded_projectile.damage = original_damage
 		shell.loaded_projectile.wound_bonus = original_wounds_bonus
-		shell.loaded_projectile.bare_wound_bonus = original_bare_wounds_bonus
+		shell.loaded_projectile.exposed_wound_bonus = original_bare_wounds_bonus
 		shell.loaded_projectile.ignored_factions = original_ignored_faction
 		pellets += shell.loaded_projectile
 		var/turf/current_loc = get_turf(fired_from)
@@ -246,7 +246,7 @@
 					wound_info_by_part[hit_part] = list(0, 0, 0)
 				wound_info_by_part[hit_part][CLOUD_POSITION_DAMAGE] += proj.damage // these account for decay
 				wound_info_by_part[hit_part][CLOUD_POSITION_W_BONUS] += proj.wound_bonus
-				wound_info_by_part[hit_part][CLOUD_POSITION_BW_BONUS] += proj.bare_wound_bonus
+				wound_info_by_part[hit_part][CLOUD_POSITION_BW_BONUS] += proj.exposed_wound_bonus
 				proj.wound_bonus = CANT_WOUND // actual wounding will be handled aggregate
 	else if(isobj(target))
 		var/obj/hit_object = target

--- a/code/datums/components/riding/riding_mob.dm
+++ b/code/datums/components/riding/riding_mob.dm
@@ -634,7 +634,7 @@
 	if(hit_projectile.armor_flag == ENERGY)
 		freak_out()
 
-/datum/component/riding/creature/raptor/proc/on_attacked(mob/living/source, damage_dealt, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, obj/item/attacking_item)
+/datum/component/riding/creature/raptor/proc/on_attacked(mob/living/source, damage_dealt, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, obj/item/attacking_item)
 	SIGNAL_HANDLER
 
 	if(damagetype == STAMINA)

--- a/code/datums/embedding.dm
+++ b/code/datums/embedding.dm
@@ -253,7 +253,7 @@
 		def_zone = owner_limb.body_zone,
 		blocked = armor,
 		wound_bonus = parent.wound_bonus,
-		bare_wound_bonus = parent.bare_wound_bonus,
+		exposed_wound_bonus = parent.exposed_wound_bonus,
 		sharpness = parent.get_sharpness(),
 		attacking_item = parent,
 	)

--- a/code/datums/proximity_monitor/fields/heretic_arena.dm
+++ b/code/datums/proximity_monitor/fields/heretic_arena.dm
@@ -231,7 +231,7 @@ GLOBAL_LIST_EMPTY(heretic_arenas)
 	def_zone,
 	blocked,
 	wound_bonus,
-	bare_wound_bonus,
+	exposed_wound_bonus,
 	sharpness,
 	attack_direction,
 	attacking_item,

--- a/code/datums/quirks/negative_quirks/glass_jaw.dm
+++ b/code/datums/quirks/negative_quirks/glass_jaw.dm
@@ -32,7 +32,7 @@
 /datum/quirk/glass_jaw/remove()
 	UnregisterSignal(quirk_holder, COMSIG_MOB_APPLY_DAMAGE)
 
-/datum/quirk/glass_jaw/proc/punch_out(mob/living/carbon/source, damage, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item)
+/datum/quirk/glass_jaw/proc/punch_out(mob/living/carbon/source, damage, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item)
 	SIGNAL_HANDLER
 
 	if(isbodypart(def_zone))

--- a/code/datums/status_effects/neutral.dm
+++ b/code/datums/status_effects/neutral.dm
@@ -23,7 +23,7 @@
 	def_zone,
 	blocked,
 	wound_bonus,
-	bare_wound_bonus,
+	exposed_wound_bonus,
 	sharpness,
 	attack_direction,
 	attacking_item,

--- a/code/datums/wounds/bones.dm
+++ b/code/datums/wounds/bones.dm
@@ -17,6 +17,7 @@
 	wound_flags = (ACCEPTS_GAUZE)
 
 	default_scar_file = BONE_SCAR_FILE
+	threshold_penalty = 5
 
 	/// Have we been bone gel'd?
 	var/gelled
@@ -237,7 +238,7 @@
 	interaction_efficiency_penalty = 1.3
 	limp_slowdown = 3
 	limp_chance = 50
-	threshold_penalty = 15
+	series_threshold_penalty = 15
 	treatable_tools = list(TOOL_BONESET)
 	status_effect_type = /datum/status_effect/wound/blunt/bone/moderate
 	scar_keyword = "dislocate"
@@ -378,7 +379,7 @@
 	interaction_efficiency_penalty = 2
 	limp_slowdown = 6
 	limp_chance = 60
-	threshold_penalty = 30
+	series_threshold_penalty = 30
 	treatable_by = list(/obj/item/stack/sticky_tape/surgical, /obj/item/stack/medical/bone_gel)
 	status_effect_type = /datum/status_effect/wound/blunt/bone/severe
 	scar_keyword = "bluntsevere"
@@ -418,7 +419,7 @@
 	limp_slowdown = 7
 	limp_chance = 70
 	sound_effect = 'sound/effects/wounds/crack2.ogg'
-	threshold_penalty = 50
+	threshold_penalty = 15
 	disabling = TRUE
 	treatable_by = list(/obj/item/stack/sticky_tape/surgical, /obj/item/stack/medical/bone_gel)
 	status_effect_type = /datum/status_effect/wound/blunt/bone/critical

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -14,6 +14,7 @@
 	name = "Burn (Flesh) Wound"
 	a_or_from = "from"
 	processes = TRUE
+	threshold_penalty = 15
 
 	default_scar_file = FLESH_SCAR_FILE
 
@@ -137,7 +138,7 @@
 						to_chat(victim, span_deadsay("<b>Infection has just about completely claimed your [limb.plaintext_zone]!</b>"))
 					if(0)
 						to_chat(victim, span_deadsay("<b>The last of the nerve endings in your [limb.plaintext_zone] wither away, as the infection completely paralyzes your joint connector.</b>"))
-						threshold_penalty = 120 // piss easy to destroy
+						threshold_penalty *= 2 // piss easy to destroy
 						set_disabling(TRUE)
 
 /datum/wound/burn/flesh/set_disabling(new_value)
@@ -294,7 +295,7 @@
 	occur_text = "breaks out with violent red burns"
 	severity = WOUND_SEVERITY_MODERATE
 	damage_multiplier_penalty = 1.1
-	threshold_penalty = 30 // burns cause significant decrease in limb integrity compared to other wounds
+	series_threshold_penalty = 30 // burns cause significant decrease in limb integrity compared to other wounds
 	status_effect_type = /datum/status_effect/wound/burn/flesh/moderate
 	flesh_damage = 5
 	scar_keyword = "burnmoderate"
@@ -322,7 +323,7 @@
 	occur_text = "chars rapidly, exposing ruined tissue and spreading angry red burns"
 	severity = WOUND_SEVERITY_SEVERE
 	damage_multiplier_penalty = 1.2
-	threshold_penalty = 40
+	series_threshold_penalty = 40
 	status_effect_type = /datum/status_effect/wound/burn/flesh/severe
 	treatable_by = list(/obj/item/flashlight/pen/paramedic, /obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh)
 	infestation_rate = 0.07 // appx 9 minutes to reach sepsis without any treatment
@@ -353,7 +354,7 @@
 	severity = WOUND_SEVERITY_CRITICAL
 	damage_multiplier_penalty = 1.3
 	sound_effect = 'sound/effects/wounds/sizzle2.ogg'
-	threshold_penalty = 80
+	threshold_penalty = 25
 	status_effect_type = /datum/status_effect/wound/burn/flesh/critical
 	treatable_by = list(/obj/item/flashlight/pen/paramedic, /obj/item/stack/medical/ointment, /obj/item/stack/medical/mesh)
 	infestation_rate = 0.075 // appx 4.33 minutes to reach sepsis without any treatment

--- a/code/datums/wounds/cranial_fissure.dm
+++ b/code/datums/wounds/cranial_fissure.dm
@@ -6,7 +6,7 @@
 
 	wound_series = WOUND_SERIES_CRANIAL_FISSURE
 
-	threshold_minimum = 150
+	threshold_minimum = 110
 	weight = 10
 
 	viable_zones = list(BODY_ZONE_HEAD)

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -4,6 +4,7 @@
 */
 /datum/wound/pierce
 	undiagnosed_name = "Puncture"
+	threshold_penalty = 5
 
 /datum/wound/pierce/get_self_check_description(self_aware)
 	if(!limb.can_bleed())
@@ -208,7 +209,7 @@
 	clot_rate = 0.03
 	internal_bleeding_chance = 30
 	internal_bleeding_coefficient = 1.25
-	threshold_penalty = 20
+	series_threshold_penalty = 20
 	status_effect_type = /datum/status_effect/wound/pierce/moderate
 	scar_keyword = "piercemoderate"
 
@@ -270,7 +271,7 @@
 	clot_rate = 0.02
 	internal_bleeding_chance = 60
 	internal_bleeding_coefficient = 1.5
-	threshold_penalty = 35
+	series_threshold_penalty = 35
 	status_effect_type = /datum/status_effect/wound/pierce/severe
 	scar_keyword = "piercesevere"
 
@@ -364,7 +365,7 @@
 	gauzed_clot_rate = 0.4
 	internal_bleeding_chance = 80
 	internal_bleeding_coefficient = 1.75
-	threshold_penalty = 50
+	threshold_penalty = 15
 	status_effect_type = /datum/status_effect/wound/pierce/critical
 	scar_keyword = "piercecritical"
 	wound_flags = (ACCEPTS_GAUZE | MANGLES_EXTERIOR | CAN_BE_GRASPED)

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -32,6 +32,7 @@
 
 /datum/wound/slash/flesh
 	name = "Slashing (Cut) Flesh Wound"
+	threshold_penalty = 5
 	processes = TRUE
 	treatable_by = list(/obj/item/stack/medical/suture)
 	treatable_by_grabbed = list(/obj/item/gun/energy/laser)
@@ -308,7 +309,7 @@
 	initial_flow = 2
 	minimum_flow = 0.5
 	clot_rate = 0.05
-	threshold_penalty = 10
+	series_threshold_penalty = 10
 	status_effect_type = /datum/status_effect/wound/slash/flesh/moderate
 	scar_keyword = "slashmoderate"
 
@@ -340,7 +341,7 @@
 	initial_flow = 3.25
 	minimum_flow = 2.75
 	clot_rate = 0.03
-	threshold_penalty = 25
+	series_threshold_penalty = 25
 	demotes_to = /datum/wound/slash/flesh/moderate
 	status_effect_type = /datum/status_effect/wound/slash/flesh/severe
 	scar_keyword = "slashsevere"
@@ -373,7 +374,7 @@
 	initial_flow = 4
 	minimum_flow = 3.85
 	clot_rate = -0.015 // critical cuts actively get worse instead of better
-	threshold_penalty = 40
+	threshold_penalty = 15
 	demotes_to = /datum/wound/slash/flesh/severe
 	status_effect_type = /datum/status_effect/wound/slash/flesh/critical
 	scar_keyword = "slashcritical"

--- a/code/game/machinery/dna_infuser/organ_sets/roach_organs.dm
+++ b/code/game/machinery/dna_infuser/organ_sets/roach_organs.dm
@@ -114,7 +114,7 @@
  *
  * Does a special effect if we blocked damage with our back
  */
-/obj/item/organ/heart/roach/proc/do_block_effect(mob/living/carbon/human/source, damage_dealt, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, obj/item/attacking_item)
+/obj/item/organ/heart/roach/proc/do_block_effect(mob/living/carbon/human/source, damage_dealt, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, obj/item/attacking_item)
 	SIGNAL_HANDLER
 
 	if(!is_blocking(source, damage_dealt, damagetype, attack_direction))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -1852,7 +1852,7 @@
 	force = modify_fantasy_variable("force", force, bonus)
 	throwforce = modify_fantasy_variable("throwforce", throwforce, bonus)
 	wound_bonus = modify_fantasy_variable("wound_bonus", wound_bonus, bonus)
-	bare_wound_bonus = modify_fantasy_variable("bare_wound_bonus", bare_wound_bonus, bonus)
+	exposed_wound_bonus = modify_fantasy_variable("exposed_wound_bonus", exposed_wound_bonus, bonus)
 	toolspeed = modify_fantasy_variable("toolspeed", toolspeed, -bonus/10, minimum = 0.1)
 
 /obj/item/proc/remove_fantasy_bonuses(bonus)
@@ -1860,7 +1860,7 @@
 	force = reset_fantasy_variable("force", force)
 	throwforce = reset_fantasy_variable("throwforce", throwforce)
 	wound_bonus = reset_fantasy_variable("wound_bonus", wound_bonus)
-	bare_wound_bonus = reset_fantasy_variable("bare_wound_bonus", bare_wound_bonus)
+	exposed_wound_bonus = reset_fantasy_variable("exposed_wound_bonus", exposed_wound_bonus)
 	toolspeed = reset_fantasy_variable("toolspeed", toolspeed)
 	SEND_SIGNAL(src, COMSIG_ITEM_REMOVE_FANTASY_BONUSES, bonus)
 
@@ -2013,7 +2013,7 @@
 			DAMTYPE: <font size='1'><a href='byond://?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=damtype' id='damtype'>[uppertext(damtype)]</a>
 			FORCE: <font size='1'><a href='byond://?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=force' id='force'>[force]</a>
 			WOUND: <font size='1'><a href='byond://?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=wound' id='wound'>[wound_bonus]</a>
-			BARE WOUND: <font size='1'><a href='byond://?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=bare wound' id='bare wound'>[bare_wound_bonus]</a>
+			BARE WOUND: <font size='1'><a href='byond://?_src_=vars;[HrefToken()];item_to_tweak=[REF(src)];var_tweak=bare wound' id='bare wound'>[exposed_wound_bonus]</a>
 		</font>
 	"}
 

--- a/code/game/objects/items/dualsaber.dm
+++ b/code/game/objects/items/dualsaber.dm
@@ -30,7 +30,7 @@
 	armor_type = /datum/armor/item_dualsaber
 	resistance_flags = FIRE_PROOF
 	wound_bonus = -10
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	demolition_mod = 1.5 //1.5x damage to objects, robots, etc.
 	item_flags = NO_BLOOD_ON_ITEM
 	var/w_class_on = WEIGHT_CLASS_BULKY

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -24,7 +24,7 @@ GLOBAL_DATUM(bridge_axe, /obj/item/fireaxe)
 	armor_type = /datum/armor/item_fireaxe
 	resistance_flags = FIRE_PROOF
 	wound_bonus = -15
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	/// How much damage to do unwielded
 	var/force_unwielded = 5
 	/// How much damage to do wielded

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -687,7 +687,7 @@
 	armour_penetration = 0
 	damage = 25
 	wound_bonus = -20
-	bare_wound_bonus = 40
+	exposed_wound_bonus = 40
 	silent_blown = TRUE
 
 /obj/projectile/kiss/french

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -176,7 +176,7 @@
 	obj_flags = CONDUCTS_ELECTRICITY
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT * 1.5, /datum/material/plastic = SHEET_MATERIAL_AMOUNT * 1.5)
 	custom_price = PAYCHECK_CREW * 2
-	bare_wound_bonus = 14
+	exposed_wound_bonus = 14
 
 /obj/item/kitchen/rollingpin/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins flattening [user.p_their()] head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/game/objects/items/knives.dm
+++ b/code/game/objects/items/knives.dm
@@ -23,7 +23,7 @@
 	sharpness = SHARP_EDGED
 	armor_type = /datum/armor/item_knife
 	wound_bonus = 5
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	tool_behaviour = TOOL_KNIFE
 	var/list/alt_continuous = list("stabs", "pierces", "shanks")
 	var/list/alt_simple = list("stab", "pierce", "shank")
@@ -295,7 +295,7 @@
 	throw_speed = 4
 	throw_range = 8
 	wound_bonus = 10
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	armor_type = /datum/armor/shiv_plastitanium
 	custom_materials = list(/datum/material/glass= SMALL_MATERIAL_AMOUNT * 4, /datum/material/alloy/plastitanium= SMALL_MATERIAL_AMOUNT * 2)
 

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -331,7 +331,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NONE
 	force = 0
-	bare_wound_bonus = 5
+	exposed_wound_bonus = 5
 	clumsy_knockdown_time = 15 SECONDS
 	active = FALSE
 	activated_word = "extended"
@@ -978,7 +978,7 @@
 	stamina_damage = 30 // 4 hit stamcrit
 	stun_armour_penetration = 30 // bronze-silver telescopic
 	force = 16 // 7 hit crit
-	bare_wound_bonus = 5
+	exposed_wound_bonus = 5
 
 /obj/item/melee/baton/nunchaku/proc/randomize_state()
 	icon_state = pick(list("nunchaku", "nunchaku_x", "nunchaku_y"))

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -10,7 +10,7 @@
 	light_range = 3
 	light_power = 1
 	light_on = FALSE
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	demolition_mod = 1.5 //1.5x damage to objects, robots, etc.
 	stealthy_audio = TRUE
 	w_class = WEIGHT_CLASS_SMALL

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -18,7 +18,7 @@
 	throwforce = 7
 	demolition_mod = 0.25
 	wound_bonus = 15
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb_continuous = list("flogs", "whips", "lashes", "disciplines")
 	attack_verb_simple = list("flog", "whip", "lash", "discipline")
@@ -82,7 +82,7 @@
 	hitsound = 'sound/items/weapons/rapierhit.ogg'
 	custom_materials = list(/datum/material/iron = HALF_SHEET_MATERIAL_AMOUNT)
 	wound_bonus = 10
-	bare_wound_bonus = 25
+	exposed_wound_bonus = 25
 
 /obj/item/melee/sabre/Initialize(mapload)
 	. = ..()
@@ -195,7 +195,7 @@
 	hitsound = 'sound/items/weapons/rapierhit.ogg'
 	custom_materials = null
 	wound_bonus = 5
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 
 /obj/item/melee/parsnip_sabre/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/shrapnel.dm
+++ b/code/game/objects/items/shrapnel.dm
@@ -111,7 +111,7 @@
 	stamina = 8
 	sharpness = SHARP_EDGED
 	wound_bonus = 5
-	bare_wound_bonus = 5
+	exposed_wound_bonus = 5
 	ricochets_max = 2
 	ricochet_chance = 140
 	shrapnel_type = /obj/item/shrapnel/capmine

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -23,7 +23,7 @@
 	max_integrity = 200
 	armor_type = /datum/armor/item_spear
 	wound_bonus = -15
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	/// For explosive spears, what we cry out when we use this to bap someone
 	var/war_cry = "AAAAARGH!!!"
 	/// The icon prefix for this flavor of spear
@@ -112,7 +112,7 @@
 			throw_speed = 5
 			custom_materials = list(/datum/material/iron= HALF_SHEET_MATERIAL_AMOUNT, /datum/material/alloy/plastitaniumglass= HALF_SHEET_MATERIAL_AMOUNT * 2)
 			wound_bonus = -10
-			bare_wound_bonus = 20
+			exposed_wound_bonus = 20
 			force_unwielded = 13
 			force_wielded = 20
 			icon_prefix = "spearplastitanium"
@@ -222,7 +222,7 @@
 	throwforce = 30
 	demolition_mod = 1
 	wound_bonus = 5
-	bare_wound_bonus = 25
+	exposed_wound_bonus = 25
 	throw_range = 9
 	throw_speed = 5
 	sharpness = NONE // we break bones instead of cutting flesh

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -217,7 +217,7 @@
 	toolspeed = 1.25
 	armor_type = /datum/armor/crowbar_mechremoval
 	resistance_flags = FIRE_PROOF
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	wound_bonus = 10
 
 /datum/armor/crowbar_mechremoval

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -29,7 +29,7 @@
 	tool_behaviour = TOOL_WELDER
 	toolspeed = 1
 	wound_bonus = 10
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	custom_materials = list(/datum/material/iron=SMALL_MATERIAL_AMOUNT*0.7, /datum/material/glass=SMALL_MATERIAL_AMOUNT*0.3)
 	/// Whether the welding tool is on or off.
 	var/welding = FALSE

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -1236,7 +1236,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	force = 10
 	wound_bonus = 25
-	bare_wound_bonus = 50
+	exposed_wound_bonus = 50
 	throwforce = 25
 	throw_speed = 4
 	attack_speed = CLICK_CD_HYPER_RAPID
@@ -1318,7 +1318,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	playsound(src, 'sound/items/weapons/zapbang.ogg', 50, vary = TRUE)
 	if(isliving(target))
 		var/mob/living/living_target = target
-		living_target.apply_damage(force*damage_mod, BRUTE, sharpness = SHARP_EDGED, wound_bonus = wound_bonus, bare_wound_bonus = bare_wound_bonus, def_zone = user.zone_selected)
+		living_target.apply_damage(force*damage_mod, BRUTE, sharpness = SHARP_EDGED, wound_bonus = wound_bonus, exposed_wound_bonus = exposed_wound_bonus, def_zone = user.zone_selected)
 		log_combat(user, living_target, "slashed", src)
 		if(living_target.stat == DEAD && prob(force*damage_mod*0.5))
 			living_target.visible_message(span_danger("[living_target] explodes in a shower of gore!"), blind_message = span_hear("You hear organic matter ripping and tearing!"))
@@ -1368,7 +1368,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 8
 	throwforce = 20
 	wound_bonus = 20
-	bare_wound_bonus = 25
+	exposed_wound_bonus = 25
 
 /obj/item/highfrequencyblade/wizard/attack_self(mob/user, modifiers)
 	if(!HAS_MIND_TRAIT(user, TRAIT_MAGICALLY_GIFTED))

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -22,7 +22,7 @@
 	/// How good a given object is at causing wounds on carbons. Higher values equal better shots at creating serious wounds.
 	var/wound_bonus = 0
 	/// If this attacks a human with no wound armor on the affected body part, add this to the wound mod. Some attacks may be significantly worse at wounding if there's even a slight layer of armor to absorb some of it vs bare flesh
-	var/bare_wound_bonus = 0
+	var/exposed_wound_bonus = 0
 
 	/// A multiplier to an object's force when used against a structure, vehicle, machine, or robot.
 	/// Use [/obj/proc/get_demolition_modifier] to get the value.

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -74,7 +74,7 @@
 /// For when a mob comes flying through the window, smash it and damage the mob
 /obj/structure/proc/smash_and_injure(mob/living/flying_mob, atom/oldloc, direction)
 	flying_mob.balloon_alert_to_viewers("smashed through!")
-	flying_mob.apply_damage(damage = rand(5, 15), damagetype = BRUTE, wound_bonus = 15, bare_wound_bonus = 25, sharpness = SHARP_EDGED, attack_direction = get_dir(src, oldloc))
+	flying_mob.apply_damage(damage = rand(5, 15), damagetype = BRUTE, wound_bonus = 15, exposed_wound_bonus = 25, sharpness = SHARP_EDGED, attack_direction = get_dir(src, oldloc))
 	new /obj/effect/decal/cleanable/glass(get_step(flying_mob, flying_mob.dir))
 	deconstruct(disassembled = FALSE)
 

--- a/code/modules/admin/view_variables/topic.dm
+++ b/code/modules/admin/view_variables/topic.dm
@@ -117,7 +117,7 @@
 			if("wound")
 				existing_val = editing.wound_bonus
 			if("bare wound")
-				existing_val = editing.bare_wound_bonus
+				existing_val = editing.exposed_wound_bonus
 			else
 				CRASH("Invalid var_tweak passed to item vv set var: [href_list["var_tweak"]]")
 
@@ -137,7 +137,7 @@
 			if("wound")
 				editing.wound_bonus = new_val
 			if("bare wound")
-				editing.bare_wound_bonus = new_val
+				editing.exposed_wound_bonus = new_val
 
 		message_admins("[key_name(usr)] set [editing]'s [href_list["var_tweak"]] to [new_val] (was [existing_val])")
 		log_admin("[key_name(usr)] set [editing]'s [href_list["var_tweak"]] to [new_val] (was [existing_val])")

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -202,7 +202,7 @@
 	attack_verb_simple = list("attack", "slash", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_EDGED
 	wound_bonus = 10
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 	armour_penetration = 35
 	var/can_drop = FALSE
 	var/fake = FALSE

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -25,7 +25,7 @@
 	throwforce = 25
 	block_chance = 25
 	wound_bonus = -10
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	armour_penetration = 35
 	block_sound = 'sound/items/weapons/parry.ogg'
 	///Reference to a boomerang component we add when a non-cultist throws us.
@@ -101,7 +101,7 @@ Striking a noncultist, however, will tear their flesh."}
 	throwforce = 10
 	block_chance = 50 // now it's officially a cult esword
 	wound_bonus = -50
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
 	block_sound = 'sound/items/weapons/parry.ogg'
 	attack_verb_continuous = list("attacks", "slashes", "slices", "tears", "lacerates", "rips", "dices", "rends")
@@ -158,7 +158,7 @@ Striking a noncultist, however, will tear their flesh."}
 	throwforce = 25
 	block_chance = 55
 	wound_bonus = -25
-	bare_wound_bonus = 30
+	exposed_wound_bonus = 30
 	free_use = TRUE
 	light_color = COLOR_HERETIC_GREEN
 	light_range = 3

--- a/code/modules/antagonists/heretic/items/heretic_blades.dm
+++ b/code/modules/antagonists/heretic/items/heretic_blades.dm
@@ -17,7 +17,7 @@
 	force = 20
 	throwforce = 10
 	wound_bonus = 5
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	toolspeed = 0.375
 	demolition_mod = 0.8
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
@@ -245,7 +245,7 @@
 	throwforce = 15
 	block_chance = 35
 	wound_bonus = 25
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	armour_penetration = 35
 	icon_state = "cursed_blade"
 	inhand_icon_state = "cursed_blade"

--- a/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
+++ b/code/modules/antagonists/heretic/knowledge/side_void_blade.dm
@@ -112,7 +112,7 @@
 	hitsound = SFX_SHATTER
 	force = 16
 	wound_bonus = -30
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	demolition_mod = 1.5
 	sharpness = SHARP_EDGED
 

--- a/code/modules/antagonists/nightmare/nightmare_equipment.dm
+++ b/code/modules/antagonists/nightmare/nightmare_equipment.dm
@@ -18,7 +18,7 @@
 	tool_behaviour = TOOL_MINING
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
 	wound_bonus = -30
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	///If this is true, our next hit will be critcal, temporarily stunning our target
 	var/has_crit = FALSE
 	///The timer which controls our next crit

--- a/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
+++ b/code/modules/antagonists/voidwalker/voidwalker_void_eater.dm
@@ -22,7 +22,7 @@
 	tool_behaviour = TOOL_MINING
 	hitsound = 'sound/items/weapons/bladeslice.ogg'
 	wound_bonus = -30
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 
 	/// Damage we loss per hit
 	var/damage_loss_per_hit = 0.5

--- a/code/modules/clothing/head/cakehat.dm
+++ b/code/modules/clothing/head/cakehat.dm
@@ -16,7 +16,7 @@
 	flags_cover = HEADCOVERSEYES
 	heat = 999
 	wound_bonus = 10
-	bare_wound_bonus = 5
+	exposed_wound_bonus = 5
 	dog_fashion = /datum/dog_fashion/head
 	hitsound = 'sound/items/weapons/tap.ogg'
 	var/hitsound_on = 'sound/items/weapons/sear.ogg' //so we can differentiate between cakehat and energyhat

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -194,7 +194,6 @@
 	acid = 50
 	wound = 5
 
-
 /obj/item/clothing/head/fedora/det_hat/Initialize(mapload)
 	. = ..()
 
@@ -479,7 +478,7 @@
 	bomb = 25
 	fire = 30
 	acid = 60
-	wound = 6
+	wound = 5
 
 /obj/item/clothing/head/hats/warden/police
 	name = "police officer's hat"
@@ -581,7 +580,7 @@
 	bomb = 25
 	fire = 20
 	acid = 50
-	wound = 4
+	wound = 5
 
 /obj/item/clothing/head/beret/sec/navywarden
 	name = "warden's beret"
@@ -798,7 +797,7 @@
 	bomb = 10
 	fire = 30
 	acid = 5
-	wound = 4
+	wound = 5
 
 /obj/item/clothing/head/beret/highlander
 	desc = "That was white fabric. <i>Was.</i>"

--- a/code/modules/fishing/fish/_fish.dm
+++ b/code/modules/fishing/fish/_fish.dm
@@ -707,7 +707,7 @@ GLOBAL_LIST_INIT(fish_compatible_fluid_types, list(
 	block_chance = initial(block_chance)
 	armour_penetration = initial(armour_penetration)
 	wound_bonus = initial(wound_bonus)
-	bare_wound_bonus = initial(bare_wound_bonus)
+	exposed_wound_bonus = initial(exposed_wound_bonus)
 	toolspeed = initial(toolspeed)
 
 	var/weight_rank = GET_FISH_WEIGHT_RANK(weight)

--- a/code/modules/fishing/fish/types/rift.dm
+++ b/code/modules/fishing/fish/types/rift.dm
@@ -8,7 +8,7 @@
 	force = 12
 	sharpness = SHARP_POINTY
 	wound_bonus = -10
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	armour_penetration = 6
 	demolition_mod = 1.2
 	throwforce = 11
@@ -114,7 +114,7 @@
 	force = 19
 	sharpness = SHARP_POINTY
 	wound_bonus = -5
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	armour_penetration = 12
 	block_chance = 33
 	throwforce = 7
@@ -188,7 +188,7 @@
 	block_chance *= multiplier
 	armour_penetration *= multiplier
 	wound_bonus *= multiplier
-	bare_wound_bonus *= multiplier
+	exposed_wound_bonus *= multiplier
 
 /obj/item/fish/dolphish/do_fish_process(seconds_per_tick)
 	. = ..()
@@ -226,7 +226,7 @@
 		if(0)
 			// No check, we always want sharky to bite jerky on 0
 			moc.visible_message(span_bolddanger("[src] bites directly into [moc] and squirms away from [moc.p_their()] grasp!"), span_userdanger("[src] sinks its fangs into you!!"))
-			moc.apply_damage(force, BRUTE, moc.get_active_hand(), wound_bonus = wound_bonus, bare_wound_bonus = bare_wound_bonus, sharpness = sharpness, attacking_item = src)
+			moc.apply_damage(force, BRUTE, moc.get_active_hand(), wound_bonus = wound_bonus, exposed_wound_bonus = exposed_wound_bonus, sharpness = sharpness, attacking_item = src)
 			forceMove(moc.drop_location())
 			moc.painful_scream()
 			patience = max_patience
@@ -258,7 +258,7 @@
 		span_warning("You try to pet [src], but it sinks its fangs into your hand!"),
 		vision_distance = DEFAULT_MESSAGE_RANGE - 3,
 		)
-	user.apply_damage(force, BRUTE, user.get_active_hand(), wound_bonus = wound_bonus, bare_wound_bonus = bare_wound_bonus, sharpness = sharpness, attacking_item = src)
+	user.apply_damage(force, BRUTE, user.get_active_hand(), wound_bonus = wound_bonus, exposed_wound_bonus = exposed_wound_bonus, sharpness = sharpness, attacking_item = src)
 	if(!in_aquarium)
 		forceMove(user.drop_location())
 	user.painful_scream()

--- a/code/modules/fishing/fish/types/saltwater.dm
+++ b/code/modules/fishing/fish/types/saltwater.dm
@@ -156,7 +156,7 @@
 	attack_speed = 1 SECONDS
 	block_chance = 50
 	wound_bonus = 10
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	armour_penetration = 75
 	base_pixel_w = -18
 	pixel_w = -18
@@ -191,28 +191,28 @@
 			block_chance -= 45
 			armour_penetration -= 20
 			wound_bonus -= 15
-			bare_wound_bonus -= 20
+			exposed_wound_bonus -= 20
 		if(WEIGHT_CLASS_SMALL)
 			force -= 8
 			attack_speed -= 0.3 SECONDS
 			block_chance -= 30
 			armour_penetration -= 15
 			wound_bonus -= 10
-			bare_wound_bonus -= 20
+			exposed_wound_bonus -= 20
 		if(WEIGHT_CLASS_NORMAL)
 			force -= 5
 			attack_speed -= 0.2 SECONDS
 			block_chance -= 20
 			armour_penetration -= 10
 			wound_bonus -= 10
-			bare_wound_bonus -= 15
+			exposed_wound_bonus -= 15
 		if(WEIGHT_CLASS_BULKY)
 			force -= 3
 			attack_speed -= 0.1 SECONDS
 			block_chance -= 10
 			armour_penetration -= 5
 			wound_bonus -= 5
-			bare_wound_bonus -= 10
+			exposed_wound_bonus -= 10
 		if(WEIGHT_CLASS_GIGANTIC)
 			force += 5
 			attack_speed += 0.2 SECONDS
@@ -220,20 +220,20 @@
 			block_chance += 10
 			armour_penetration += 5
 			wound_bonus += 5
-			bare_wound_bonus += 10
+			exposed_wound_bonus += 10
 
 	if(status == FISH_DEAD)
 		force -= 4 + w_class
 		block_chance -= 25
 		armour_penetration -= 30
 		wound_bonus -= 10
-		bare_wound_bonus -= 10
+		exposed_wound_bonus -= 10
 
 /obj/item/fish/swordfish/calculate_fish_force_bonus(bonus_malus)
 	. = ..()
 	armour_penetration += bonus_malus * 5
 	wound_bonus += bonus_malus * 3
-	bare_wound_bonus += bonus_malus * 5
+	exposed_wound_bonus += bonus_malus * 5
 	block_chance += bonus_malus * 7
 
 /obj/item/fish/squid

--- a/code/modules/fishing/fish/types/syndicate.dm
+++ b/code/modules/fishing/fish/types/syndicate.dm
@@ -145,7 +145,7 @@
 			block_chance -= 15
 			armour_penetration -= 10
 			wound_bonus -= 10
-			bare_wound_bonus -= 10
+			exposed_wound_bonus -= 10
 			toolspeed += 0.6
 		if(WEIGHT_CLASS_SMALL)
 			force -= 8
@@ -154,7 +154,7 @@
 			block_chance -= 10
 			armour_penetration -= 10
 			wound_bonus -= 10
-			bare_wound_bonus -= 10
+			exposed_wound_bonus -= 10
 			toolspeed += 0.4
 		if(WEIGHT_CLASS_NORMAL)
 			force -= 5
@@ -162,7 +162,7 @@
 			block_chance -= 5
 			armour_penetration -= 5
 			wound_bonus -= 5
-			bare_wound_bonus -= 5
+			exposed_wound_bonus -= 5
 			toolspeed += 0.2
 		if(WEIGHT_CLASS_HUGE)
 			force += 2
@@ -171,7 +171,7 @@
 			armour_penetration += 10
 			block_chance += 10
 			wound_bonus += 10
-			bare_wound_bonus += 5
+			exposed_wound_bonus += 5
 		if(WEIGHT_CLASS_GIGANTIC)
 			force += 4
 			attack_speed += 0.4 SECONDS
@@ -179,7 +179,7 @@
 			block_chance += 20
 			armour_penetration += 20
 			wound_bonus += 15
-			bare_wound_bonus += 10
+			exposed_wound_bonus += 10
 			toolspeed -= 0.1
 
 	if(status == FISH_DEAD)
@@ -189,14 +189,14 @@
 		demolition_mod -= 0.3
 		armour_penetration -= 15
 		wound_bonus -= 5
-		bare_wound_bonus -= 5
+		exposed_wound_bonus -= 5
 		toolspeed += 1
 
 /obj/item/fish/chainsawfish/calculate_fish_force_bonus(bonus_malus)
 	. = ..()
 	armour_penetration += bonus_malus * 3
 	wound_bonus += bonus_malus * 2
-	bare_wound_bonus += bonus_malus * 3
+	exposed_wound_bonus += bonus_malus * 3
 	block_chance += bonus_malus * 2
 	toolspeed -= bonus_malus * 0.1
 
@@ -229,7 +229,7 @@
 	wound_bonus = -15
 	attack_speed = 1 SECONDS
 	block_chance = 25
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	demolition_mod = 0.8
 	armour_penetration = 10
 	stable_population = 3
@@ -265,21 +265,21 @@
 			block_chance -= 25
 			armour_penetration -= 15
 			wound_bonus -= 15
-			bare_wound_bonus -= 30
+			exposed_wound_bonus -= 30
 		if(WEIGHT_CLASS_SMALL)
 			force -= 6
 			attack_speed -= 0.3 SECONDS
 			block_chance -= 20
 			armour_penetration -= 10
 			wound_bonus -= 10
-			bare_wound_bonus -= 25
+			exposed_wound_bonus -= 25
 		if(WEIGHT_CLASS_NORMAL)
 			force -= 4
 			attack_speed -= 0.2 SECONDS
 			block_chance -= 20
 			armour_penetration -= 5
 			wound_bonus -= 10
-			bare_wound_bonus -= 15
+			exposed_wound_bonus -= 15
 		if(WEIGHT_CLASS_HUGE)
 			force += 3
 			attack_speed += 0.2 SECONDS
@@ -287,7 +287,7 @@
 			demolition_mod += 0.1
 			armour_penetration += 5
 			wound_bonus += 10
-			bare_wound_bonus += 5
+			exposed_wound_bonus += 5
 		if(WEIGHT_CLASS_GIGANTIC)
 			force += 7
 			attack_speed += 0.3 SECONDS
@@ -295,18 +295,18 @@
 			block_chance += 20
 			armour_penetration += 10
 			wound_bonus += 15
-			bare_wound_bonus += 10
+			exposed_wound_bonus += 10
 
 	if(status == FISH_DEAD)
 		force -= 5 + w_class
 		block_chance -= 15
 		armour_penetration -= 10
 		wound_bonus -= 5
-		bare_wound_bonus -= 15
+		exposed_wound_bonus -= 15
 
 /obj/item/fish/pike/armored/calculate_fish_force_bonus(bonus_malus)
 	. = ..()
 	armour_penetration += bonus_malus * 3
 	wound_bonus += bonus_malus * 2
-	bare_wound_bonus += bonus_malus * 4
+	exposed_wound_bonus += bonus_malus * 4
 	block_chance += bonus_malus * 4

--- a/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_nullrod.dm
@@ -554,7 +554,7 @@
 	w_class = WEIGHT_CLASS_HUGE
 	sharpness = SHARP_EDGED
 	wound_bonus = -20
-	bare_wound_bonus = 25
+	exposed_wound_bonus = 25
 	menu_description = "An undroppable sharp armblade capable of inflicting deep wounds. Capable of an ineffective butchering of bodies. Disappears if the arm holding it is cut off."
 
 /obj/item/nullrod/armblade/Initialize(mapload)
@@ -795,7 +795,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 12
 	wound_bonus = 10
-	bare_wound_bonus = 30
+	exposed_wound_bonus = 30
 	slot_flags = ITEM_SLOT_BELT
 	block_sound = 'sound/items/weapons/parry.ogg'
 	sharpness = SHARP_EDGED
@@ -934,6 +934,6 @@
 	var/armor_block = living_target.run_armor_check(affecting, MELEE, armour_penetration = armour_penetration)
 
 	// We got a sneak attack!
-	living_target.apply_damage(round(sneak_attack_dice, DAMAGE_PRECISION), BRUTE, def_zone = affecting, blocked = armor_block, wound_bonus = bare_wound_bonus, sharpness = SHARP_EDGED)
+	living_target.apply_damage(round(sneak_attack_dice, DAMAGE_PRECISION), BRUTE, def_zone = affecting, blocked = armor_block, wound_bonus = exposed_wound_bonus, sharpness = SHARP_EDGED)
 	living_target.balloon_alert(user, "sneak attack!")
 	playsound(living_target, 'sound/items/weapons/guillotine.ogg', 50, TRUE)

--- a/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
+++ b/code/modules/jobs/job_types/chaplain/chaplain_vorpal_scythe.dm
@@ -44,7 +44,7 @@ If the scythe isn't empowered when you sheath it, you take a heap of damage and 
 	attack_verb_continuous = list("chops", "slices", "cuts", "reaps")
 	attack_verb_simple = list("chop", "slice", "cut", "reap")
 	wound_bonus = 10
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	/*What state is our scythe in?
 
 	If it is SCYTHE_WEAK, it will harm our reaper on being sheathed.

--- a/code/modules/mining/lavaland/mining_loot/cursed_katana.dm
+++ b/code/modules/mining/lavaland/mining_loot/cursed_katana.dm
@@ -122,7 +122,7 @@
 	RegisterSignal(target, COMSIG_MOVABLE_IMPACT, PROC_REF(strike_throw_impact))
 	var/atom/throw_target = get_edge_target_turf(target, user.dir)
 	target.throw_at(throw_target, 5, 3, user, FALSE, gentle = TRUE)
-	target.apply_damage(damage = 17, bare_wound_bonus = 10)
+	target.apply_damage(damage = 17, exposed_wound_bonus = 10)
 	to_chat(target, span_userdanger("You've been struck by [user]!"))
 	user.do_attack_animation(target, ATTACK_EFFECT_PUNCH)
 
@@ -153,7 +153,7 @@
 		user.do_attack_animation(turf, ATTACK_EFFECT_SLASH)
 		for(var/mob/living/additional_target in turf)
 			if(user.Adjacent(additional_target) && additional_target.density)
-				additional_target.apply_damage(damage = 15, sharpness = SHARP_EDGED, bare_wound_bonus = 10)
+				additional_target.apply_damage(damage = 15, sharpness = SHARP_EDGED, exposed_wound_bonus = 10)
 				to_chat(additional_target, span_userdanger("You've been sliced by [user]!"))
 	target.apply_damage(damage = 5, sharpness = SHARP_EDGED, wound_bonus = 10)
 
@@ -199,7 +199,7 @@
 		span_notice("You dash through [target]!"))
 	to_chat(target, span_userdanger("[user] dashes through you!"))
 	playsound(src, 'sound/effects/magic/blink.ogg', 50, TRUE)
-	target.apply_damage(damage = 17, sharpness = SHARP_POINTY, bare_wound_bonus = 10)
+	target.apply_damage(damage = 17, sharpness = SHARP_POINTY, exposed_wound_bonus = 10)
 	var/turf/dash_target = get_turf(target)
 	for(var/distance in 0 to 8)
 		var/turf/current_dash_target = dash_target

--- a/code/modules/mining/lavaland/mining_loot/megafauna/bubblegum.dm
+++ b/code/modules/mining/lavaland/mining_loot/megafauna/bubblegum.dm
@@ -148,7 +148,7 @@
 	throwforce = 17
 	armour_penetration = 50
 	sharpness = SHARP_EDGED
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 	layer = MOB_LAYER
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	/// Soulscythe mob in the scythe
@@ -337,7 +337,7 @@
 		var/mob/living/attacked_mob = attacked_atom
 		if(attacked_mob.stat != DEAD)
 			give_blood(15)
-		attacked_mob.apply_damage(damage = force * (ismining(attacked_mob) ? 2 : 1), sharpness = SHARP_EDGED, bare_wound_bonus = 5)
+		attacked_mob.apply_damage(damage = force * (ismining(attacked_mob) ? 2 : 1), sharpness = SHARP_EDGED, exposed_wound_bonus = 5)
 		to_chat(attacked_mob, span_userdanger("You're slashed by [src]!"))
 	else if((ismachinery(attacked_atom) || isstructure(attacked_atom)) && use_blood(5))
 		var/obj/attacked_obj = attacked_atom

--- a/code/modules/mining/lavaland/mining_loot/megafauna/legion.dm
+++ b/code/modules/mining/lavaland/mining_loot/megafauna/legion.dm
@@ -15,7 +15,7 @@
 	damtype = BURN
 	hitsound = 'sound/items/weapons/taserhit.ogg'
 	wound_bonus = -30
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	var/max_thunder_charges = 3
 	var/thunder_charges = 3

--- a/code/modules/mob/living/basic/basic.dm
+++ b/code/modules/mob/living/basic/basic.dm
@@ -30,7 +30,7 @@
 	///How much wounding power it has
 	var/wound_bonus = CANT_WOUND
 	///How much bare wounding power it has
-	var/bare_wound_bonus = 0
+	var/exposed_wound_bonus = 0
 	///If the attacks from this are sharp
 	var/sharpness = NONE
 

--- a/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
+++ b/code/modules/mob/living/basic/lavaland/goliath/goliath.dm
@@ -95,7 +95,7 @@
 		. += span_info("Someone appears to have attached a saddle to this one.")
 
 // Goliaths can summon tentacles more frequently as they take damage, scary.
-/mob/living/basic/mining/goliath/apply_damage(damage, damagetype, def_zone, blocked, forced, spread_damage, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item)
+/mob/living/basic/mining/goliath/apply_damage(damage, damagetype, def_zone, blocked, forced, spread_damage, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item)
 	. = ..()
 	if (. <= 0)
 		return

--- a/code/modules/mob/living/basic/pets/dog/dog_subtypes.dm
+++ b/code/modules/mob/living/basic/pets/dog/dog_subtypes.dm
@@ -57,7 +57,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 15
 	wound_bonus = -25
-	bare_wound_bonus = 45
+	exposed_wound_bonus = 45
 	sharpness = SHARP_EDGED
 	gold_core_spawnable = HOSTILE_SPAWN
 	faction = list(FACTION_HOSTILE)

--- a/code/modules/mob/living/basic/space_fauna/bear/_bear.dm
+++ b/code/modules/mob/living/basic/space_fauna/bear/_bear.dm
@@ -23,7 +23,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	wound_bonus = -5
-	bare_wound_bonus = 10 // BEAR wound bonus am i right
+	exposed_wound_bonus = 10 // BEAR wound bonus am i right
 	sharpness = SHARP_EDGED
 	attack_verb_continuous = "claws"
 	attack_verb_simple = "claw"

--- a/code/modules/mob/living/basic/space_fauna/demon/demon_subtypes.dm
+++ b/code/modules/mob/living/basic/space_fauna/demon/demon_subtypes.dm
@@ -17,7 +17,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	wound_bonus = -10
-	bare_wound_bonus = 0
+	exposed_wound_bonus = 0
 	sharpness = SHARP_EDGED
 
 	antag_type = /datum/antagonist/slaughter
@@ -28,7 +28,7 @@
 	var/slam_cooldown_time = 45 SECONDS
 	/// How many times we have hit humanoid targets since we last bloodcrawled, scaling wounding power
 	var/current_hitstreak = 0
-	/// How much both our wound_bonus and bare_wound_bonus go up per hitstreak hit
+	/// How much both our wound_bonus and exposed_wound_bonus go up per hitstreak hit
 	var/wound_bonus_per_hit = 5
 	/// How much our wound_bonus hitstreak bonus caps at (peak demonry)
 	var/wound_bonus_hitstreak_max = 12
@@ -62,7 +62,7 @@
 	// Reset our streaks
 	current_hitstreak = 0
 	wound_bonus = initial(wound_bonus)
-	bare_wound_bonus = initial(bare_wound_bonus)
+	exposed_wound_bonus = initial(exposed_wound_bonus)
 
 /// Performs the classic slaughter demon bodyslam on the attack_target. Yeets them a screen away.
 /mob/living/basic/demon/slaughter/proc/bodyslam(atom/attack_target)
@@ -114,7 +114,7 @@
 
 	current_hitstreak++
 	wound_bonus += wound_bonus_per_hit
-	bare_wound_bonus += wound_bonus_per_hit
+	exposed_wound_bonus += wound_bonus_per_hit
 
 /// The laughter demon! It's everyone's best friend! It just wants to hug them so much, it wants to hug everyone at once!
 /mob/living/basic/demon/slaughter/laughter

--- a/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spiders.dm
+++ b/code/modules/mob/living/basic/space_fauna/spider/giant_spider/giant_spiders.dm
@@ -323,7 +323,7 @@
 	maximum_survivable_temperature = 700
 	unsuitable_cold_damage = 0
 	wound_bonus = 25
-	bare_wound_bonus = 50
+	exposed_wound_bonus = 50
 	sharpness = SHARP_EDGED
 	obj_damage = 60
 	web_speed = 0.25

--- a/code/modules/mob/living/basic/trooper/syndicate.dm
+++ b/code/modules/mob/living/basic/trooper/syndicate.dm
@@ -231,7 +231,7 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	wound_bonus = -10
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	sharpness = SHARP_EDGED
 	obj_damage = 0
 	attack_verb_continuous = "cuts"

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -6,7 +6,7 @@
 	forced = FALSE,
 	spread_damage = FALSE,
 	wound_bonus = 0,
-	bare_wound_bonus = 0,
+	exposed_wound_bonus = 0,
 	sharpness = NONE,
 	attack_direction = null,
 	attacking_item,
@@ -43,7 +43,7 @@
 	forced = FALSE,
 	spread_damage = FALSE,
 	wound_bonus = 0,
-	bare_wound_bonus = 0,
+	exposed_wound_bonus = 0,
 	sharpness = NONE,
 	attack_direction = null,
 	attacking_item,
@@ -265,7 +265,7 @@
  *
  * It automatically updates health status
  */
-/mob/living/carbon/take_bodypart_damage(brute = 0, burn = 0, updating_health = TRUE, required_bodytype, check_armor = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = NONE)
+/mob/living/carbon/take_bodypart_damage(brute = 0, burn = 0, updating_health = TRUE, required_bodytype, check_armor = FALSE, wound_bonus = 0, exposed_wound_bonus = 0, sharpness = NONE)
 	. = FALSE
 	if(HAS_TRAIT(src, TRAIT_GODMODE))
 		return
@@ -275,7 +275,7 @@
 
 	var/obj/item/bodypart/picked = pick(parts)
 	var/damage_calculator = picked.get_damage()
-	if(picked.receive_damage(abs(brute), abs(burn), check_armor ? run_armor_check(picked, (brute ? MELEE : burn ? FIRE : null)) : FALSE, wound_bonus = wound_bonus, bare_wound_bonus = bare_wound_bonus, sharpness = sharpness))
+	if(picked.receive_damage(abs(brute), abs(burn), check_armor ? run_armor_check(picked, (brute ? MELEE : burn ? FIRE : null)) : FALSE, wound_bonus = wound_bonus, exposed_wound_bonus = exposed_wound_bonus, sharpness = sharpness))
 		update_damage_overlays()
 	return (damage_calculator - picked.get_damage())
 

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -12,7 +12,7 @@
  * * forced - "Force" exactly the damage dealt. This means it skips damage modifier from blocked.
  * * spread_damage - For carbons, spreads the damage across all bodyparts rather than just the targeted zone.
  * * wound_bonus - Bonus modifier for wound chance.
- * * bare_wound_bonus - Bonus modifier for wound chance on bare skin.
+ * * exposed_wound_bonus - Bonus modifier for wound chance on bare skin.
  * * sharpness - Sharpness of the weapon.
  * * attack_direction - Direction of the attack from the attacker to [src].
  * * attacking_item - Item that is attacking [src].
@@ -28,7 +28,7 @@
 	forced = FALSE,
 	spread_damage = FALSE,
 	wound_bonus = 0,
-	bare_wound_bonus = 0,
+	exposed_wound_bonus = 0,
 	sharpness = NONE,
 	attack_direction = null,
 	attacking_item,
@@ -42,7 +42,7 @@
 	if(damage_amount <= 0)
 		return 0
 
-	SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMAGE, damage_amount, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item, wound_clothing)
+	SEND_SIGNAL(src, COMSIG_MOB_APPLY_DAMAGE, damage_amount, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item, wound_clothing)
 
 	var/damage_dealt = 0
 	switch(damagetype)
@@ -55,7 +55,7 @@
 					burn = 0,
 					forced = forced,
 					wound_bonus = wound_bonus,
-					bare_wound_bonus = bare_wound_bonus,
+					exposed_wound_bonus = exposed_wound_bonus,
 					sharpness = sharpness,
 					attack_direction = attack_direction,
 					damage_source = attacking_item,
@@ -74,7 +74,7 @@
 					burn = damage_amount,
 					forced = forced,
 					wound_bonus = wound_bonus,
-					bare_wound_bonus = bare_wound_bonus,
+					exposed_wound_bonus = exposed_wound_bonus,
 					sharpness = sharpness,
 					attack_direction = attack_direction,
 					damage_source = attacking_item,
@@ -93,7 +93,7 @@
 		if(BRAIN)
 			damage_dealt = -1 * adjustOrganLoss(ORGAN_SLOT_BRAIN, damage_amount)
 
-	SEND_SIGNAL(src, COMSIG_MOB_AFTER_APPLY_DAMAGE, damage_dealt, damagetype, def_zone, blocked, wound_bonus, bare_wound_bonus, sharpness, attack_direction, attacking_item, wound_clothing)
+	SEND_SIGNAL(src, COMSIG_MOB_AFTER_APPLY_DAMAGE, damage_dealt, damagetype, def_zone, blocked, wound_bonus, exposed_wound_bonus, sharpness, attack_direction, attacking_item, wound_clothing)
 	return damage_dealt
 
 /**
@@ -505,7 +505,7 @@
 		updatehealth()
 
 /// damage ONE external organ, organ gets randomly selected from damaged ones.
-/mob/living/proc/take_bodypart_damage(brute = 0, burn = 0, updating_health = TRUE, required_bodytype, check_armor = FALSE, wound_bonus = 0, bare_wound_bonus = 0, sharpness = NONE)
+/mob/living/proc/take_bodypart_damage(brute = 0, burn = 0, updating_health = TRUE, required_bodytype, check_armor = FALSE, wound_bonus = 0, exposed_wound_bonus = 0, sharpness = NONE)
 	. = (adjustBruteLoss(abs(brute), updating_health = FALSE) + adjustFireLoss(abs(burn), updating_health = FALSE))
 	if(!.) // no change, no need to update
 		return FALSE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -125,7 +125,7 @@
 		def_zone = def_zone,
 		blocked = min(ARMOR_MAX_BLOCK, armor_check),  //cap damage reduction at 90%
 		wound_bonus = proj.wound_bonus,
-		bare_wound_bonus = proj.bare_wound_bonus,
+		exposed_wound_bonus = proj.exposed_wound_bonus,
 		sharpness = proj.sharpness,
 		attack_direction = get_dir(proj.starting, src),
 		attacking_item = proj,
@@ -437,7 +437,7 @@
 		def_zone = user.zone_selected,
 		blocked = armor_block,
 		wound_bonus = user.wound_bonus,
-		bare_wound_bonus = user.bare_wound_bonus,
+		exposed_wound_bonus = user.exposed_wound_bonus,
 		sharpness = user.sharpness,
 		attack_direction = get_dir(user, src),
 	)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -147,7 +147,7 @@
 	///How much wounding power it has
 	var/wound_bonus = CANT_WOUND
 	///How much bare wounding power it has
-	var/bare_wound_bonus = 0
+	var/exposed_wound_bonus = 0
 	///If the attacks from this are sharp
 	var/sharpness = NONE
 	///Generic flags

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -93,7 +93,7 @@
 		"embedding" = get_embed().create_copy(),
 		"armour_penetration" = armour_penetration,
 		"wound_bonus" = wound_bonus,
-		"bare_wound_bonus" = bare_wound_bonus,
+		"exposed_wound_bonus" = exposed_wound_bonus,
 		"demolition_mod" = demolition_mod,
 	)
 
@@ -309,7 +309,7 @@
 	attack_verb_simple = list("slash", "slice", "tear", "lacerate", "rip", "dice", "cut")
 	sharpness = SHARP_POINTY
 	armour_penetration = 20
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 	item_flags = NO_BLOOD_ON_ITEM
 	light_system = OVERLAY_LIGHT
 	light_range = 1.5

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -65,8 +65,8 @@
 
 		loaded_projectile.wound_bonus += gun.projectile_wound_bonus
 		loaded_projectile.wound_bonus *= loaded_projectile.wound_bonus >= 0 ? 1 : 2 - integrity_mult
-		loaded_projectile.bare_wound_bonus += gun.projectile_wound_bonus
-		loaded_projectile.bare_wound_bonus *= loaded_projectile.bare_wound_bonus >= 0 ? 1 : 2 - integrity_mult
+		loaded_projectile.exposed_wound_bonus += gun.projectile_wound_bonus
+		loaded_projectile.exposed_wound_bonus *= loaded_projectile.exposed_wound_bonus >= 0 ? 1 : 2 - integrity_mult
 
 	if(tk_firing(user, fired_from))
 		loaded_projectile.ignore_source_check = TRUE

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -303,9 +303,9 @@
 		span_hear("You can hear sound of plastic shattering."))
 
 	if (poor_sod)
-		poor_sod.receive_damage((damage_to_take - atom_integrity) * 0.5, wound_bonus = -10, bare_wound_bonus = 20, sharpness = SHARP_EDGED, damage_source = src)
+		poor_sod.receive_damage((damage_to_take - atom_integrity) * 0.5, wound_bonus = -10, exposed_wound_bonus = 20, sharpness = SHARP_EDGED, damage_source = src)
 	else
-		user.take_bodypart_damage((damage_to_take - atom_integrity) * 0.5, wound_bonus = -10, bare_wound_bonus = 20, sharpness = SHARP_EDGED)
+		user.take_bodypart_damage((damage_to_take - atom_integrity) * 0.5, wound_bonus = -10, exposed_wound_bonus = 20, sharpness = SHARP_EDGED)
 
 	if (shrapnel_bomb)
 		var/obj/item/shrapnel/plastic/shrapnel = new(user.loc)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -262,7 +262,7 @@
 	var/damage_falloff_tile
 	/// How much we want to drop stamina damage (defined by the stamina variable) per tile as it travels through the air
 	var/stamina_falloff_tile
-	/// How much we want to drop both wound_bonus and bare_wound_bonus (to a minimum of 0 for the latter) per tile, for falloff purposes
+	/// How much we want to drop both wound_bonus and exposed_wound_bonus (to a minimum of 0 for the latter) per tile, for falloff purposes
 	var/wound_falloff_tile
 	/// How much we want to drop the embed_chance value, if we can embed, per tile, for falloff purposes
 	var/embed_falloff_tile
@@ -301,7 +301,7 @@
 	pixels_moved_last_tile -= ICON_SIZE_ALL
 	if(wound_falloff_tile && wound_bonus != CANT_WOUND)
 		wound_bonus += wound_falloff_tile
-		bare_wound_bonus = max(0, bare_wound_bonus + wound_falloff_tile)
+		exposed_wound_bonus = max(0, exposed_wound_bonus + wound_falloff_tile)
 	if(embed_falloff_tile && get_embed())
 		embed_data.embed_chance += embed_falloff_tile
 	if(damage_falloff_tile && damage >= 0)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -17,7 +17,7 @@
 	ricochet_chance = 80
 	reflectable = TRUE
 	wound_bonus = -20
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 
 
 /obj/projectile/beam/laser
@@ -26,7 +26,7 @@
 	impact_type = /obj/effect/projectile/impact/laser
 	wound_bonus = -20
 	damage = 25
-	bare_wound_bonus = 40
+	exposed_wound_bonus = 40
 
 /obj/projectile/beam/laser/carbine
 	icon_state = "carbine_laser"
@@ -102,7 +102,7 @@
 	icon_state = "scatterlaser"
 	damage = 7.5
 	wound_bonus = 5
-	bare_wound_bonus = 5
+	exposed_wound_bonus = 5
 	damage_falloff_tile = -0.45
 	wound_falloff_tile = -2.5
 
@@ -206,7 +206,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 	wound_bonus = -40
-	bare_wound_bonus = 70
+	exposed_wound_bonus = 70
 
 /obj/projectile/beam/emitter/singularity_pull(atom/singularity, current_size)
 	return //don't want the emitters to miss

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -37,7 +37,7 @@
 	armor_flag = BOMB
 	speed = 0.8
 	wound_bonus = 30
-	bare_wound_bonus = 30
+	exposed_wound_bonus = 30
 	wound_falloff_tile = -4
 	fire_stacks = 3
 
@@ -84,7 +84,7 @@
 			LAZYADD(launched_items, iter_item)
 		else if(isliving(iter))
 			var/mob/living/incineratee = iter
-			incineratee.take_bodypart_damage(0, damage, check_armor = TRUE, wound_bonus=wound_bonus, bare_wound_bonus=bare_wound_bonus)
+			incineratee.take_bodypart_damage(0, damage, check_armor = TRUE, wound_bonus=wound_bonus, exposed_wound_bonus=exposed_wound_bonus)
 			incineratee.adjust_fire_stacks(fire_stacks)
 
 #undef BACKBLAST_MAX_ITEM_KNOCKBACK

--- a/code/modules/projectiles/projectile/bullets/junk.dm
+++ b/code/modules/projectiles/projectile/bullets/junk.dm
@@ -78,7 +78,7 @@
 	damage = 10
 	embed_type = /datum/embedding/bullet/junk/ripper
 	wound_bonus = 10
-	bare_wound_bonus = 30
+	exposed_wound_bonus = 30
 
 /datum/embedding/bullet/junk/ripper
 	embed_chance = 100

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -44,7 +44,7 @@
 	sharpness = SHARP_EDGED
 	weak_against_armour = TRUE
 	wound_bonus = -40
-	bare_wound_bonus = 30
+	exposed_wound_bonus = 30
 	wound_falloff_tile = -8
 
 /obj/projectile/bullet/incendiary/a7mm

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -20,7 +20,7 @@
 	ricochet_auto_aim_angle = 10
 	ricochet_auto_aim_range = 3
 	wound_bonus = -20
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 	embed_type = /datum/embedding/bullet/c38
 	embed_falloff_tile = -4
 
@@ -74,7 +74,7 @@
 	ricochets_max = 0
 	sharpness = SHARP_EDGED
 	wound_bonus = 20
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	embed_type = /datum/embedding/bullet/c38/dumdum
 	wound_falloff_tile = -5
 	embed_falloff_tile = -15

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -47,7 +47,7 @@
 	damage = 60
 	armour_penetration = 50
 	wound_bonus = -20
-	bare_wound_bonus = 80
+	exposed_wound_bonus = 80
 	embed_type = /datum/embedding/harpoon
 	wound_falloff_tile = -5
 	shrapnel_type = null
@@ -71,7 +71,7 @@
 	dismemberment = 1 //because a 1 in 100 chance to just blow someones arm off is enough to be cool but also not enough to be reliable
 	armour_penetration = 10
 	wound_bonus = -20
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	embed_type = /datum/embedding/rebar
 	embed_falloff_tile = -5
 	wound_falloff_tile = -2
@@ -96,7 +96,7 @@
 	dismemberment = 2 //It's a budget sniper rifle.
 	armour_penetration = 20 //A bit better versus armor. Gets past anti laser armor or a vest, but doesnt wound proc on sec armor.
 	wound_bonus = 10
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	embed_falloff_tile = -3
 	embed_type = /datum/embedding/rebar_syndie
 	shrapnel_type = /obj/item/ammo_casing/rebar/syndie
@@ -121,7 +121,7 @@
 	eyeblur = 5
 	armour_penetration = 20 // not nearly as good, as its not as sharp.
 	wound_bonus = 10
-	bare_wound_bonus = 40
+	exposed_wound_bonus = 40
 	embed_type = /datum/embedding/rebar_zaukerite
 	embed_falloff_tile = 0 // very spiky.
 	shrapnel_type = /obj/item/ammo_casing/rebar/zaukerite
@@ -149,7 +149,7 @@
 	damage_type = BRUTE
 	armour_penetration = 30 //very pointy.
 	wound_bonus = -100
-	bare_wound_bonus = 0
+	exposed_wound_bonus = 0
 	shrapnel_type = /obj/item/ammo_casing/rebar/hydrogen
 	embed_type = /datum/embedding/rebar_hydrogen
 	embed_falloff_tile = -3
@@ -175,7 +175,7 @@
 	damage_type = BRUTE
 	armour_penetration = 100
 	wound_bonus = -100
-	bare_wound_bonus = -100
+	exposed_wound_bonus = -100
 	embed_type = null
 	embed_falloff_tile = -3
 	shrapnel_type = /obj/item/ammo_casing/rebar/healium

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -5,7 +5,7 @@
 	armour_penetration = 30
 	sharpness = SHARP_POINTY
 	wound_bonus = 0
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 
 /obj/projectile/bullet/shotgun_slug/milspec
 	name = "12g shotgun milspec slug"
@@ -83,7 +83,7 @@
 	name = "buckshot pellet"
 	damage = 5
 	wound_bonus = 5
-	bare_wound_bonus = 5
+	exposed_wound_bonus = 5
 	speed = 1.1
 	wound_falloff_tile = -0.5 //We would very much like this to cause wounds despite the low damage, so the drop off is relatively slow
 	sharpness = SHARP_EDGED
@@ -95,7 +95,7 @@
 /obj/projectile/bullet/pellet/shotgun_buckshot/old
 	damage_falloff_tile = -1
 	wound_bonus = -100
-	bare_wound_bonus = -100
+	exposed_wound_bonus = -100
 
 /obj/projectile/bullet/pellet/shotgun_buckshot/milspec
 	name = "milspec buckshot pellet"
@@ -135,7 +135,7 @@
 	icon_state = "flechette"
 	damage = 2
 	wound_bonus = 5
-	bare_wound_bonus = 5
+	exposed_wound_bonus = 5
 	armour_penetration = 30
 	damage_falloff_tile = -0.2
 	wound_falloff_tile = -0.5
@@ -159,7 +159,7 @@
 	icon_state = "flechette_plastic"
 	damage = 1 // good god its awful
 	wound_bonus = 20 // but it WILL mulch you if you don't have armor.
-	bare_wound_bonus = 20
+	exposed_wound_bonus = 20
 	armour_penetration = 0
 	damage_falloff_tile = -0.1
 	wound_falloff_tile = -2

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -26,7 +26,7 @@
 	name = "4.6x30mm bullet"
 	damage = 20
 	wound_bonus = -5
-	bare_wound_bonus = 5
+	exposed_wound_bonus = 5
 	embed_falloff_tile = -4
 
 /obj/projectile/bullet/c46x30mm/ap

--- a/code/modules/projectiles/projectile/energy/thermal.dm
+++ b/code/modules/projectiles/projectile/energy/thermal.dm
@@ -7,7 +7,7 @@
 	armour_penetration = 10
 	reflectable = NONE
 	wound_bonus = 0
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 
 /obj/projectile/energy/inferno/on_hit(atom/target, blocked = 0, pierce_hit)
@@ -36,7 +36,7 @@
 	sharpness = SHARP_POINTY //it's a big ol' shard of ice
 	reflectable = NONE
 	wound_bonus = 0
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 
 /obj/projectile/energy/cryo/on_hit(atom/target, blocked = 0, pierce_hit)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -192,7 +192,7 @@
 		"embedding" = embed_data,
 		"armour_penetration" = armour_penetration,
 		"wound_bonus" = wound_bonus,
-		"bare_wound_bonus" = bare_wound_bonus,
+		"exposed_wound_bonus" = exposed_wound_bonus,
 		"demolition_mod" = demolition_mod,
 	)
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -146,7 +146,7 @@
 	/// Our current stored wound damage multiplier
 	var/wound_damage_multiplier = 1
 
-	/// This number is subtracted from all wound rolls on this bodypart, higher numbers mean more defense, negative means easier to wound
+	/// This number is added to the effective wound armor on this body part (as long as it isn't managled externally or internally), higher numbers mean more defense, negative means easier to wound
 	var/wound_resistance = 0
 	/// When this bodypart hits max damage, this number is added to all wound rolls. Obviously only relevant for bodyparts that have damage caps.
 	var/disabled_wound_penalty = 15
@@ -492,13 +492,13 @@
  * update_health - Whether to update the owner's health from receiving the hit.
  * required_bodytype - A bodytype flag requirement to get this damage (ex: BODYTYPE_ORGANIC)
  * wound_bonus - Additional bonus chance to get a wound.
- * bare_wound_bonus - Additional bonus chance to get a wound if the bodypart is naked.
+ * exposed_wound_bonus - Additional bonus chance to get a wound if the bodypart is naked.
  * wound_clothing - If this should damage clothing.
  * sharpness - Flag on whether the attack is edged or pointy
  * attack_direction - The direction the bodypart is attacked from, used to send blood flying in the opposite direction.
  * damage_source - The source of damage, typically a weapon.
  */
-/obj/item/bodypart/proc/receive_damage(brute = 0, burn = 0, blocked = 0, updating_health = TRUE, forced = FALSE, required_bodytype = null, wound_bonus = 0, bare_wound_bonus = 0, sharpness = NONE, attack_direction = null, damage_source, wound_clothing = TRUE)
+/obj/item/bodypart/proc/receive_damage(brute = 0, burn = 0, blocked = 0, updating_health = TRUE, forced = FALSE, required_bodytype = null, wound_bonus = 0, exposed_wound_bonus = 0, sharpness = NONE, attack_direction = null, damage_source, wound_clothing = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 
 	var/hit_percent = forced ? 1 : (100-blocked)/100
@@ -565,11 +565,11 @@
 				if(wounding_type == WOUND_PIERCE && !easy_dismember)
 					wounding_dmg *= 0.75 // piercing weapons pass along 75% of their wounding damage to the bone since it's more concentrated
 				wounding_type = WOUND_BLUNT
-		if ((dismemberable_by_wound() || dismemberable_by_total_damage()) && try_dismember(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus))
+		if ((dismemberable_by_wound() || dismemberable_by_total_damage()) && try_dismember(wounding_type, wounding_dmg, wound_bonus, exposed_wound_bonus))
 			return
 		// now we have our wounding_type and are ready to carry on with wounds and dealing the actual damage
 		if(wounding_dmg >= WOUND_MINIMUM_DAMAGE && wound_bonus != CANT_WOUND)
-			check_wounding(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus, attack_direction, damage_source = damage_source, wound_clothing = wound_clothing)
+			check_wounding(wounding_type, wounding_dmg, wound_bonus, exposed_wound_bonus, attack_direction, damage_source = damage_source, wound_clothing = wound_clothing)
 
 	for(var/datum/wound/iter_wound as anything in wounds)
 		iter_wound.receive_damage(wounding_type, wounding_dmg, wound_bonus, damage_source)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -170,9 +170,9 @@
  * * wounding_type: Either WOUND_BLUNT, WOUND_SLASH, or WOUND_PIERCE, basically only matters for the dismember message
  * * wounding_dmg: The damage of the strike that prompted this roll, higher damage = higher chance
  * * wound_bonus: Not actually used right now, but maybe someday
- * * bare_wound_bonus: ditto above
+ * * exposed_wound_bonus: ditto above
  */
-/obj/item/bodypart/proc/try_dismember(wounding_type, wounding_dmg, wound_bonus, bare_wound_bonus)
+/obj/item/bodypart/proc/try_dismember(wounding_type, wounding_dmg, wound_bonus, exposed_wound_bonus)
 	if (!can_dismember())
 		return
 

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -173,7 +173,7 @@
 	toolspeed = 1
 	sharpness = SHARP_POINTY
 	wound_bonus = 10
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 	/// How this looks when placed in a surgical tray
 	var/surgical_tray_overlay = "drill_normal"
 
@@ -226,7 +226,7 @@
 	tool_behaviour = TOOL_SCALPEL
 	toolspeed = 1
 	wound_bonus = 10
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	/// How this looks when placed in a surgical tray
 	var/surgical_tray_overlay = "scalpel_normal"
 	var/list/alt_continuous = list("stabs", "pierces", "impales")
@@ -285,7 +285,7 @@
 	tool_behaviour = TOOL_SAW
 	toolspeed = 1
 	wound_bonus = 15
-	bare_wound_bonus = 10
+	exposed_wound_bonus = 10
 	/// How this looks when placed in a surgical tray
 	var/surgical_tray_overlay = "saw_normal"
 

--- a/code/modules/vehicles/vehicle_key.dm
+++ b/code/modules/vehicles/vehicle_key.dm
@@ -36,7 +36,7 @@
 	sharpness = SHARP_EDGED
 	embed_type = /datum/embedding/janicart_key
 	wound_bonus = -1
-	bare_wound_bonus = 2
+	exposed_wound_bonus = 2
 
 /datum/embedding/janicart_key
 	pain_mult = 1

--- a/code/modules/zombie/items.dm
+++ b/code/modules/zombie/items.dm
@@ -8,7 +8,7 @@
 	hitsound = 'sound/effects/hallucinations/growl1.ogg'
 	force = 21 // Just enough to break airlocks with melee attacks
 	wound_bonus = -30
-	bare_wound_bonus = 15
+	exposed_wound_bonus = 15
 	sharpness = SHARP_EDGED
 
 /obj/item/mutant_hand/zombie/afterattack(atom/target, mob/user, list/modifiers, list/attack_modifiers)


### PR DESCRIPTION
Original PR: 91099
-----
## About The Pull Request

This is a big one so please bear with me, wounds are complicated

### Max Potential Wound Rolls

We've decreased the max contributed damage to wound rolls from 35 to 25. This results, after the exponent, a max possible wound roll of 1 to 91 before any modifiers (assuming the attack, after armor, is 25 or above).

The minimum value to wound is still 5.

### Wound Escalation Penalties

Most wounds were contributing significant numbers per wound type to the potential for a new wound to occur. Getting wounded once meant you were getting wound a lot, but actually getting past that first wounding may be the tricky part.

We have significantly reigned in the wound penalty that having a wound contributes, and instead utilize the series wound penalty to allow same type wounds to escalate themselves faster as a priority. Having wounds still makes you more wound vulnerable, just not to such an extreme degree.

The priority here for what wounds matter most for contributing to overall wounding vulnerability is ``Infected BURNS > BURNS > SLASH|PIERCE > BLUNT.``

### Wound Armor

Wound armor, unlike all other kinds of armor, was used as a additive value to the wound roll modifiers rather than a multiplicative value.

We have reworked how wound armor is determined by changing how wound modifiers are calculated.

Firstly, we're passing our entire injury roll into the ``check_woundings_mod()`` proc, as we're not treating this as a proc that just adds values anymore.

Secondly, bare wound bonus only applies if there is no potential wound protection from any source, as expected. But it comes last in the calculations.

Thirdly, wound protection is applied to the injury roll last, after wound bonuses from the attack, wound bonuses from other wounds and wound bonuses from a disabled limb are applied. This does not include serial wound bonuses, which are determined outside of this proc.

Wound protection comes from two sources. Clothing and limb wound resistance. Your chest and head have an amount of wound resistance so long as they are not mangled in any fashion. Being mangled means having either a hairline fracture or a weeping avulsion wound.

Wound protection reduces the final injury roll by a percentage. Say our roll is 50, and we have effectively 50% wound protection. The final roll would be 25.

### ~~Wound Armor on Clothing~~ Reverted

~~Most clothing have had their wound armor values changed. As a loose rule, I used the highest of melee or bomb armor, except where that value was 100, in which case I used the lowest instead. I'm basing this decision on how embeds are calculated, which is attack type agnostic.~~

~~Some armor have inconsistent values because they are alternative armors to an existing armor type or are hyperspecialized armor. Ablative, bulletproof and security vests all share a value of 35, despite the former two not having decent melee or bomb armor.~~

~~Some clothing missing wound armor that should have had them now have wound armor.~~

~~This may need a bit of scrutiny in case one or two seem weirdly high. Some have maybe become too low. Its a bit hard to say.~~

### The ``bare_wound_bonus`` variable

I changed it to ``exposed_wound_bonus`` to better represent when it applies. You can be naked and still not be affected by this bonus if the limb has wound resistance.

## Why It's Good For The Game

I'm not promising anything with this PR, but this is an attempt to sanity check the values on wounds so that we're not seeing what the data that determined the removal of beheading presented. An extreme over-representation of tier 3 wounds. ~~And, from that, maybe I can argue for beheadings coming back. That's my goal. I think beheadings happened so much because the numbers were in need of work.~~ Well okay I just wanna make wounds a bit more workable actually more than I want beheadings.

Why is it that tier 3 wounds were so over-represented? Because wounds will often force more severe wounds of other types by merit of any wounds existing at all on a limb. Having **_a_** wound makes you more wound prone for any kind of wound, and not just making you more likely to suffer a more severe type of the same wound.

The threshold mechanic was intended to simulate making a wound worse, but oddly just made a limb broadly more prone to getting worse from any kind of attack to such a degree that future wound rolls of different types were often going to start at the threshold necessary to be a tier 3 wound.

Dismemberment, mind you, requires you to suffer a flesh wound while you have a bone wound of tier 2 or higher (with tier 3 giving a bonus to this). You can do this readily via just a sharp weapon, because having a mangled limb causes the wound to turn into a bone wound. Technically, this is meant to be less likely as the effective damage for this wound is halved. But the wound bonus from having a flesh wound was almost always significant enough to kick your new bone wound up to a tier 3.

In other words; its not surprising that you saw so many beheadings, because the system wanted to behead you as fast as it possibly can thanks to all these escalating values.

Wound armor was only applied as a flat reduction on the roll. The average for wound armor was 10. After receiving a single wound, you can expect wound rolls to reach upwards of 100, even if the actual damage roll was not particularly high, due to wound stacking bonuses form being wounded.

This meant that wounds, if they happened, came thick and fast after the first, regardless of what your protection might be to wounds. It was just a matter of getting past the initial bump.

This is why effects that forced wounds were so powerful. They basically made a given limb more prone to taking a wound without having to deal with the protection problem first.

Finally, this is just a broad flaw with the system that is not its fault. It is actually a problem that isn't a problem. Most people in the game are not wearing helmets that protect their head. So most people are going to suffer from a higher proclivity of being wounded if people are aiming for the head. There is this...kind of cargo cult belief that aiming for the head means you do more damage, or can stun someone if you're lucky or what have you. It's entirely nonsense, but it has a grain of truth in that people rarely wear, or even have access too, headwear that provides wound protection or any protection at all. People have jumpsuits, which are universally wound protected, but that isn't true of the head. Look, the point is, they're not aiming at the head because it is usually less armored, its for other reasons but it just so happens to become true due to wounds and how wounds roll their type.

To soften this issue, I've decided to treat wound resistance as armor until the limb suffers a tier 3 wound. This way, hits to the head MAY not necessarily escalate to tier 3 instantly as they would on live even from relatively low power weapons. Some weapons have very low force, but have extreme bare wound bonuses. This should be less likely after this change. I doubt this will necessarily make high damage high wound weapons like energy swords any less prone to cutting you clean open, but it might thanks to the reduction to contributed damage to the injury roll. The system is now _a bit more random_.

## Changelog
:cl:
balance: Wounds do not make you as vulnerable to suffering wounds of all types as before. Instead, wounds make you more vulnerable to suffering worse versions of themselves as a priority.
balance: Wound armor is now more impactful when protecting you from wounds when you have already been wounded.
balance: Your head and chest are more difficult to wound until they have been mangled; either from suffering from a weeping avulsion or a hairline fracture.
code: Changed the variable for bare_wound_bonus to exposed_wound_bonus to better explain what that variable is doing.
/:cl:
