### PR TITLE
[TG Mirror] Fix egalitarian station not working on all airlocks [MDB IGNORE]

### DIFF
--- a/code/modules/admin/verbs/secrets.dm
+++ b/code/modules/admin/verbs/secrets.dm
@@ -336,9 +336,18 @@ ADMIN_VERB(secrets, R_NONE, "Secrets", "Abuse harder than you ever have before w
 			if(!is_funmin)
 				return
 			SSblackbox.record_feedback("nested tally", "admin_secrets_fun_used", 1, list("Egalitarian Station"))
-			for(var/obj/machinery/door/airlock/W as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/door/airlock))
-				if(is_station_level(W.z) && !istype(get_area(W), /area/station/command) && !istype(get_area(W), /area/station/commons) && !istype(get_area(W), /area/station/service) && !istype(get_area(W), /area/station/command/heads_quarters) && !istype(get_area(W), /area/station/security/prison))
-					W.req_access = list()
+			for(var/obj/machinery/door/airlock/airlock as anything in SSmachines.get_machines_by_type_and_subtypes(/obj/machinery/door/airlock))
+				var/airlock_area = get_area(airlock)
+				if(
+					is_station_level(airlock.z) && \
+					!istype(airlock_area, /area/station/command) && \
+					!istype(airlock_area, /area/station/commons) && \
+					!istype(airlock_area, /area/station/service) && \
+					!istype(airlock_area, /area/station/command/heads_quarters) && \
+					!istype(airlock_area, /area/station/security/prison) \
+				)
+					airlock.req_access = list()
+					airlock.req_one_access = list()
 			message_admins("[key_name_admin(holder)] activated Egalitarian Station mode")
 			priority_announce("CentCom airlock control override activated. Please take this time to get acquainted with your coworkers.", null, SSstation.announcer.get_rand_report_sound())
 		if("ancap")


### PR DESCRIPTION
Original PR: 91788
-----
## About The Pull Request

Make egalitarian station button also wipe `req_one_access` because some airlocks use that and it doesn't currently do that. Also changed a single letter var and broke an incredibly long `if` into multiple lines

## Why It's Good For The Game

Egaltarian station should work on all doors that meet the area requirements and not miss random ones

## Changelog

:cl:
fix: fixed egalitarian station mode missing airlocks that use req_one_access
/:cl:
