### PR TITLE
[TG Mirror] Properly defines the fire attack of the Phazon to be BURN damage and not FIRE damage, which is not a damtype. [MDB IGNORE]

### DIFF
--- a/code/modules/vehicles/mecha/mech_melee_attack.dm
+++ b/code/modules/vehicles/mecha/mech_melee_attack.dm
@@ -110,7 +110,7 @@
 			else if(mecha_attacker.force > 20 && !IsKnockdown()) // lightweight mechas like gygax
 				mecha_attacker.melee_attack_effect(src, heavy = FALSE)
 			playsound(src, mecha_attacker.brute_attack_sound, 50, TRUE)
-		if(FIRE)
+		if(BURN)
 			playsound(src, mecha_attacker.burn_attack_sound, 50, TRUE)
 		if(TOX)
 			playsound(src, mecha_attacker.tox_attack_sound, 50, TRUE)


### PR DESCRIPTION
Original PR: 91723
-----

## About The Pull Request

Fixes https://github.com/tgstation/tgstation/issues/91672

## Why It's Good For The Game

I feel like this speaks to just how dreadful the Phazon punch actually is if nobody noticed this was bugged as long as it was.

## Changelog
:cl:
fix: Phazon fire punches now properly deal damage, rather than make a funny fire special effect and doing literally nothing at all.
/:cl:
