### PR TITLE
[TG Mirror] sdql wrapper for generators and getting list output from generators [MDB IGNORE]

### DIFF
--- a/code/__HELPERS/generators.dm
+++ b/code/__HELPERS/generators.dm
@@ -9,3 +9,13 @@
 	string_repr = copytext(string_repr, 11, length(string_repr)) // strips extraneous data
 	string_repr = replacetext(string_repr, "\"", "") // removes the " around the type
 	return splittext(string_repr, ", ")
+
+/generator/proc/RandList()
+	var/possible_vector = Rand()
+	var/vector_length = length(possible_vector)
+	if(vector_length == 0)
+		return possible_vector
+	. = list()
+	for(var/i in 1 to vector_length)
+		. += possible_vector[i]
+	return .

--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -286,6 +286,9 @@
 /proc/_viewers(Dist, Center = usr)
 	return viewers(Dist, Center)
 
+/proc/_generator(type = "num", A = 0, B = 1, rand = UNIFORM_RAND)
+	return generator(type, A, B, rand)
+
 /// Auxtools REALLY doesn't know how to handle filters as values;
 /// when passed as arguments to auxtools-called procs, they aren't simply treated as nulls -
 /// they don't even count towards the length of args.


### PR DESCRIPTION
Original PR: 91954
-----
## About The Pull Request
adds sdql wrapper for making a generator
adds a RandList proc for generators which makes them return a list instead of vector
this means u can work with generators in lua scripts or sdql (or any other reason you would rather handle a list than a vector)
see here
![image](https://github.com/user-attachments/assets/3e73dd6f-4c7c-44d9-981b-f80c1bf14897)

## Why It's Good For The Game
cool script bro

## Changelog
:cl:
admin: _generator wrapper for sdql, RandList proc for generators
/:cl:
