### PR TITLE
[TG Mirror] Airlock variable door delay fixes [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/airlock.dm
+++ b/code/__DEFINES/airlock.dm
@@ -6,9 +6,8 @@
 #define AIRLOCK_LIGHT_OPENING "opening"
 
 // Airlock physical states
-#define AIRLOCK_CLOSED 1
-#define AIRLOCK_CLOSING 2
-#define AIRLOCK_OPEN 3
-#define AIRLOCK_OPENING 4
-#define AIRLOCK_DENY 5
-#define AIRLOCK_EMAG 6
+#define AIRLOCK_CLOSED "closed"
+#define AIRLOCK_CLOSING "closing"
+#define AIRLOCK_OPEN "open"
+#define AIRLOCK_OPENING "opening"
+#define AIRLOCK_DENY "deny"

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -436,17 +436,17 @@
 	switch(animation)
 		if(DOOR_OPENING_ANIMATION)
 			if(panel_open)
-				icon_state = "o_door_opening"
+				icon_state = "o_[base_icon_state]_opening"
 			else
-				icon_state = "door_opening"
+				icon_state = "[base_icon_state]_opening"
 		if(DOOR_CLOSING_ANIMATION)
 			if(panel_open)
-				icon_state = "o_door_closing"
+				icon_state = "o_[base_icon_state]_closing"
 			else
-				icon_state = "door_closing"
+				icon_state = "[base_icon_state]_closing"
 		if(DOOR_DENY_ANIMATION)
 			if(!machine_stat)
-				icon_state = "door_deny"
+				icon_state = "[base_icon_state]_deny"
 		else
 			icon_state = "[base_icon_state]_[density ? "closed" : "open"]"
 


### PR DESCRIPTION
Original PR: 91828
-----
## About The Pull Request

- Fixes airlock's run_animation from having a duplicate open in the switch case instead of an open/closed.
- Completes the implementation of [Variable Door Delay](https://github.com/tgstation/tgstation/pull/84631) on airlocks. (The procs were made but never called in the airlock code.
- Implements a set_airlock_state that sets the airlock state as well as managing operating status and animations instead of calling it individually.

## Why It's Good For The Game

Fixes, less code duplication, airlocks use the new animation procs.

## Changelog

:cl: LT3
fix: Fixed incorrect opening case in variable door delay
code: Airlocks can have variable animation delay same as doors
/:cl: