### PR TITLE
[TG Mirror] Stops borgs from exploding before emag ends [MDB IGNORE]

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -436,7 +436,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		return TRUE
 
 	SetEmagged(1)
-	SetStun(60) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
+	SetStun(10 SECONDS) //Borgs were getting into trouble because they would attack the emagger before the new laws were shown
 	lawupdate = FALSE
 	set_connected_ai(null)
 	message_admins("[ADMIN_LOOKUPFLW(user)] emagged cyborg [ADMIN_LOOKUPFLW(src)].  Laws overridden.")


### PR DESCRIPTION
Original PR: 91821
-----

## About The Pull Request
Extends the hardstun duration to stop borgs from being able to act before new laws show up.
## Why It's Good For The Game
Since silicon.log shows that borg gets emagged exactly when they get clicked by emag, but from POV of the borg emag takes around 8 seconds, there was a window where emagged cyborg being emagged again could blow themselves up. Prolonging the hardstun stops that.
## Changelog
:cl:
fix: Emag stun is long enough to not let a cyborg act before they see their new laws
/:cl:
