### PR TITLE
[TG Mirror] Fix runtime when grabbing/helping someone with no suit on [MDB IGNORE]

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -380,7 +380,7 @@
 	if(get_dist(attacker, src) > 1)
 		return TRUE
 
-	if(ishuman(attacker))
+	if(!ishuman(attacker))
 		attacker.add_mob_blood(src)
 		return TRUE
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -299,7 +299,7 @@
 
 	for(var/obj/item/thing as anything in who_touched_us.get_equipped_items())
 		if((thing.body_parts_covered & HANDS) && prob(GET_ATOM_BLOOD_DNA_LENGTH(thing) * 25))
-			add_blood_DNA_to_items(GET_ATOM_BLOOD_DNA(who_touched_us.wear_suit), messy_slots)
+			add_blood_DNA_to_items(GET_ATOM_BLOOD_DNA(thing), messy_slots)
 			return
 
 	if(prob(blood_in_hands * GET_ATOM_BLOOD_DNA_LENGTH(who_touched_us) * 10))


### PR DESCRIPTION
Original PR: 91721
-----
## About The Pull Request

Evidently this checks if any item you're wearing that covers your hands are bloody, and if they are, the blood will pass on. But though it checks hands cover, it always refers to suit, for some reason.

This is technically my code

Bonus fix: Fixes an inverted check in `attack_effects`