### PR TITLE
[TG Mirror] Fix high impact rulesets being disregarded for roundstart selection [MDB IGNORE]

### DIFF
--- a/code/controllers/subsystem/dynamic/dynamic.dm
+++ b/code/controllers/subsystem/dynamic/dynamic.dm
@@ -260,6 +260,12 @@ SUBSYSTEM_DEF(dynamic)
 			rulesets_weighted -= picked_ruleset
 			picked_rulesets += picked_ruleset
 			break
+		if(current_tier.tier != DYNAMIC_TIER_HIGH && (picked_ruleset.ruleset_flags & RULESET_HIGH_IMPACT))
+			for(var/datum/dynamic_ruleset/roundstart/high_impact_ruleset as anything in rulesets_weighted)
+				if(!(high_impact_ruleset.ruleset_flags & RULESET_HIGH_IMPACT))
+					continue
+				total_weight -= rulesets_weighted[high_impact_ruleset]
+				rulesets_weighted -= high_impact_ruleset
 		if(!picked_ruleset.repeatable)
 			rulesets_weighted -= picked_ruleset
 			picked_rulesets += picked_ruleset


### PR DESCRIPTION
Original PR: 91883
-----
## About The Pull Request

Fixes #91882 

`RULESET_HIGH_IMPACT` is checked in `get_weight`, but by the time `get_weight` is called for roundstart rulesets, no rulesets are selected.

So we need to add logic in `pick_roundstart_rulesets`

Not super big fan of this fix - I think it'd be a lot cleaner if all the rulesets recalculated their weights, but this is a needed temp fix.

## Changelog

:cl: Melbert
fix: Multiple high impact rulesets will no longer roll simultaneously unless dynamic picks "high chaos" 
/:cl:
