### PR TITLE
[TG Mirror] [NO GBP] Fix: Evidences twitching on the detective's board [MDB IGNORE]

### DIFF
--- a/tgui/packages/tgui/interfaces/DetectiveBoard/Evidence.tsx
+++ b/tgui/packages/tgui/interfaces/DetectiveBoard/Evidence.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Button, Flex, Stack } from 'tgui-core/components';
 
 import { DataEvidence } from './DataTypes';
@@ -38,7 +38,7 @@ export function Evidence(props: EvidenceProps) {
     null,
   );
 
-  const randomRotation = Math.random() * 2 - 1;
+  const randomRotation = useMemo(() => Math.random() * 2 - 1, []);
 
   function handleMouseDown(args) {
     if (canDrag) {


### PR DESCRIPTION
Original PR: 91899
-----
## About The Pull Request

After updating the detective's board styles, a bug appeared that caused the evidences on the board to twitch, especially when there were other pieces of evidence on the board and they were moving. This bug was caused by the fact that a random angle rotation was added for the sake of aesthetics. When the board was updated, this rotation was recalculated, resulting in a twitching effect. Now, the rotation is remembered and does not need to be recalculated every time the board is updated. My fault

## Why It's Good For The Game

This is fix, why it can be bad for the game?

## Changelog

:cl: FeudeyTF
fix: fixed evidences twitching on the detective's board
/:cl: