### PR TITLE
[TG Mirror] Move airlock sound to animation_effects [NO GBP] [MDB IGNORE]

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -507,13 +507,13 @@
  * Set the airlock state to a new value, change the icon state
  * and run the associated animation if required.
  */
-/obj/machinery/door/airlock/proc/set_airlock_state(new_state, animated = FALSE)
+/obj/machinery/door/airlock/proc/set_airlock_state(new_state, animated = FALSE, force_type = DEFAULT_DOOR_CHECKS)
 	if(!new_state)
 		new_state = density ? AIRLOCK_CLOSED : AIRLOCK_OPEN
 	airlock_state = new_state
 	if(animated)
 		operating = TRUE
-		run_animation(airlock_state)
+		run_animation(airlock_state, force_type)
 		return
 	operating = FALSE
 	set_animation()
@@ -613,18 +613,29 @@
 					floorlight.pixel_z = 0
 			. += floorlight
 
-/obj/machinery/door/airlock/run_animation(animation)
+/obj/machinery/door/airlock/run_animation(animation, force_type = DEFAULT_DOOR_CHECKS)
 	if(animation == DOOR_DENY_ANIMATION)
 		if(machine_stat)
 			return
-		set_airlock_state(AIRLOCK_DENY, animated = FALSE)
+		set_airlock_state(AIRLOCK_DENY, animated = FALSE, force_type = force_type)
 
 	return ..()
 
-/obj/machinery/door/airlock/animation_effects(animation)
-	if(animation == DOOR_DENY_ANIMATION)
-		playsound(src, soundin = doorDeni, vol = 50, vary = FALSE, extrarange = 3)
-		addtimer(CALLBACK(src, PROC_REF(handle_deny_end)), AIRLOCK_DENY_ANIMATION_TIME)
+/obj/machinery/door/airlock/animation_effects(animation, force_type = DEFAULT_DOOR_CHECKS)
+	if(force_type == BYPASS_DOOR_CHECKS)
+		playsound(src, soundin = 'sound/machines/airlock/airlockforced.ogg', vol = 30, vary = TRUE)
+		return
+
+	switch(animation)
+		if(DOOR_OPENING_ANIMATION)
+			use_energy(50 JOULES)
+			playsound(src, soundin = doorOpen, vol = 30, vary = TRUE)
+		if(DOOR_CLOSING_ANIMATION)
+			use_energy(50 JOULES)
+			playsound(src, soundin = doorClose, vol = 30, vary = TRUE)
+		if(DOOR_DENY_ANIMATION)
+			playsound(src, soundin = doorDeni, vol = 50, vary = FALSE, extrarange = 3)
+			addtimer(CALLBACK(src, PROC_REF(handle_deny_end)), AIRLOCK_DENY_ANIMATION_TIME)
 
 /obj/machinery/door/airlock/proc/handle_deny_end()
 	if(airlock_state == AIRLOCK_DENY)
@@ -1294,7 +1305,7 @@
 				addtimer(CALLBACK(cyclelinkedairlock, PROC_REF(close)), BYPASS_DOOR_CHECKS)
 
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_OPEN, forced)
-	set_airlock_state(AIRLOCK_OPENING, animated = TRUE)
+	set_airlock_state(AIRLOCK_OPENING, animated = TRUE, force_type = forced)
 	var/transparent_delay = animation_segment_delay(AIRLOCK_OPENING_TRANSPARENT)
 	sleep(transparent_delay)
 	set_opacity(0)
@@ -1323,19 +1334,14 @@
 		if(DEFAULT_DOOR_CHECKS) // Regular behavior.
 			if(!hasPower() || wires.is_cut(WIRE_OPEN) || (obj_flags & EMAGGED))
 				return FALSE
-			use_energy(50 JOULES)
-			playsound(src, doorOpen, 30, TRUE)
 			return TRUE
 
 		if(FORCING_DOOR_CHECKS) // Only one check.
 			if(obj_flags & EMAGGED)
 				return FALSE
-			use_energy(50 JOULES)
-			playsound(src, doorOpen, 30, TRUE)
 			return TRUE
 
 		if(BYPASS_DOOR_CHECKS) // No power usage, special sound, get it open.
-			playsound(src, 'sound/machines/airlock/airlockforced.ogg', 30, TRUE)
 			return TRUE
 
 		else
@@ -1368,7 +1374,7 @@
 	if(killthis)
 		SSexplosions.med_mov_atom += killthis
 	SEND_SIGNAL(src, COMSIG_AIRLOCK_CLOSE, forced)
-	set_airlock_state(AIRLOCK_CLOSING, animated = TRUE)
+	set_airlock_state(AIRLOCK_CLOSING, animated = TRUE, force_type = forced)
 	layer = CLOSED_DOOR_LAYER
 	if(air_tight)
 		set_density(TRUE)
@@ -1406,12 +1412,9 @@
 		if(DEFAULT_DOOR_CHECKS to FORCING_DOOR_CHECKS)
 			if(obj_flags & EMAGGED)
 				return FALSE
-			use_energy(50 JOULES)
-			playsound(src, doorClose, 30, TRUE)
 			return TRUE
 
 		if(BYPASS_DOOR_CHECKS)
-			playsound(src, 'sound/machines/airlock/airlockforced.ogg', 30, TRUE)
 			return TRUE
 
 		else

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -480,15 +480,15 @@
 			return 0.6 SECONDS
 
 /// Override this to do misc tasks on animation start
-/obj/machinery/door/proc/animation_effects(animation)
+/obj/machinery/door/proc/animation_effects(animation, force_type = DEFAULT_DOOR_CHECKS)
 	return
 
 /// Used to start a new animation
 /// Accepts the animation to start as an arg
-/obj/machinery/door/proc/run_animation(animation)
+/obj/machinery/door/proc/run_animation(animation, force_type = DEFAULT_DOOR_CHECKS)
 	set_animation(animation)
 	addtimer(CALLBACK(src, PROC_REF(set_animation), null), animation_length(animation), TIMER_UNIQUE|TIMER_OVERRIDE)
-	animation_effects(animation)
+	animation_effects(animation, force_type)
 
 // React to our animation changing
 /obj/machinery/door/proc/set_animation(animation)


### PR DESCRIPTION
Original PR: 91943
-----
## About The Pull Request

Follow up to https://github.com/tgstation/tgstation/pull/91828, moves the open/close airlock sounds to the animation_effects proc

## Why It's Good For The Game

All the airlock effects are now in the same proc

## Changelog

None required