### PR TITLE
[TG Mirror] Fixes the text of the Rust Walker in the ghost poll notifications menu [MDB IGNORE]

### DIFF
--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_PYROSLIME = "Slime",
 	POLL_IGNORE_RAW_PROPHET = "Raw Prophet",
 	POLL_IGNORE_REGAL_RAT = "Regal rat",
-	POLL_IGNORE_RUST_SPIRIT = "Rust Spirit",
+	POLL_IGNORE_RUST_SPIRIT = "Rust Walker",
 	POLL_IGNORE_SENTIENCE_POTION = "Sentience potion",
 	POLL_IGNORE_SHADE = "Shade",
 	POLL_IGNORE_SHUTTLE_DENIZENS = "Shuttle denizens",
@@ -76,7 +76,7 @@ GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_STALKER = "Stalker",
 	POLL_IGNORE_SYNDICATE = "Syndicate",
 	POLL_IGNORE_VENUSHUMANTRAP = "Venus Human Traps",
-	POLL_IGNORE_RECOVERED_CREW = "recovered_crew",
+	POLL_IGNORE_RECOVERED_CREW = "Recovered Crew",
 ))
 GLOBAL_LIST_INIT(poll_ignore, init_poll_ignore())
 


### PR DESCRIPTION
Original PR: 91731
-----

## About The Pull Request
Changes the name of the Rust Walker in the ghost poll for selecting notifications. Currently it's Rust Spirit, that is not a mob, we have a Rust Walker and an Ash Spirit. It cleary was meant to be the Rust Walker.

## Why It's Good For The Game

Fixes a naming error

## Changelog

:cl:
fix: Rust Spirit -> Rust Walker in ghost poll menu
/:cl:
