### PR TITLE
[TG Mirror] sparks will not ignire things in enclosed container, also slime extracts are enclosed containers [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -25,7 +25,7 @@
 #define REAGENT_HOLDER_ALIVE (1<<9)
 
 //Special properties
-///If the holder a sealed container - Used if you don't want reagent contents boiling out (plasma, specifically, in which case it only bursts out when at ignition temperatures)
+///If the holder is a sealed container - Used if you don't want reagent contents boiling out (plasma, specifically, in which case it only bursts out when at ignition temperatures)
 #define SEALED_CONTAINER (1<<10)
 /// Prevents spilling and splashing but does prevent pouring and drinking reagents like the badly named spillable var.
 #define SMART_CAP (1<<11)

--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -75,9 +75,9 @@
 
 	SEND_SIGNAL(singed, COMSIG_ATOM_TOUCHED_SPARKS, src)
 	if(isobj(singed))
-		if(singed.reagents)
-			var/datum/reagents/reagents = singed.reagents // heat up things that contain reagents before we check to see if they burn
-			reagents?.expose_temperature(1000) // we set this at 1000 because that's the max reagent temp for a chem heater, higher temps require more than sparks
+		var/datum/reagents/reagents = singed.reagents // heat up things that contain reagents before we check to see if they burn
+		if(reagents && !(reagents.flags & SEALED_CONTAINER))
+			reagents.expose_temperature(1000) // we set this at 1000 because that's the max reagent temp for a chem heater, higher temps require more than sparks
 		return
 	if(ishuman(singed))
 		var/mob/living/carbon/human/singed_human = singed
@@ -86,8 +86,6 @@
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks
-
-
 
 /datum/effect_system/spark_spread/quantum
 	effect_type = /obj/effect/particle_effect/sparks/quantum

--- a/code/modules/research/xenobiology/crossbreeding/__corecross.dm
+++ b/code/modules/research/xenobiology/crossbreeding/__corecross.dm
@@ -100,7 +100,7 @@ To add a crossbreed:
 
 /obj/item/slimecrossbeaker/Initialize(mapload)
 	. = ..()
-	create_reagents(50, INJECTABLE | DRAWABLE)
+	create_reagents(50, INJECTABLE | DRAWABLE | SEALED_CONTAINER)
 	if(list_reagents)
 		for(var/reagent in list_reagents)
 			reagents.add_reagent(reagent, list_reagents[reagent])

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -42,7 +42,7 @@
 
 /obj/item/slime_extract/Initialize(mapload)
 	. = ..()
-	create_reagents(100, INJECTABLE | DRAWABLE)
+	create_reagents(100, INJECTABLE | DRAWABLE | SEALED_CONTAINER)
 
 /**
 * Effect when activated by a Luminescent.


### PR DESCRIPTION
Original PR: 91779
-----

## About The Pull Request
title
closes https://github.com/tgstation/tgstation/issues/91749
## Changelog
:cl:
fix: sparks will no longer ignite reagents in enclosed containers
/:cl:
