### PR TITLE
[TG Mirror] makes lit ciggies emit light [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/cigarettes.dm
+++ b/code/game/objects/items/cigarettes.dm
@@ -199,6 +199,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	slot_flags = ITEM_SLOT_MASK
 	grind_results = list()
 	heat = 1000
+	light_range = 1
+	light_color = LIGHT_COLOR_FIRE
+	light_system = OVERLAY_LIGHT
+	light_on = FALSE
 	throw_verb = "flick"
 	/// Whether this cigarette has been lit.
 	VAR_FINAL/lit = FALSE
@@ -407,6 +411,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	lit = TRUE
 	playsound(src.loc, 'sound/items/lighter/cig_light.ogg', 100, 1)
 	make_cig_smoke()
+	set_light_on(TRUE)
 	if(!(flags_1 & INITIALIZED_1))
 		update_appearance(UPDATE_ICON)
 		return
@@ -456,6 +461,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	lit = FALSE
 	playsound(src.loc, 'sound/items/lighter/cig_snuff.ogg', 100, 1)
 	update_appearance(UPDATE_ICON)
+	set_light_on(FALSE)
 	if(ismob(loc))
 		to_chat(loc, span_notice("Your [name] goes out."))
 	QDEL_NULL(cig_smoke)
@@ -928,6 +934,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			to_chat(user, span_notice("Your [name] goes out."))
 		packeditem = null
 	update_appearance(UPDATE_ICON)
+	set_light_on(FALSE)
 	STOP_PROCESSING(SSobj, src)
 	QDEL_NULL(cig_smoke)
 
@@ -1005,6 +1012,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	w_class = WEIGHT_CLASS_TINY
 	slot_flags = ITEM_SLOT_MASK
 	flags_1 = IS_PLAYER_COLORABLE_1
+	light_range = 1
+	light_color = LIGHT_COLOR_HALOGEN
+	light_system = OVERLAY_LIGHT
+	light_on = FALSE
 
 	/// The capacity of the vape.
 	var/chem_volume = 100
@@ -1104,12 +1115,14 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	to_chat(user, span_notice("You start puffing on the vape."))
 	reagents.flags &= ~(NO_REACT)
 	START_PROCESSING(SSobj, src)
+	set_light_on(TRUE)
 
 /obj/item/vape/dropped(mob/user)
 	. = ..()
 	if(user.get_item_by_slot(ITEM_SLOT_MASK) == src)
 		reagents.flags |= NO_REACT
 		STOP_PROCESSING(SSobj, src)
+		set_light_on(FALSE)
 
 /obj/item/vape/proc/handle_reagents()
 	if(!reagents.total_volume)


### PR DESCRIPTION
Original PR: 91648
-----
## About The Pull Request

![455125089-37e64bf0-485b-4ff8-853f-da033e19e938](https://github.com/user-attachments/assets/1e815c66-784e-47e0-9d39-c9556f6a7f03)

ciggies and their children now emit light onto their tile when sparked up :3c
and stop emitting light when they're put out

tha screenies from downstream where i did it initially but this is like 7 lines of code its a good pr it works trust me just merge it im begging u my new tg repo has been building for twenty minutes im scared of what its making in there please dont make me find out

*edit* nvm it built now look
![image](https://github.com/user-attachments/assets/8c9931d7-5650-47da-902a-36921affe72e)
wahoo!
## Why It's Good For The Game

its cute! its flavor! you can farm aura by sparking a dart in a dark maint tunnel! tactical dudes can talk about 'light discipline' and go oorah! there's something for everyone here really

## Changelog

:cl:
add: Lit smokables now act as a weak lightsource.
:cl:
