### PR TITLE
[TG Mirror] change raw nonrendered browser bg color of tgui windows [MDB IGNORE]

### DIFF
--- a/tgui/public/tgui.html
+++ b/tgui/public/tgui.html
@@ -12,7 +12,7 @@
     <!-- tgui:ntos-error -->
     <!-- tgui:inline-css -->
   </head>
-  <body>
+  <body style="background-color: #333">
     <!-- tgui:assets -->
     <!-- tgui:inline-html-start -->
     <!-- tgui:inline-html -->


### PR DESCRIPTION
Original PR: 92004
-----
## About The Pull Request

helps remove the shitty white flashing, way way less noticeable

so like this will still happen on first mount of each♻️reused tgui window♻️, but subsequent full **full** rerenders won't look shitty ugly gross

pictured: me spamming refresh


https://github.com/user-attachments/assets/706cde5f-06a0-4658-a489-8038d2c517fe



i can't fix first mount unless lummox gives us the ability to set `WebView2.DefaultBackgroundColor` via `browse()` which, ..... LOL

feel free to merge or close or edit or whatever this is just a courtesy upstream PR, no warranty


here's the song i was listening to while i wrote this
[![image](https://github.com/user-attachments/assets/24b5643d-7108-4e2b-85d0-b9303ea0444f)](https://open.spotify.com/track/2dYwmQKGTqHEFEafnNwr60)



## Why It's Good For The Game

obviously not as good on different themes than default but still better than shitty white

i don't think you even have light mode, so no 5% of users or whatever to complain there either

## Changelog

:cl:
fix: white TGUI window flashing should be less present
/:cl:
