### PR TITLE
[TG Mirror] Regenerative extract no longer drops voidwalker loot [MDB IGNORE]

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -244,7 +244,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/black/core_effect_before(mob/living/target, mob/user)
 	var/dummytype = target.type
-	if(ismegafauna(target)) //Prevents megafauna duping in a lame way
+	if(target.mob_biotypes & MOB_SPECIAL) //Prevents megafauna and voidwalker duping in a lame way
 		dummytype = /mob/living/basic/slime
 		to_chat(user, span_warning("The milky goo flows over [target], falling into a weak puddle."))
 	var/mob/living/dummy = new dummytype(target.loc)


### PR DESCRIPTION
Original PR: 91938
-----

## About The Pull Request

You can click the regenerative black extract on a voidwalker and it will instantly drop the voidwalker loot gamer skull reward. I have blacklisted voidwalker and other "Special" flag mobs (nothing significant besides voidwalker)

## Why It's Good For The Game

I can't express at how bad this mechanic is. You can click this on ANY mob and it will instantly create a copy and kill it?????? WHO THOUGHT THIS WAS EVEN CLOSE TO A GOOD IDEA???!!!!

Voidwalker skull is balanced to be one per antag. While I'm sure they had fun, I was dismayed at seeing a scientist run up to the walker, spawn a few skulls and leave. Why the fuck can they do this? The skulls are incredibly strong 

I honestly think this entire thing needs to be wiped from the face of the codebase, but I'll be content with protecting my son from this vile thing for now

## Changelog
:cl:
balance: Regenerative black extract can no longer be used to create infinite voidwalker loot skulls
/:cl:

Like seriously why does this exist???? You can use this to create infinite bodies of any species and any other mob??? I could use this to duplicate a ton of slaughter demon hearts, alien queen bodies, abductors, nightmares etc etc I just wanna cry thinking about this why did we let them do this


