### PR TITLE
[TG Mirror] Its morbin time! Morbid people like the coroner use the amputation shears and dig graves more quickly.  Better shovels also dig graves more quickly.  [MDB IGNORE]

### DIFF
--- a/code/datums/elements/gravedigger.dm
+++ b/code/datums/elements/gravedigger.dm
@@ -44,5 +44,5 @@
 	return ITEM_INTERACT_BLOCKING
 
 /datum/element/gravedigger/proc/perform_digging(mob/user, atom/dig_area, obj/item/our_tool)
-	if(our_tool.use_tool(dig_area, user, 10 SECONDS))
+	if(our_tool.use_tool(dig_area, user, 10 SECONDS * (HAS_MIND_TRAIT(user, TRAIT_MORBID) ? 0.7 : 1) * our_tool.toolspeed))
 		new /obj/structure/closet/crate/grave/fresh(dig_area) //We don't get_turf for the location since this is guaranteed to be a turf at this point.

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -574,6 +574,8 @@
 		amputation_speed_mod *= 0.5
 	if(patient.stat != DEAD && patient.has_status_effect(/datum/status_effect/jitter)) //jittering will make it harder to secure the shears, even if you can't otherwise move
 		amputation_speed_mod *= 1.5 //15*0.5*1.5=11.25, so staminacritting someone who's jittering (from, say, a stun baton) won't give you enough time to snip their head off, but staminacritting someone who isn't jittering will
+	if(HAS_MIND_TRAIT(user, TRAIT_MORBID))
+		amputation_speed_mod *= 0.7 //its morbin time
 
 	if(do_after(user,  toolspeed * 15 SECONDS * amputation_speed_mod, target = patient))
 		playsound(get_turf(patient), 'sound/items/weapons/bladeslice.ogg', 250, TRUE)


### PR DESCRIPTION
Original PR: 91841
-----

## About The Pull Request

This PR reinforces the flavour and mechanical prowess of morbid people like the coroner by giving them a 30% speed bonus for two additional morbid activities: shearing off limbs and digging graves. 

It also makes toolspeed modifers affect the time it takes to dig a grave.

I have not rebalanced the shovels stats or toolspeed mods in this PR, that will have to wait until my upcoming gravedigging expansion.

## Why It's Good For The Game

The amputation shears is a decent luxury chase item for coroner because it synergizes nicely with his playstyle, but it currently doesn't take any morbid or autopsy bonuses into account which makes not that great as a time saver.

I think is a shame because the item has perfect flavour and base mechanics for the role.

This change makes shelling out the 700 credits feel more worth it and makes the choice regarding what to spend your credits on more meaningful. 

Digging graves, while a very niche interaction, is also a very flavourful way of getting rid of rejected cadavers, so having a boost there is also nice for encouraging players to try it out instead of just leaving it on the floor to rot or throwing it in disposals.

The tool speed modifier change is something that makes the very marginal upgraded shovels a little more special, and is in line with how other advanced tools work. 

I was touching that line anyway so I figured I might as well add it.

## Changelog

:cl:
balance: Morbid people, like the coroner now amputate 30% faster using the amputation shears.
balance: Morbid people dig graves 30% faster. 
balance:  Better shovels dig graves faster.
/:cl:

