### PR TITLE
[TG Mirror] Remove a pointless and bad `static` from mob spawn unit test [MDB IGNORE]

### DIFF
--- a/code/modules/unit_tests/mob_spawn.dm
+++ b/code/modules/unit_tests/mob_spawn.dm
@@ -15,7 +15,7 @@
 	)
 
 	//vars that must not be set if the mob type isn't human
-	var/static/list/human_only_vars = list(
+	var/list/human_only_vars = list(
 		NAMEOF(ghost_role, facial_haircolor),
 		NAMEOF(ghost_role, facial_hairstyle),
 		NAMEOF(ghost_role, haircolor),
@@ -26,7 +26,7 @@
 	)
 
 	//vars that must be set on all ghost roles.
-	var/static/list/required_vars = list(
+	var/list/required_vars = list(
 		//mob_type is not included because the errors on it are loud and some types choose their mob_type on selection
 		NAMEOF(ghost_role, prompt_name) = "Your ghost role has broken tgui without it.",
 		//these must be set even if show_flavor is false because the spawn menu still uses them and we simply must have higher quality roles


### PR DESCRIPTION
Original PR: 91772
-----

## About The Pull Request

A couple lists were marked as `static` when they should not be. 

The contents of these static lists refer to a local var in the proc, which would normally error except `list()` init is delayed from normal static var defs. 

For example, doing
```
var/beep = 123
var/static/thing = beep
```
would throw an error on compile, but 
```
var/beep = 123
var/static/list/thing = list(beep)
```
would not.

## Why It's Good For The Game

OD errors on this.

## Changelog
:cl:
code: removes an unnecessary static def in a unit test
/:cl:
