### PR TITLE
[TG Mirror] Adds some throwing datum nullchecks [MDB IGNORE]

### DIFF
--- a/code/datums/components/boomerang.dm
+++ b/code/datums/components/boomerang.dm
@@ -83,7 +83,7 @@
  * * hit_atom: The atom that has been hit by the boomerang'd object.
  */
 /datum/component/boomerang/proc/aerodynamic_swing(datum/thrownthing/throwingdatum)
-	var/mob/thrown_by = throwingdatum.get_thrower()
+	var/mob/thrown_by = throwingdatum?.get_thrower()
 	var/obj/item/true_parent = parent
 	if(thrown_by)
 		addtimer(CALLBACK(true_parent, TYPE_PROC_REF(/atom/movable, throw_at), thrown_by, boomerang_throw_range, throwingdatum.speed, thrown_by, TRUE), 0.1 SECONDS)

--- a/code/datums/elements/relay_attackers.dm
+++ b/code/datums/elements/relay_attackers.dm
@@ -74,7 +74,7 @@
 	var/obj/item/hit_item = hit_atom
 	if(!hit_item.throwforce)
 		return
-	var/mob/thrown_by = throwingdatum.get_thrower()
+	var/mob/thrown_by = throwingdatum?.get_thrower()
 	if(!ismob(thrown_by))
 		return
 	relay_attacker(target, thrown_by, hit_item.damtype == STAMINA ? ATTACKER_STAMINA_ATTACK : ATTACKER_DAMAGING_ATTACK)

--- a/code/datums/proximity_monitor/fields/heretic_arena.dm
+++ b/code/datums/proximity_monitor/fields/heretic_arena.dm
@@ -262,7 +262,7 @@ GLOBAL_LIST_EMPTY(heretic_arenas)
 	// Track being hit by a mob throwing a stick
 	if(!isitem(throwingdatum.thrownthing))
 		return
-	var/thrown_by = throwingdatum.get_thrower()
+	var/thrown_by = throwingdatum?.get_thrower()
 	if(ismob(thrown_by))
 		last_attacker = WEAKREF(thrown_by)
 

--- a/code/game/objects/items/dice.dm
+++ b/code/game/objects/items/dice.dm
@@ -69,7 +69,7 @@
 	diceroll(user, in_hand = TRUE)
 
 /obj/item/dice/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
-	var/mob/thrown_by = throwingdatum.get_thrower()
+	var/mob/thrown_by = throwingdatum?.get_thrower()
 	if(thrown_by)
 		diceroll(thrown_by)
 	return ..()

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -777,7 +777,7 @@
 /obj/item/melee/baton/security/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
 	if(!. && active && prob(throw_stun_chance) && isliving(hit_atom))
-		finalize_baton_attack(hit_atom, throwingdatum.get_thrower())
+		finalize_baton_attack(hit_atom, throwingdatum?.get_thrower())
 
 /obj/item/melee/baton/security/emp_act(severity)
 	. = ..()

--- a/code/modules/mapfluff/ruins/lavalandruin_code/biodome_winter.dm
+++ b/code/modules/mapfluff/ruins/lavalandruin_code/biodome_winter.dm
@@ -28,7 +28,7 @@
 /obj/item/freeze_cube/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	icon_state = initial(icon_state)
 	var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
-	var/mob/thrown_by = throwingdatum.get_thrower()
+	var/mob/thrown_by = throwingdatum?.get_thrower()
 	if(ismovable(hit_atom) && !caught && (!thrown_by || thrown_by && COOLDOWN_FINISHED(src, freeze_cooldown)))
 		freeze_hit_atom(hit_atom)
 	if(thrown_by && !caught)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -219,7 +219,7 @@
 		return ..()
 
 	var/obj/item/thrown_item = AM
-	if(throwingdatum.get_thrower() != src) //No throwing stuff at yourself to trigger hit reactions
+	if(throwingdatum?.get_thrower() != src) //No throwing stuff at yourself to trigger hit reactions
 		if(check_block(AM, thrown_item.throwforce, "\the [thrown_item.name]", THROWN_PROJECTILE_ATTACK, 0, thrown_item.damtype))
 			hitpush = FALSE
 			skipcatch = TRUE
@@ -235,13 +235,13 @@
 		return SUCCESSFUL_BLOCK
 
 	if(nosell_hit)
-		log_hit_combat(throwingdatum.get_thrower(), thrown_item)
+		log_hit_combat(throwingdatum?.get_thrower(), thrown_item)
 		return ..()
 
 	visible_message(span_danger("[src] is hit by [thrown_item]!"),
 		span_userdanger("You're hit by [thrown_item]!"))
 	if(!thrown_item.throwforce)
-		log_hit_combat(throwingdatum.get_thrower(), thrown_item)
+		log_hit_combat(throwingdatum?.get_thrower(), thrown_item)
 		return
 
 	var/armor = run_armor_check(
@@ -255,7 +255,7 @@
 		thrown_item.weak_against_armour,
 	)
 	apply_damage(thrown_item.throwforce, thrown_item.damtype, zone, armor, sharpness = thrown_item.get_sharpness(), wound_bonus = (nosell_hit * CANT_WOUND), attacking_item = thrown_item)
-	log_hit_combat(throwingdatum.get_thrower(), thrown_item)
+	log_hit_combat(throwingdatum?.get_thrower(), thrown_item)
 
 	if(QDELETED(src)) //Damage can delete the mob.
 		return

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -327,7 +327,7 @@
 /mob/living/simple_animal/bot/secbot/hitby(atom/movable/hitting_atom, skipcatch = FALSE, hitpush = TRUE, blocked = FALSE, datum/thrownthing/throwingdatum)
 	if(isitem(hitting_atom))
 		var/obj/item/item_hitby = hitting_atom
-		var/mob/thrown_by = throwingdatum.get_thrower()
+		var/mob/thrown_by = throwingdatum?.get_thrower()
 		if(item_hitby.throwforce < src.health && thrown_by && ishuman(thrown_by))
 			var/mob/living/carbon/human/human_throwee = thrown_by
 			retaliate(human_throwee)

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -102,7 +102,7 @@
 	if(.)
 		return
 	var/obj/projectile/energy/fisher/melee/simulated_hit = new
-	simulated_hit.firer = throwingdatum.get_thrower()
+	simulated_hit.firer = throwingdatum?.get_thrower()
 	simulated_hit.on_hit(hit_atom)
 
 /obj/item/gun/ballistic/automatic/pistol/m1911

--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -168,5 +168,5 @@
 	// ...you reeeeeally just shoot them, but in case you can't/won't
 	. = ..()
 	var/obj/projectile/energy/fisher/melee/simulated_hit = new
-	simulated_hit.firer = throwingdatum.get_thrower()
+	simulated_hit.firer = throwingdatum?.get_thrower()
 	simulated_hit.on_hit(hit_atom)

--- a/code/modules/religion/sparring/sparring_datum.dm
+++ b/code/modules/religion/sparring/sparring_datum.dm
@@ -123,7 +123,7 @@
 		return
 	var/mob/living/honorbound = source
 	var/obj/item/thrown_item = thrown_movable
-	var/mob/thrown_by = throwingdatum.get_thrower()
+	var/mob/thrown_by = throwingdatum?.get_thrower()
 	if(thrown_item.throwforce < honorbound.health && ishuman(thrown_by))
 		INVOKE_ASYNC(src, PROC_REF(flub), thrown_by)
 


### PR DESCRIPTION
Original PR: 91720
-----
## About The Pull Request

A few places seem to call `hitby` or `throw_impact` without a throwing datum to mimic the effect of colliding with something, which is cringe, but I guess we should support it.

So we need to nullcheck for `get_thrower`, else it runtimes and cancels the whole proc.

## Changelog

:cl: Melbert
fix: Glass shards from colliding with vendors or glass table hurt you again.
/:cl:
