### PR TITLE
[TG Mirror] Hijacked shuttles now broadcast their shuttle call reason to other servers [MDB IGNORE]

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -566,6 +566,7 @@ SUBSYSTEM_DEF(ticker)
 	var/news_message
 	var/news_source = "Nanotrasen News Network"
 	var/decoded_station_name = html_decode(station_name()) //decode station_name to avoid minor_announce double encode
+	var/decoded_emergency_reason = html_decode(emergency_reason)
 
 	switch(news_report)
 		// The nuke was detonated on the syndicate recon outpost
@@ -581,7 +582,7 @@ SUBSYSTEM_DEF(ticker)
 			// Had an emergency reason supplied to pass along
 			if(emergency_reason)
 				news_message = "[decoded_station_name] has been evacuated after transmitting \
-					the following distress beacon:\n\n[html_decode(emergency_reason)]"
+					the following distress beacon:\n\n[Gibberish(decoded_emergency_reason, FALSE, 8)]"
 			else
 				news_message = "The crew of [decoded_station_name] has been \
 					evacuated amid unconfirmed reports of enemy activity."
@@ -650,7 +651,8 @@ SUBSYSTEM_DEF(ticker)
 		// The emergency escape shuttle was hijacked
 		if(SHUTTLE_HIJACK)
 			news_message = "During routine evacuation procedures, the emergency shuttle of [decoded_station_name] \
-				had its navigation protocols corrupted and went off course, but was recovered shortly after."
+				had its navigation protocols corrupted and went off course, but was recovered shortly after. \
+				The following distress beacon was sent prior to evacuation:\n\n[decoded_emergency_reason]"
 		// A supermatter cascade triggered
 		if(SUPERMATTER_CASCADE)
 			news_message = "Officials are advising nearby colonies about a newly declared exclusion zone in \


### PR DESCRIPTION
Original PR: 91725
-----

## About The Pull Request

When the shuttle is hijacked, the ticker announcement sent to the other servers includes the shuttle call reason. 
## Why It's Good For The Game

I enjoy reading people's wacky evac messages and imagining what the station looked like in that moment. This helps paint a better picture of how a round ended. 
## Changelog
:cl: Rhials
qol: When the ticker announces the end of a round on another server, it will include the shuttle call reason if the shuttle is hijacked.
/:cl:
