### PR TITLE
[TG Mirror] Ghosts can't haunt canvases [MDB IGNORE]

### DIFF
--- a/code/modules/art/paintings.dm
+++ b/code/modules/art/paintings.dm
@@ -175,8 +175,9 @@
 	if(.)
 		return
 	var/mob/user = usr
-	///this is here to allow observers and viewers to zoom in and out regardless of adjacency.
-	if(action != "zoom_in" && action != "zoom_out" && !can_interact(user))
+	//this is here to allow observers and viewers to zoom in and out regardless of adjacency.
+	//observers need this special check because we allow them to operate the UI in ui_state
+	if((action != "zoom_in" && action != "zoom_out") && (isobserver(user) || !can_interact(user)))
 		return
 	switch(action)
 		if("paint", "fill")


### PR DESCRIPTION
Original PR: 91759
-----
## About The Pull Request

Ghosts are snowflaked able to interact with the canvas UI, which meant they were able to press buttons including finalize. This fixes that with a special observer check. Leaves a comment to explain why it is the way it is as well in case someone in the future messes it up.

## Why It's Good For The Game

Closes https://github.com/tgstation/tgstation/issues/91750

## Changelog

:cl:
fix: Observers can no longer finalize unfinished canvas paintings.
/:cl: