### PR TITLE
[TG Mirror] malf ais can dominate again [MDB IGNORE]

### DIFF
--- a/code/modules/vehicles/mecha/mecha_ai_interaction.dm
+++ b/code/modules/vehicles/mecha/mecha_ai_interaction.dm
@@ -20,7 +20,7 @@
 
 	if(data_tracker || user.can_dominate_mechs)
 		output += span_notice("[icon2html(src, user)] [name] Exosuit Status Report\n")
-		output += data_tracker.get_mecha_info()
+		output += data_tracker?.get_mecha_info()
 
 	if(user.can_dominate_mechs)
 		if(data_tracker)


### PR DESCRIPTION
Original PR: 91776
-----

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/91558
closes https://github.com/tgstation/tgstation/issues/91761

## Changelog

:cl:
fix: fixed malf ais not being able to dominate mechs
/:cl:

