### PR TITLE
[TG Mirror] Makes mushroom people available to admins via config. [MDB IGNORE]

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -36,9 +36,6 @@
 	/// Martial art for the mushpeople
 	var/datum/martial_art/mushpunch/mush
 
-/datum/species/mush/check_roundstart_eligible()
-	return FALSE //hard locked out of roundstart on the order of design lead kor, this can be removed in the future when planetstation is here OR SOMETHING but right now we have a problem with races.
-
 /datum/species/mush/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load, regenerate_icons)
 	. = ..()
 	mush = new(src)


### PR DESCRIPTION
Original PR: 91664
-----
## About The Pull Request

Makes mushroom people available to admins via config.

## Why It's Good For The Game

Kor is gone and the headmins requested it.

## Changelog

:cl:
admin: Makes mushroom people available to admins via config.
/:cl:
