### PR TITLE
[TG Mirror] Cardboard box speed potion fix [MDB IGNORE]

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -37,7 +37,7 @@
 
 /obj/structure/closet/cardboard/proc/on_speed_potioned(datum/source)
 	SIGNAL_HANDLER
-	move_speed_multiplier *= 2
+	move_speed_multiplier *= 0.2
 
 /obj/structure/closet/cardboard/relaymove(mob/living/user, direction)
 	if(opened || move_delay || user.incapacitated || !isturf(loc) || !has_gravity(loc))


### PR DESCRIPTION
Original PR: 91830
-----

## About The Pull Request

Cardboard boxes now speed up when speedpotioned, as opposed to being slowed down.

This also heavily increases the intended speed boost that the speed potion was meant to give, because -50% speed reduction was still really slow.
## Why It's Good For The Game

Speed potions should not be acting like slow potions.
## Changelog
:cl: Rhials
fix: Cardboard boxes are no longer slowed down by speed potions. They are now sped up by them instead.
/:cl:
