### PR TITLE
[TG Mirror] Patches random sanitization issues [MDB IGNORE]

### DIFF
--- a/code/game/machinery/announcement_system.dm
+++ b/code/game/machinery/announcement_system.dm
@@ -145,7 +145,7 @@ GLOBAL_LIST_EMPTY(announcement_systems)
 				update_appearance()
 		if("Text")
 			if(!(params["lineKey"] in config.announcement_lines_map))
-				message_admins("[ADMIN_LOOKUPFLW(usr)] tried to set announcement line for nonexisting line in the [config.name] for AAS. Probably href injection. Received line: [params["lineKey"]]")
+				message_admins("[ADMIN_LOOKUPFLW(usr)] tried to set announcement line for nonexisting line in the [config.name] for AAS. Probably href injection. Received line: [html_encode(params["lineKey"])]")
 				log_game("[key_name(usr)] tried to mess with AAS. For [config.name] he tried to edit nonexistend [params["lineKey"]]")
 				return
 			var/new_message = trim(html_encode(params["newText"]), MAX_MESSAGE_LEN)

--- a/code/game/machinery/newscaster/newscaster_machine.dm
+++ b/code/game/machinery/newscaster/newscaster_machine.dm
@@ -316,13 +316,13 @@ MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/newscaster, 30)
 			return TRUE
 
 		if("setChannelName")
-			var/pre_channel_name = params["channeltext"]
+			var/pre_channel_name = reject_bad_text(params["channeltext"], max_length = MAX_NAME_LEN)
 			if(!pre_channel_name)
 				return TRUE
 			channel_name = pre_channel_name
 
 		if("setChannelDesc")
-			var/pre_channel_desc = params["channeldesc"]
+			var/pre_channel_desc = reject_bad_text(params["channeldesc"], max_length = MAX_BROADCAST_LEN)
 			if(!pre_channel_desc)
 				return TRUE
 			channel_desc = pre_channel_desc


### PR DESCRIPTION
Original PR: 91948
-----
## About The Pull Request

2 sanitization fixes.

Announcement system one is pretty self-explanatory.

During creation of cross-sector news channels, channel name is sent to admins for verification. And every time a new story is created.
I think it's better to sanitize channel's name and description during assignment to prevent any issues later on.
Regarding `max_length`, these values are used in .jsx for newscasters.