### PR TITLE
[TG Mirror] Flying mobs no longer have 3x worse damage slowdown [MDB IGNORE]

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -967,10 +967,8 @@
 	var/health_deficiency = max((maxHealth - health), staminaloss)
 	if(health_deficiency >= 40)
 		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown, TRUE, multiplicative_slowdown = health_deficiency / 75)
-		add_or_update_variable_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying, TRUE, multiplicative_slowdown = health_deficiency / 25)
 	else
 		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown)
-		remove_movespeed_modifier(/datum/movespeed_modifier/damage_slowdown_flying)
 
 /mob/living/carbon/human/is_bleeding()
 	if(HAS_TRAIT(src, TRAIT_NOBLOOD))

--- a/code/modules/movespeed/modifiers/mobs.dm
+++ b/code/modules/movespeed/modifiers/mobs.dm
@@ -28,11 +28,7 @@
 	variable = TRUE
 
 /datum/movespeed_modifier/damage_slowdown
-	blacklisted_movetypes = FLOATING|FLYING
-	variable = TRUE
-
-/datum/movespeed_modifier/damage_slowdown_flying
-	movetypes = FLYING
+	blacklisted_movetypes = FLOATING
 	variable = TRUE
 
 /// Movespeed modifier applied by worn equipment.


### PR DESCRIPTION
Original PR: 91710
-----
## About The Pull Request

Removes a damage modifier introduced for a feature that's been long removed.

## Why It's Good For The Game

Floating mobs are currently suffering a higher damange slowdown than walking, this was apparently changed in this PR  

https://github.com/tgstation/tgstation/pull/20860

This distinction was introduced to balance flight suits, a feature has long been removed, therefore we no longer need this modifier.

## Changelog

:cl:
del: Flying mobs no longer have 3x worse damage slowdown
/:cl:

