### PR TITLE
[TG Mirror] Biddler Malf [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/malf_ai/malf_ai_module_picker.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_module_picker.dm
@@ -41,6 +41,9 @@
 	var/list/data = list()
 	data["processingTime"] = processing_time
 	data["compactMode"] = compact_mode
+	if(isAI(user))
+		var/mob/living/silicon/ai/ai_user = user
+		data["hackedAPCs"] = ai_user.hacked_apcs.len
 	return data
 
 /datum/module_picker/ui_static_data(mob/user)
@@ -57,6 +60,7 @@
 				"name" = AM.name,
 				"cost" = AM.cost,
 				"desc" = AM.description,
+				"minimum_apcs" = AM.minimum_apcs,
 			))
 		data["categories"] += list(cat)
 
@@ -93,7 +97,8 @@
 		return
 	if(AM.cost > processing_time)
 		return
-
+	if(AM.minimum_apcs > AI.hacked_apcs.len)
+		return
 	var/datum/action/innate/ai/action = locate(AM.power_type) in AI.actions
 	// Give the power and take away the money.
 	if(AM.upgrade) //upgrade and upgrade() are separate, be careful!

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -121,6 +121,8 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 	var/category = "generic category"
 	var/description = "generic description"
 	var/cost = 5
+	/// Minimum amount of APCs that has to be under the AI's control to purchase this module.
+	var/minimum_apcs = 0
 	/// If this module can only be purchased once. This always applies to upgrades, even if the variable is set to false.
 	var/one_purchase = FALSE
 	/// If the module gives an active ability, use this. Mutually exclusive with upgrade.
@@ -156,6 +158,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 		Obtaining control of the weapon will be easier if Head of Staff office APCs are already under your control."
 	cost = 130
 	one_purchase = TRUE
+	minimum_apcs = 15 // So you cant speedrun delta
 	power_type = /datum/action/innate/ai/nuke_station
 	unlock_text = span_notice("You slowly, carefully, establish a connection with the on-station self-destruct. You can now activate it at any time.")
 	///List of areas that grant discounts. "heads_quarters" will match any head of staff office.
@@ -637,6 +640,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 	name = "Robotic Factory (Removes Shunting)"
 	description = "Build a machine anywhere, using expensive nanomachines, that can convert a living human into a loyal cyborg slave when placed inside."
 	cost = 100
+	minimum_apcs = 10 // So you can't speedrun this
 	power_type = /datum/action/innate/ai/place_transformer
 	unlock_text = span_notice("You make contact with Space Amazon and request a robotics factory for delivery.")
 	unlock_sound = 'sound/machines/ping.ogg'
@@ -919,7 +923,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 /datum/ai_module/malf/upgrade/voice_changer
 	name = "Voice Changer"
 	description = "Allows you to change the AI's voice. Upgrade is active immediately upon purchase."
-	cost = 40
+	cost = 20
 	one_purchase = TRUE
 	power_type = /datum/action/innate/ai/voice_changer
 	unlock_text = span_notice("OTA firmware distribution complete! Voice changer online.")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -923,7 +923,7 @@
 		playsound(get_turf(src), 'sound/machines/buzz/buzz-sigh.ogg', 50, TRUE, ignore_walls = FALSE)
 		return
 
-	malf_picker.processing_time += 10
+	malf_picker.processing_time += max(0, 9 - hacked_apcs.len) // Less resources for each apc hacked, 9 instead of 10 is because you will get 1 as soon as the hacked apc processes
 	var/area/apcarea = apc.area
 	var/datum/ai_module/malf/destructive/nuke_station/doom_n_boom = locate(/datum/ai_module/malf/destructive/nuke_station) in malf_picker.possible_modules["Destructive Modules"]
 	if(doom_n_boom && (is_type_in_list (apcarea, doom_n_boom.discount_areas)) && !(is_type_in_list (apcarea, doom_n_boom.hacked_command_areas)))

--- a/code/modules/power/apc/apc_main.dm
+++ b/code/modules/power/apc/apc_main.dm
@@ -140,6 +140,8 @@
 	var/no_charge = FALSE
 	/// Used for apc helper called full_charge to make apc's charge at 100% meter.
 	var/full_charge = FALSE
+	///When did the apc generate last malf ai processing time.
+	COOLDOWN_DECLARE(malf_ai_pt_generation)
 	armor_type = /datum/armor/power_apc
 
 /datum/armor/power_apc
@@ -263,8 +265,6 @@
 
 /obj/machinery/power/apc/Destroy()
 	if(malfai)
-		if(operating)
-			malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10, 0, 1000)
 		malfai.hacked_apcs -= src
 		malfai = null
 	disconnect_from_area()
@@ -361,8 +361,6 @@
 /obj/machinery/power/apc/atom_break(damage_flag)
 	. = ..()
 	if(.)
-		if(malfai && operating)
-			malfai.malf_picker.processing_time = clamp(malfai.malf_picker.processing_time - 10, 0, 1000)
 		operating = FALSE
 		if(occupier)
 			malfvacate(TRUE)
@@ -596,6 +594,11 @@
 		hacked_flicker_counter = hacked_flicker_counter - 1
 		if(hacked_flicker_counter <= 0)
 			flicker_hacked_icon()
+		if(COOLDOWN_FINISHED(src, malf_ai_pt_generation) && cell.use(30 KILO JOULES)>0) // Over time generation of malf points for the ai controlling it, costs a bit of power
+			COOLDOWN_START(src, malf_ai_pt_generation, 30 SECONDS)
+			malfai.malf_picker.processing_time += 1
+
+
 
 	//dont use any power from that channel if we shut that power channel off
 	if(operating)

--- a/code/modules/power/apc/apc_malf.dm
+++ b/code/modules/power/apc/apc_malf.dm
@@ -19,7 +19,7 @@
 		return
 	to_chat(malf, span_notice("Beginning override of APC systems. This takes some time, and you cannot perform other actions during the process."))
 	malf.malfhack = src
-	malf.malfhacking = addtimer(CALLBACK(malf, TYPE_PROC_REF(/mob/living/silicon/ai/, malfhacked), src), 600, TIMER_STOPPABLE)
+	malf.malfhacking = addtimer(CALLBACK(malf, TYPE_PROC_REF(/mob/living/silicon/ai/, malfhacked), src), 30 SECONDS + 10*malf.hacked_apcs.len SECONDS, TIMER_STOPPABLE)
 
 	var/atom/movable/screen/alert/hackingapc/hacking_apc
 	hacking_apc = malf.throw_alert(ALERT_HACKING_APC, /atom/movable/screen/alert/hackingapc)

--- a/tgui/packages/tgui/interfaces/common/MalfAiModules.tsx
+++ b/tgui/packages/tgui/interfaces/common/MalfAiModules.tsx
@@ -3,21 +3,26 @@ import { GenericUplink, Item } from '../Uplink/GenericUplink';
 
 type Category = {
   name: string;
-  items: Item[];
+  items: MalfItem[];
+};
+/* This is shitcode, but someone used normal uplink so i feel justified */
+type MalfItem = Item & {
+  minimum_apcs: number;
 };
 
 type Data = {
   processingTime: string;
+  apcsHacked: number;
   categories: Category[];
 };
 
 /** Common ui for selecting malf ai modules */
 export function MalfAiModules(props) {
   const { act, data } = useBackend<Data>();
-  const { processingTime, categories = [] } = data;
+  const { processingTime, apcsHacked, categories = [] } = data;
 
   const categoriesList: string[] = [];
-  const items: Item[] = [];
+  const items: MalfItem[] = [];
 
   for (let idx = 0; idx < categories.length; idx++) {
     const category = categories[idx];
@@ -28,14 +33,19 @@ export function MalfAiModules(props) {
       items.push({
         category: category.name,
         cost: `${item.cost} PT`,
-        desc: item.desc,
-        disabled: processingTime < item.cost,
+        desc:
+          item.desc +
+          (item.minimum_apcs
+            ? ` Requires at least ${item.minimum_apcs} APCs hacked.`
+            : ''),
+        disabled: processingTime < item.cost || apcsHacked < item.minimum_apcs,
         icon_state: item.icon_state,
         icon: item.icon,
         id: item.name,
         name: item.name,
         population_tooltip: '',
         insufficient_population: false,
+        minimum_apcs: item.minimum_apcs || 0, // Handle the case where minimum_apcs is not defined
       });
     }
   }


### PR DESCRIPTION
Original PR: 91895
-----
## About The Pull Request
AI now gains its malf points over time, based on the number of APCs hacked. I also added a simple way to lock malf modules from being bought if you haven't hacked enough APCs, to avoid cheese with delta or robot factory.
## Why It's Good For The Game
APCs hacked are a constant risk of being found, and instantly targeted, yet they give one time bonus, that is fairly small. This incentivises not using antag powers, and using natural AI tools, which blurs the line for the crew between malf and subverted AIs, and makes fighting it easier and more boring. With constant gain from the APCs the risk of being found is rewarded, and malf that hacks a big amount of APCs and avoids being found can use its powers fairly liberally, at a cost of having to manage the detection chance.
## Changelog
:cl:
add: Malfunctioning AI gets constant influx of processing time from hacked APCs
add: Delta and robot factory are now locked behind a minimum amount of hacked APCs
refactor: Malf AI modules can now be locked behind a certain minimum number of hacked APCs
balance: Lowers the cost of voicechanger to make it less punishing at the beginning of the round
/:cl:
