### PR TITLE
[TG Mirror] makes meatpizza show up in recipes menu [MDB IGNORE]

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
@@ -15,7 +15,7 @@
 	)
 	result = /obj/item/food/pizza/margherita/raw
 
-/datum/crafting_recipe/food/meatpizza
+/datum/crafting_recipe/food/pizza/meatpizza
 	reqs = list(
 		/obj/item/food/flatdough = 1,
 		/obj/item/food/meat/rawcutlet = 4,


### PR DESCRIPTION
Original PR: 91872
-----

## About The Pull Request
changes call path to be for real meatpizza


## Why It's Good For The Game
fixes #91857

## Changelog
:cl:


fix: makes raw meatpizza appear correctly in cooking menu
/:cl:
