### PR TITLE
[TG Mirror] [NO GBP] Fixes narcolepsy's sleep_chance var not resetting [MDB IGNORE]

### DIFF
--- a/code/datums/brain_damage/severe.dm
+++ b/code/datums/brain_damage/severe.dm
@@ -164,14 +164,15 @@
 
 	var/drowsy = !!owner.has_status_effect(/datum/status_effect/drowsiness)
 	var/caffeinated = HAS_TRAIT(owner, TRAIT_STIMULATED)
+	var/final_sleep_chance = sleep_chance
 	if(owner.move_intent == MOVE_INTENT_RUN)
-		sleep_chance += sleep_chance_running
+		final_sleep_chance += sleep_chance_running
 	if(drowsy)
-		sleep_chance += sleep_chance_drowsy //stack drowsy ontop of base or running odds with the += operator
+		final_sleep_chance += sleep_chance_drowsy //stack drowsy ontop of base or running odds with the += operator
 	if(caffeinated)
-		sleep_chance = sleep_chance / 2 //make it harder to fall asleep on caffeine
+		final_sleep_chance *= 0.5 //make it harder to fall asleep on caffeine
 
-	if (!SPT_PROB(sleep_chance, seconds_per_tick))
+	if(!SPT_PROB(final_sleep_chance, seconds_per_tick))
 		return
 
 	//if not drowsy, don't fall asleep but make them drowsy


### PR DESCRIPTION
Original PR: 91801
-----

## About The Pull Request
Basically this variable didn't reset meaning it kept going up forever, until you were permanently in snooze mode.

## Why It's Good For The Game

I hope I'm putting this fix out before someone turns the station into a roundlong slumber party.

## Changelog
:cl:
fix: Fixed narcolepsy's odds to put you to sleep scaling infinitely
/:cl:
