### PR TITLE
[TG Mirror] Fixes jaws of life losing hit sounds when swapped twice [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -123,6 +123,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	custom_materials = list(/datum/material/iron = SHEET_MATERIAL_AMOUNT*2.25, /datum/material/silver = SHEET_MATERIAL_AMOUNT*1.25, /datum/material/titanium = SHEET_MATERIAL_AMOUNT*1.75)
 	usesound = 'sound/items/tools/jaws_pry.ogg'
+	hitsound = SFX_SWING_HIT
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
 	toolspeed = 0.7


### PR DESCRIPTION
Original PR: 91758
-----

## About The Pull Request

Closes #91756

## Changelog
:cl:
fix: Fixed jaws of life losing hit sounds when swapped twice
/:cl:
