### PR TITLE
[TG Mirror] Plumbing reaction chamber UI is scrollable again [MDB IGNORE]

### DIFF
--- a/tgui/packages/tgui/interfaces/ChemReactionChamber.tsx
+++ b/tgui/packages/tgui/interfaces/ChemReactionChamber.tsx
@@ -39,7 +39,7 @@ export const ChemReactionChamber = (props) => {
   const reagents = data.reagents || [];
   const catalysts = data.catalysts || [];
   return (
-    <Window width={290} height={520}>
+    <Window width={290} height={570}>
       <Window.Content>
         <Stack vertical fill>
           <Stack.Item>
@@ -132,9 +132,8 @@ export const ChemReactionChamber = (props) => {
           <Stack.Item grow>
             <Section
               title="Settings"
-              height="220px"
-              maxHeight="220px"
-              overflow="hidden"
+              fill
+              scrollable
               buttons={
                 (isReacting && (
                   <Box inline bold color={'purple'}>
@@ -265,13 +264,8 @@ export const ChemReactionChamber = (props) => {
               </Stack>
             </Section>
           </Stack.Item>
-          <Stack.Item>
-            <Section
-              title="Catalysts"
-              height="150px"
-              maxHeight="150px"
-              overflow="hidden"
-            >
+          <Stack.Item grow={0.7}>
+            <Section title="Catalysts" fill scrollable>
               <Stack.Item>
                 <Stack vertical fill>
                   {catalysts.map((reagent) => (


### PR DESCRIPTION
Original PR: 91792
-----
## About The Pull Request
- Fixes #91734

## Changelog
:cl:
fix: plumbing reaction chamber UI is scrollable again
/:cl:

