### PR TITLE
[TG Mirror] Change `GLOB.admin_states` to be an alist [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/tgui.dm
+++ b/code/__DEFINES/tgui.dm
@@ -53,4 +53,4 @@
  * Arguments:
  * * required_perms: Which admin permission flags to check the user for, such as [R_ADMIN]
  */
-#define ADMIN_STATE(required_perms) (GLOB.admin_states["[required_perms]"] ||= new /datum/ui_state/admin_state(required_perms))
+#define ADMIN_STATE(required_perms) (GLOB.admin_states[required_perms] ||= new /datum/ui_state/admin_state(required_perms))

--- a/code/modules/tgui/states/admin.dm
+++ b/code/modules/tgui/states/admin.dm
@@ -9,7 +9,7 @@
  * Checks if the user has specific admin permissions.
  */
 
-GLOBAL_LIST_EMPTY_TYPED(admin_states, /datum/ui_state/admin_state)
+GLOBAL_DATUM_INIT(admin_states, /alist, alist())
 GLOBAL_PROTECT(admin_states)
 
 /datum/ui_state/admin_state


### PR DESCRIPTION
Original PR: 91853
-----

## About The Pull Request

this changes `GLOB.admin_states` to be an alist instead of a normal list, so we don't have to convert stringify `required_perms` to use as a key.

## Why It's Good For The Game

https://github.com/user-attachments/assets/9baa6aff-65d3-42b6-be29-73b2dbc6bdff

## Changelog

no player-facing changes