### PR TITLE
[TG Mirror] [MDB Ignore] Removes the strange 4 second density delay that security barricades have after spawning. Refactors barricade item interaction code. [MDB IGNORE]

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -14,7 +14,9 @@
 	anchored = TRUE
 	density = TRUE
 	max_integrity = 100
-	var/proj_pass_rate = 50 //How many projectiles will pass the cover. Lower means stronger cover
+	// The probability for a projectile to pass through the barrier. Lower values result in less projectiles passing through.
+	var/proj_pass_rate = 50
+	// What type of material is our barricade made from?
 	var/bar_material = METAL
 
 /obj/structure/barricade/atom_deconstruct(disassembled = TRUE)
@@ -26,17 +28,25 @@
 
 	return
 
-/obj/structure/barricade/attackby(obj/item/I, mob/living/user, list/modifiers, list/attack_modifiers)
-	if(I.tool_behaviour == TOOL_WELDER && !user.combat_mode && bar_material == METAL)
-		if(atom_integrity < max_integrity)
-			if(!I.tool_start_check(user, amount=1))
-				return
+/obj/structure/barricade/welder_act(mob/living/user, obj/item/tool)
+	if(user.combat_mode)
+		return ITEM_INTERACT_SKIP_TO_ATTACK
 
-			to_chat(user, span_notice("You begin repairing [src]..."))
-			if(I.use_tool(src, user, 40, volume=40))
-				atom_integrity = clamp(atom_integrity + 20, 0, max_integrity)
-	else
-		return ..()
+	if(bar_material != METAL)
+		return ITEM_INTERACT_BLOCKING
+
+	if(atom_integrity >= max_integrity)
+		balloon_alert(user, "already full integrity!")
+		return ITEM_INTERACT_BLOCKING
+
+	user.balloon_alert_to_viewers("repairing [src]...", "repairing...")
+
+	if(!tool.use_tool(src, user, 4 SECONDS, amount = 10, volume=50))
+		return ITEM_INTERACT_BLOCKING
+
+	balloon_alert(user, "repaired")
+	repair_damage(20)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/barricade/CanAllowThrough(atom/movable/mover, border_dir)//So bullets will fly over and stuff.
 	. = ..()
@@ -60,6 +70,7 @@
 	icon_state = "woodenbarricade"
 	resistance_flags = FLAMMABLE
 	bar_material = WOOD
+	/// When destroyed or deconstructed, how many planks of wood does our barricade drop? Also determines how many it takes to repair the barricade and by how much.
 	var/drop_amount = 3
 
 /obj/structure/barricade/wooden/Initialize(mapload)
@@ -69,22 +80,28 @@
 	AddElement(/datum/element/contextual_screentip_tools, tool_behaviors)
 	register_context()
 
-/obj/structure/barricade/wooden/attackby(obj/item/I, mob/user)
-	if(istype(I,/obj/item/stack/sheet/mineral/wood))
-		var/obj/item/stack/sheet/mineral/wood/W = I
-		if(W.amount < 5)
-			to_chat(user, span_warning("You need at least five wooden planks to make a wall!"))
-			return
-		else
-			to_chat(user, span_notice("You start adding [I] to [src]..."))
-			playsound(src, 'sound/items/hammering_wood.ogg', 50, vary = TRUE)
-			if(do_after(user, 5 SECONDS, target=src))
-				W.use(5)
-				var/turf/T = get_turf(src)
-				T.place_on_top(/turf/closed/wall/mineral/wood/nonmetal)
-				qdel(src)
-				return
-	return ..()
+/obj/structure/barricade/wooden/item_interaction(mob/living/user, obj/item/stack/sheet/mineral/wood/our_wood, list/modifiers)
+	if(user.combat_mode)
+		return ITEM_INTERACT_SKIP_TO_ATTACK
+
+	if(!istype(our_wood,/obj/item/stack/sheet/mineral/wood))
+		return NONE
+
+	if(!our_wood.amount < 5)
+		balloon_alert(user, "not enough wood!")
+		to_chat(user, span_warning("You need at least five wooden planks to make a barricade!"))
+		return ITEM_INTERACT_BLOCKING
+
+
+	to_chat(user, span_notice("You start adding [our_wood] to [src]..."))
+	playsound(src, 'sound/items/hammering_wood.ogg', 50, vary = TRUE)
+	if(!do_after(user, 5 SECONDS, target=src))
+		balloon_alert(user, "interrupted!")
+		return ITEM_INTERACT_BLOCKING
+
+	our_wood.use(drop_amount)
+	repair_damage(20 * drop_amount)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/structure/barricade/wooden/crowbar_act(mob/living/user, obj/item/tool)
 	balloon_alert(user, "deconstructing barricade...")
@@ -136,16 +153,10 @@
 	name = "security barrier"
 	desc = "A deployable barrier. Provides good cover in fire fights."
 	icon = 'icons/obj/structures.dmi'
-	icon_state = "barrier0"
-	density = FALSE
-	anchored = FALSE
+	icon_state = "barrier1"
 	max_integrity = 180
 	proj_pass_rate = 20
 	armor_type = /datum/armor/barricade_security
-
-	var/deploy_time = 40
-	var/deploy_message = TRUE
-
 
 /datum/armor/barricade_security
 	melee = 10
@@ -154,18 +165,6 @@
 	energy = 50
 	bomb = 10
 	fire = 10
-
-/obj/structure/barricade/security/Initialize(mapload)
-	. = ..()
-	addtimer(CALLBACK(src, PROC_REF(deploy)), deploy_time)
-
-/obj/structure/barricade/security/proc/deploy()
-	icon_state = "barrier1"
-	set_density(TRUE)
-	set_anchored(TRUE)
-	if(deploy_message)
-		visible_message(span_warning("[src] deploys!"))
-
 
 /obj/item/grenade/barrier
 	name = "barrier grenade"

--- a/code/modules/awaymissions/mission_code/murderdome.dm
+++ b/code/modules/awaymissions/mission_code/murderdome.dm
@@ -24,8 +24,6 @@
 /obj/structure/barricade/security/murderdome
 	name = "respawnable barrier"
 	desc = "A barrier. Provides cover in firefights."
-	deploy_time = 0
-	deploy_message = 0
 
 /obj/structure/barricade/security/murderdome/make_debris()
 	new /obj/effect/murderdome/dead_barricade(get_turf(src))

--- a/code/modules/capture_the_flag/ctf_game.dm
+++ b/code/modules/capture_the_flag/ctf_game.dm
@@ -433,8 +433,6 @@
 /obj/structure/barricade/security/ctf
 	name = "barrier"
 	desc = "A barrier. Provides cover in fire fights."
-	deploy_time = 0
-	deploy_message = 0
 
 /obj/structure/barricade/security/ctf/make_debris()
 	new /obj/effect/ctf/dead_barricade(get_turf(src))


### PR DESCRIPTION
Original PR: 91918
-----

## About The Pull Request

Removes the quite weird 4 second density delay from security barriers. That's kind of what the grenade timer is for.

Refactors barricade interactions to use tool acts and item_interaction(), rather than attackby. Also makes it so that wooden barricades don't....delete themselves and spawn a new one instead when repaired? 

## Why It's Good For The Game

> Security Barrier

I think this was potentially depreciated code that was grandfathered forward in new forms. Very few places seem to explain WHY it has that but I think that might have been how barrier grenades used to spawn in their barrier from the grenade itself. Totally inexplicable really.

> Refactors

This codes old as hell, some of it nearly a decade.

## Changelog
:cl:
qol: Security barrier grenades no longer have an arbitrary 4 second delay on becoming tangible.
refactor: Barricades now use tool act and item interactions, and behave sanely. Looking at you wooden barricade.
/:cl:
