### PR TITLE
[TG Mirror] exclude node_modules from search [MDB IGNORE]

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,8 @@
 	"workbench.editorAssociations": {
 		"*.dmi": "dmiEditor.dmiEditor"
 	},
+	"search.exclude": {
+		"**/node_modules": true
+	},
 	"Lua.diagnostics.enable": false
 }


### PR DESCRIPTION
Original PR: 91995
-----
## About The Pull Request
No player facing changes. Excludes the node_modules folder from vscode search by default. With the new package management, we don't want to always see all the module files while searching through tgui files.

## Changelog
Excludes node_modules from vscode search
