### PR TITLE
[TG Mirror] lobby art is mouse transparent on fade out [MDB IGNORE]

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -895,10 +895,11 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/splash)
 
 	holder.screen += src
 
-/atom/movable/screen/splash/proc/Fade(out, qdel_after = TRUE)
+/atom/movable/screen/splash/proc/fade(out, qdel_after = TRUE)
 	if(QDELETED(src))
 		return
 	if(out)
+		mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		animate(src, alpha = 0, time = 30)
 	else
 		alpha = 0

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -471,7 +471,7 @@ SUBSYSTEM_DEF(ticker)
 			ADD_TRAIT(living, TRAIT_NO_TRANSFORM, SS_TICKER_TRAIT)
 			if(living.client)
 				var/atom/movable/screen/splash/fade_out = new(null, null, living.client, TRUE)
-				fade_out.Fade(TRUE)
+				fade_out.fade(TRUE)
 				living.client.init_verbs()
 			livings += living
 	if(livings.len)

--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -59,7 +59,7 @@ SUBSYSTEM_DEF(title)
 		if(!thing)
 			continue
 		var/atom/movable/screen/splash/S = new(null, null, thing, FALSE)
-		S.Fade(FALSE,FALSE)
+		S.fade(FALSE,FALSE)
 
 /datum/controller/subsystem/title/Recover()
 	icon = SStitle.icon

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -129,7 +129,7 @@
 /area/shuttle/arrival/on_joining_game(mob/living/boarder)
 	if(SSshuttle.arrivals?.mode == SHUTTLE_CALL)
 		var/atom/movable/screen/splash/Spl = new(null, null, boarder.client, TRUE)
-		Spl.Fade(TRUE)
+		Spl.fade(TRUE)
 		boarder.playsound_local(get_turf(boarder), 'sound/announcer/ApproachingTG.ogg', 25)
 	boarder.update_parallax_teleport()
 

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -60,7 +60,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 	var/client/hopper = client
 	to_chat(hopper, span_notice("Sending you to [pick]."))
 	var/atom/movable/screen/splash/fade_in = new(null, null, hopper, FALSE)
-	fade_in.Fade(FALSE)
+	fade_in.fade(FALSE)
 
 	ADD_TRAIT(src, TRAIT_NO_TRANSFORM, SERVER_HOPPER_TRAIT)
 	sleep(2.9 SECONDS) //let the animation play

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -23,7 +23,7 @@
 /mob/dead/new_player/Initialize(mapload)
 	if(client && SSticker.state == GAME_STATE_STARTUP)
 		var/atom/movable/screen/splash/fade_out = new(null, null, client, TRUE)
-		fade_out.Fade(TRUE)
+		fade_out.fade(TRUE)
 
 	if(length(GLOB.newplayer_start))
 		forceMove(pick(GLOB.newplayer_start))


### PR DESCRIPTION
Original PR: 91774
-----

## About The Pull Request
you can click things when it starts fading.
## Why It's Good For The Game
particularly annoying when the game starts because you have to wait for it to fully fade before being able to click anything.
## Changelog
:cl:
qol: you can now click on objects in the game when the lobby art starts to fade
/:cl:
