### PR TITLE
[TG Mirror] fixes mob login runtime with view_size [MDB IGNORE]

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -104,7 +104,7 @@
 		stop_sound_channel(CHANNEL_AMBIENCE)
 
 	if(client)
-		client.view_size.resetToDefault() // Resets the client.view in case it was changed.
+		client.view_size?.resetToDefault() // Resets the client.view in case it was changed.
 
 		for(var/datum/action/A as anything in persistent_client.player_actions)
 			A.Grant(src)


### PR DESCRIPTION
Original PR: 91889
-----

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/91809

https://github.com/tgstation/tgstation/blob/8cadc4792a505e566296a12792dad8a6b37dd4fa/code/modules/client/client_procs.dm#L347

mob.login is being called before

https://github.com/tgstation/tgstation/blob/8cadc4792a505e566296a12792dad8a6b37dd4fa/code/modules/client/client_procs.dm#L561

view_size is created, which was revealed by https://github.com/tgstation/tgstation/pull/91419 removing this null check

![Image](https://github.com/user-attachments/assets/f1131158-fe35-4c3e-9433-1dcbdc0ddc18)

So you might be thinking, why am I readding the nullcheck instead of creating view_size earlier in the client/New()? Simple, we don't need to update view_size for new clients because it will always be the default, therefore by doing a simple null check we can skip over updating view_size for Newly created clients.
## Why It's Good For The Game
## Changelog
:cl:
fix: fixed a client login runtime
/:cl:
