### PR TITLE
[TG Mirror] Unbuckles new arrivals from the seats of the arrival shuttle + a bugfix [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_global.dm
+++ b/code/__DEFINES/dcs/signals/signals_global.dm
@@ -107,3 +107,4 @@
 
 /// Global signal whenever a camera network broadcast is started/stopped/updated: (camera_net, is_show_active, announcement)
 #define COMSIG_GLOB_NETWORK_BROADCAST_UPDATED "!network_broadcast_updated"
+

--- a/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
+++ b/code/modules/shuttle/mobile_port/shuttle_move_callbacks.dm
@@ -319,19 +319,19 @@ All ShuttleMove procs go here
 		shake_camera(src, shake_force, 1)
 
 /mob/living/lateShuttleMove(turf/oldT, list/movement_force, move_dir)
-	if(buckled)
-		return
-
-	. = ..()
-
 	var/knockdown = movement_force["KNOCKDOWN"]
+	if(buckled && istype(get_area(src), /area/shuttle/arrival))
+		//if we're on the arrival shuttle, unbuckle so that new player's don't get stuck in there
+		buckled.user_unbuckle_mob(src, src)
+		return
 	if(knockdown > 0)
 		if(buckled)
 			// If we're buckled, no stun but we'll still be floored and frozen
 			Knockdown(knockdown)
 			Immobilize(knockdown * 0.5)
-		else
-			Paralyze(knockdown)
+			return
+		Paralyze(knockdown)
+	return ..()
 
 
 /mob/living/simple_animal/hostile/megafauna/onShuttleMove(turf/newT, turf/oldT, list/movement_force, move_dir, obj/docking_port/stationary/old_dock, obj/docking_port/mobile/moving_dock)


### PR DESCRIPTION
Original PR: 91708
-----

## About The Pull Request

Makes it so new arrivals automatically unbuckle from the seat when the arrival shuttle lands on station, this also fixes some logic from #91504 that actually makes the intended "If you're buckled on a shuttle which has "knockdown" force, you won't be paralyzed - instead, just knocked down and immobilized for a short period (so you can still use your hands / act)." from that PR work
## Why It's Good For The Game

New players should be able to just waddle away from the arrival shuttle to actually play the game instead of being stuck on their seat trying to find their seatbelt for 30 minutes (this situation has actually happened before).
## Changelog
:cl:
qol: With Nanotrasen's brand new Auto-Seats™, late crew members will now automatically unbuckle from their seats when the arrival shuttle arrives at the destination!
fix: Leaving your seat too early on a shuttle with a knockdown force will now properly immobilize and knockdown you as intended.
/:cl:
