### PR TITLE
[TG Mirror] fixes examine message for canister shot [MDB IGNORE]

### DIFF
--- a/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
+++ b/code/game/objects/structures/cannons/mounted_guns/mounted_gun.dm
@@ -185,3 +185,4 @@
 	obj_flags = CONDUCTS_ELECTRICITY
 	throwforce = 0
 	w_class = WEIGHT_CLASS_BULKY
+	projectile_type = /obj/projectile/bullet/shrapnel


### PR DESCRIPTION
Original PR: 91890
-----

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/91805

the guns are hardcoded to fire projectiles and the projectiles are not inherited from the ammo type that's put in, which is a bit annoying but the mentioned bug is fixed.
## Changelog
:cl:
fix: canister shots are no longer always "spent"
/:cl:
