### PR TITLE
[TG Mirror] Fix martial arts gloves runtiming when destroyed while equip [MDB IGNORE]

### DIFF
--- a/code/datums/components/martial_art_giver.dm
+++ b/code/datums/components/martial_art_giver.dm
@@ -10,6 +10,10 @@
 	style = new style_type(src)
 
 /datum/component/martial_art_giver/Destroy()
+	var/obj/item/item = parent
+	var/mob/living/wearer = item.loc
+	if(isliving(wearer))
+		style.unlearn(wearer)
 	QDEL_NULL(style)
 	return ..()
 
@@ -24,11 +28,6 @@
 
 /datum/component/martial_art_giver/UnregisterFromParent(datum/source)
 	UnregisterSignal(parent, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
-
-	var/obj/item/item = parent
-	var/mob/living/wearer = item.loc
-	if(istype(wearer))
-		dropped(item, wearer)
 
 /datum/component/martial_art_giver/proc/equipped(obj/item/source, mob/user, slot)
 	SIGNAL_HANDLER


### PR DESCRIPTION
Original PR: 91892
-----

## About The Pull Request
If you wear the boxing gloves from the baseball field holodeck sim and walk off, it causes a runtime where it gets deleted and then attempts to drop it shortly after. The problem is the martial arts component `Destroy()` nulls the martial arts style first, then later tries to unlearn the style, which doesn't exist anymore. This causes the style to never be properly forgotten.

You could theoretically abuse this to destroy several gloves while wearing them to gain multiple martial arts styles.

## Why It's Good For The Game
Less runtimes and exploits.

## Changelog
:cl:
fix: Fix martial arts gloves runtiming when destroyed while equip
/:cl:
