### PR TITLE
[TG Mirror] Explosions severing cable networks cause nearby(ish) connected rooms's lights to flicker. Also reduces cable integrity. [MDB IGNORE]

### DIFF
--- a/code/game/objects/effects/misc.dm
+++ b/code/game/objects/effects/misc.dm
@@ -87,3 +87,7 @@
 /obj/effect/abstract/marker/intercom
 	name = "intercom range marker"
 	color = COLOR_YELLOW
+
+/obj/effect/abstract/marker/powernet
+	name = "powernet run marker"
+	var/powernet_owner

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -956,6 +956,39 @@ ADMIN_VERB(debug_mc_dependencies, R_DEBUG, "Debug MC Dependencies", "Debug MC de
 	var/datum/mc_dependency_ui/data = new /datum/mc_dependency_ui()
 	data.ui_interact(usr)
 
+ADMIN_VERB(show_powernets, R_DEBUG, "Color Powernet Runs", "Colors every node and cable of every powernet in a different color.", ADMIN_CATEGORY_DEBUG)
+	var/removing = FALSE
+	for(var/obj/effect/abstract/marker/powernet/marker in GLOB.all_abstract_markers)
+		qdel(marker)
+		removing = TRUE
+
+	if(removing)
+		return
+
+	var/list/colors = GLOB.carp_colors.Copy()
+
+	if(length(colors) < length(SSmachines.powernets))
+		message_admins("[SSmachines.powernets.len] powernets exist - [length(colors)] colors available - Some powernets will be the same color!")
+
+	for(var/datum/powernet/net as anything in SSmachines.powernets)
+		if(!length(colors))
+			colors = GLOB.carp_colors.Copy()
+
+		var/selected_color = pick_n_take(colors)
+		for(var/atom/component as anything in net.nodes + net.cables)
+			var/turf/component_turf = get_turf(component)
+			var/existing = FALSE
+			for(var/obj/effect/abstract/marker/powernet/existing_marker in component_turf)
+				if(existing_marker.powernet_owner != REF(net))
+					continue
+				existing = TRUE
+				break
+			if(existing)
+				continue
+			var/obj/effect/abstract/marker/powernet/marker = new(component_turf)
+			marker.color = selected_color
+			marker.powernet_owner = REF(net)
+
 ADMIN_VERB(count_instances, R_DEBUG, "Count Atoms/Datums", "Count how many atom or datum instances there are of each type, then output it to a JSON to download.", ADMIN_CATEGORY_DEBUG)
 	var/option = tgui_alert(user, "What type of instances do you wish to count?", "Instance Count", list("Atoms", "Datums"))
 	if(!option)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -24,6 +24,7 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 	layer = WIRE_LAYER //Above hidden pipes, GAS_PIPE_HIDDEN_LAYER
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT
+	max_integrity = 50
 	var/linked_dirs = 0 //bitflag
 	var/node = FALSE //used for sprites display
 	var/cable_layer = CABLE_LAYER_2 //bitflag
@@ -147,6 +148,18 @@ GLOBAL_LIST_INIT(wire_node_generating_types, typecacheof(list(
 /obj/structure/cable/atom_deconstruct(disassembled = TRUE)
 	var/obj/item/stack/cable_coil/cable = new(drop_location(), 1)
 	cable.set_cable_color(cable_color)
+
+/obj/structure/cable/atom_destruction(damage_flag)
+	if(!powernet || damage_flag != BOMB)
+		return ..()
+
+	powernet.propagate_light_flicker(src)
+	return ..()
+
+/obj/structure/cable/run_atom_armor(damage_amount, damage_type, damage_flag, attack_dir, armour_penetration)
+	if(damage_flag == BOMB && HAS_TRAIT(src, TRAIT_UNDERFLOOR))
+		damage_amount *= 0.25
+	return ..()
 
 ///////////////////////////////////
 // General procedures

--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -13,6 +13,9 @@
 	var/netexcess = 0 // excess power on the powernet (typically avail-load)///////
 	var/delayedload = 0 // load applied to powernet between power ticks.
 
+	/// If a run of propagate_light_flicker is ongoing
+	VAR_PRIVATE/flickering = FALSE
+
 /datum/powernet/New()
 	SSmachines.powernets += src
 
@@ -96,3 +99,37 @@
 // Mostly just a wrapper for sending the COMSIG_POWERNET_CIRCUIT_TRANSMISSION signal, but could be retooled in the future to give it other uses
 /datum/powernet/proc/data_transmission(list/data, encryption_key, datum/weakref/port)
 	SEND_SIGNAL(src, COMSIG_POWERNET_CIRCUIT_TRANSMISSION, list("data" = data, "enc_key" = encryption_key, "port" = port))
+
+/**
+ * Triggers lights connected to this powernet to flicker a few times
+ *
+ * * flicker_source - The center of the flicker. If null the whole powernet will flicker
+ * * falloff_distance - Only relevant if you passed a source. Areas beyond this distance will be less and less likely to flicker.
+ */
+/datum/powernet/proc/propagate_light_flicker(atom/flicker_source, falloff_distance = 64)
+	if(flickering || !length(nodes))
+		return
+
+	flickering = TRUE
+	var/most_flickers = 1
+	for(var/obj/machinery/power/terminal/terminal in nodes)
+		if(!istype(terminal.master, /obj/machinery/power/apc))
+			continue
+
+		if(isnull(flicker_source))
+			if(!prob(95))
+				continue
+		else
+			var/flicker_prob = 95 + (3 * (falloff_distance - get_dist(flicker_source, terminal)))
+			if(!prob(min(95, flicker_prob)))
+				continue
+
+		var/flicker_count = rand(1, 3)
+		most_flickers = max(most_flickers, flicker_count)
+		var/obj/machinery/power/apc/apc = terminal.master
+		for(var/obj/machinery/light/light as anything in apc.get_lights())
+			light.flicker(flicker_count)
+		CHECK_TICK
+
+	// don't let another flicker propagation until our slowest area is done (with some added leeway)
+	addtimer(VARSET_CALLBACK(src, flickering, FALSE), most_flickers * 2 SECONDS)


### PR DESCRIPTION
Original PR: 91263
-----
## About The Pull Request

- If a cable is destroyed by an explosion, all rooms within 64-100 (it's a probability) tiles AND which are connected to the same powernet as the split cable will have their lights flicker 1-3 times.

- Also adds a verb for visualizing powernets.

- Reduces cable integrity from 300 to 50.

- Cables have innate 75% bomb armor when under a floor tile.

## Why It's Good For The Game

- A big devastating explosion a few doors down is, usually, not felt at all outside of the screen shake. This adds a bit more ambience to the effect - you hear a big explosion, your screen goes wild, and the lights cut for just a second. 

- Verb just makes it easier to trace powernets.

- I found it a little ridiculous that cables have 300 integrity, the same as most furniture. This ultimately makes them a lot more vulnerable to stuff like acid and fire.

- To compensate for their drastically reduced integrity, I gave cables a considerable boost to explosive resistance while concealed under the floor. This prevents bombs from outright shredding all cables in a 50 mile radius. (Devastating explosions will still one-tap them, but heavy explosions will on average take two blasts.)

## Changelog

:cl: Melbert
add: If a cable is destroyed by an explosion, all rooms within 64-100 (it's a probability) tiles AND which are connected to the same powernet as the split cable will have their lights flicker 1-3 times.
balance: Cable integrity has been reduced from 300 to 50
balance: Cables have an innate 75% bomb resistance while under floor tiles
/:cl:
