### PR TITLE
[TG Mirror] [NO GBP] fix server hop lobby art fade-in [MDB IGNORE]

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -59,7 +59,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 	var/client/hopper = client
 	to_chat(hopper, span_notice("Sending you to [pick]."))
-	var/atom/movable/screen/splash/fade_in = new(null, null, src, hopper, FALSE)
+	var/atom/movable/screen/splash/fade_in = new(null, null, hopper, FALSE)
 	fade_in.Fade(FALSE)
 
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, SERVER_HOPPER_TRAIT)


### PR DESCRIPTION
Original PR: 91693
-----

## About The Pull Request

accidentally broke this in https://github.com/tgstation/tgstation/pull/91637, whoops

## Why It's Good For The Game

bugfix

## Changelog
:cl:
fix: Fixed lobby art not fading in when server hopping.
/:cl:
