### PR TITLE
[TG Mirror] Adds Cat tongue to Felinid disk for limb grower [MDB IGNORE]

### DIFF
--- a/code/modules/research/designs/limbgrower_designs.dm
+++ b/code/modules/research/designs/limbgrower_designs.dm
@@ -141,6 +141,14 @@
 	build_path = /obj/item/organ/ears/cat
 	category = list(SPECIES_HUMAN)
 
+/datum/design/cat_tongue
+	name = "Cat Tongue"
+	id = "cattongue"
+	build_type = LIMBGROWER
+	reagents_list = list(/datum/reagent/medicine/c2/synthflesh = 10)
+	build_path = /obj/item/organ/tongue/cat
+	category = list(SPECIES_HUMAN)
+
 /datum/design/plasmaman_lungs
 	name = "Plasma Filter"
 	id = "plasmamanlungs"
@@ -240,11 +248,11 @@
 
 /obj/item/disk/design_disk/limbs/felinid
 	name = "Felinid Organ Design Disk"
-	limb_designs = list(/datum/design/cat_tail, /datum/design/cat_ears)
+	limb_designs = list(/datum/design/cat_tail, /datum/design/cat_ears, /datum/design/cat_tongue)
 
 /datum/design/limb_disk/felinid
 	name = "Felinid Organ Design Disk"
-	desc = "Contains designs for felinid organs for the limbgrower - Felinid ears and tail."
+	desc = "Contains designs for felinid organs for the limbgrower - Felinid ears, tail and tongue."
 	id = "limbdesign_felinid"
 	build_path = /obj/item/disk/design_disk/limbs/felinid
 


### PR DESCRIPTION
Original PR: 91839
-----
## About The Pull Request

Added felinid tongue to limb grower from the felinid disk since it was the only organ not in the limb grower as felinid so now you can actually get all organs

## Why It's Good For The Game

This missing feels like an oversight when felinid tongue was added and its the only organ missing for felinid disk which seems a bit too weird to not have

## Changelog
:cl:
add: Added felinid tongue to the felinid disk from research of the limbgrower
/:cl:
