### PR TITLE
[TG Mirror] Makes the Organ Jar printable, lowers it chemical capacity and makes it pour large amounts at once [MDB IGNORE]

### DIFF
--- a/code/modules/jobs/job_types/coroner.dm
+++ b/code/modules/jobs/job_types/coroner.dm
@@ -33,7 +33,7 @@
 		/obj/item/healthanalyzer = 10,
 		/obj/item/shovel/serrated/dull = 5,
 		/obj/effect/spawner/random/medical/organs = 5,
-		/obj/item/reagent_containers/cup/organ_jar/brain_in_a_jar = 5,
+		/obj/item/reagent_containers/cup/beaker/organ_jar/brain_in_a_jar = 5,
 		/obj/effect/spawner/random/medical/memeorgans = 1,
 		/obj/item/scythe = 1,
 	)

--- a/code/modules/reagents/reagent_containers/cups/organ_jar.dm
+++ b/code/modules/reagents/reagent_containers/cups/organ_jar.dm
@@ -1,37 +1,34 @@
-// The organ jar - a 150u bottle that can hold a single organ
-/obj/item/reagent_containers/cup/organ_jar
+// The organ jar - a 120u beaker that can hold a single organ
+/obj/item/reagent_containers/cup/beaker/organ_jar
 	name = "organ jar"
-	desc = "A jar large enough to put an organ inside it."
-	possible_transfer_amounts = list(10, 20, 30, 50, 150)
-	// It's pretty big
-	volume = 150
+	desc = "A large shatter-resistant jar, unwieldy for the sake of chemistry, but big enough to put an organ inside of."
 	icon_state = "organ_jar"
 	fill_icon_state = "organ_jar"
-	inhand_icon_state = "atoxinbottle"
-	worn_icon_state = "bottle"
+	// The plastic makes it more shatter-proof!
+	custom_materials = list(/datum/material/glass=SHEET_MATERIAL_AMOUNT*1.25, /datum/material/plastic=SHEET_MATERIAL_AMOUNT * 1.5)
+	volume = 120
+	// Difficult to transfer from in small amounts (to discourage using it for things besides organs)
+	amount_per_transfer_from_this = 20
+	possible_transfer_amounts = list(20, 40, 60, 120)
 	fill_icon_thresholds = list(0, 1, 20, 40, 60, 80, 100)
 	w_class = WEIGHT_CLASS_SMALL // Organs are small by default, so the jar should be at least small as well
-	// The organ that is currently inside the jar
+	/// The organ that is currently inside the jar
 	var/obj/item/organ/held_organ = null
-	// Whether the jar should preserve the organ inside (which would only happen if it's full of formaldehyde)
+	/// Whether the jar is filled to capacity with formaldehyde, preserving any organ inside
 	var/full_of_formaldehyde = FALSE
 
-/obj/item/reagent_containers/cup/organ_jar/examine(mob/user)
+/obj/item/reagent_containers/cup/beaker/organ_jar/examine(mob/user)
 	. = ..()
-	. += span_info("Any organ inside the jar will be preserved if it is filled with formaldehyde.")
+	. += span_info("Any organ inside the jar will be preserved if it is entirely filled with formaldehyde.")
 	if(held_organ && held_organ.GetComponent(/datum/component/ghostrole_on_revive))
 		. += span_smallnoticeital("The brain is twitching...") // Guaranteed to be a brain if it has that component
 
-/obj/item/reagent_containers/cup/organ_jar/Initialize(mapload)
-	. = ..()
-	update_appearance()
-
-/obj/item/reagent_containers/cup/organ_jar/Destroy(force)
+/obj/item/reagent_containers/cup/beaker/organ_jar/Destroy(force)
 	. = ..()
 	QDEL_NULL(held_organ)
 
 // Alt click lets you take the organ out, if it's present
-/obj/item/reagent_containers/cup/organ_jar/click_alt(mob/user)
+/obj/item/reagent_containers/cup/beaker/organ_jar/click_alt(mob/user)
 	if(held_organ)
 		balloon_alert(user, "removed [held_organ]")
 		user.put_in_hands(held_organ)
@@ -45,7 +42,7 @@
 
 // Clicking on the jar with an organ lets you put the organ inside, if there isn't one already
 // Otherwise it should act like a normal bottle
-/obj/item/reagent_containers/cup/organ_jar/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+/obj/item/reagent_containers/cup/beaker/organ_jar/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
 	if(!istype(tool, /obj/item/organ))
 		return
@@ -66,7 +63,7 @@
 // Organ icon size goes from 32 to this
 #define JAR_INNER_ICON_SIZE 24
 
-/obj/item/reagent_containers/cup/organ_jar/update_overlays()
+/obj/item/reagent_containers/cup/beaker/organ_jar/update_overlays()
 	. = ..()
 	// Draw the organ icon inside the jar, if present
 	if(!isnull(held_organ))
@@ -83,13 +80,13 @@
 
 #undef JAR_INNER_ICON_SIZE
 
-/obj/item/reagent_containers/cup/organ_jar/on_reagent_change(datum/reagents/holder, ...)
+/obj/item/reagent_containers/cup/beaker/organ_jar/on_reagent_change(datum/reagents/holder, ...)
 	. = ..()
 	full_of_formaldehyde = !!holder.has_reagent(/datum/reagent/toxin/formaldehyde, amount = holder.maximum_volume)
 	check_organ_freeze()
 
 // Proc that stops the held organ from rotting if the jar is full of formaldehyde
-/obj/item/reagent_containers/cup/organ_jar/proc/check_organ_freeze()
+/obj/item/reagent_containers/cup/beaker/organ_jar/proc/check_organ_freeze()
 	if(isnull(held_organ))
 		return
 	if(full_of_formaldehyde)
@@ -106,15 +103,15 @@
 // A note with a "discarded brain from the recovered crew" flavor will appear upon examining more
 #define NOTE_DISCARDED_LOST_CREW 2
 
-/obj/item/reagent_containers/cup/organ_jar/brain_in_a_jar
+/obj/item/reagent_containers/cup/beaker/organ_jar/brain_in_a_jar
 	// Which note to show when someone examins more
 	var/note_type = NOTE_STUCK_IN_MAIL
 
-/obj/item/reagent_containers/cup/organ_jar/brain_in_a_jar/examine(mob/user)
+/obj/item/reagent_containers/cup/beaker/organ_jar/brain_in_a_jar/examine(mob/user)
 	. = ..()
 	. += span_notice("<i>You can see a note attached to the bottom..</i>")
 
-/obj/item/reagent_containers/cup/organ_jar/brain_in_a_jar/examine_more(mob/user)
+/obj/item/reagent_containers/cup/beaker/organ_jar/brain_in_a_jar/examine_more(mob/user)
 	. = ..()
 	// Flavor for why the brain is scarred
 	switch(note_type)
@@ -132,7 +129,7 @@
 			I know you like these sorts of things. Signed, ZZZ.")
 
 
-/obj/item/reagent_containers/cup/organ_jar/brain_in_a_jar/Initialize(mapload)
+/obj/item/reagent_containers/cup/beaker/organ_jar/brain_in_a_jar/Initialize(mapload)
 	. = ..()
 	note_type = rand(0, 2) // Attach a random note to it
 	var/obj/item/organ/brain/scarred_brain = new() // Make a new brain
@@ -149,7 +146,7 @@
 	update_appearance()
 
 // All this does is add a random special brain trauma + add recovered crew antag datum for logging
-/obj/item/reagent_containers/cup/organ_jar/brain_in_a_jar/proc/handle_revival(obj/item/organ/brain/brain_to_scar)
+/obj/item/reagent_containers/cup/beaker/organ_jar/brain_in_a_jar/proc/handle_revival(obj/item/organ/brain/brain_to_scar)
 	brain_to_scar.gain_trauma_type(BRAIN_TRAUMA_SPECIAL, TRAUMA_RESILIENCE_ABSOLUTE, natural_gain = TRUE)
 	var/mob/living/carbon/human/owner = brain_to_scar.owner
 	owner.mind.add_antag_datum(/datum/antagonist/recovered_crew) // for tracking mostly (c)

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -59,6 +59,17 @@
 	build_path = /obj/item/reagent_containers/cup/beaker/plastic
 	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
 
+/datum/design/organ_jar
+	name = "Organ Jar"
+	id = "organ_jar"
+	build_type = PROTOLATHE | AWAY_LATHE
+	materials = list(/datum/material/glass = HALF_SHEET_MATERIAL_AMOUNT*2.5, /datum/material/plastic =SHEET_MATERIAL_AMOUNT * 1.5)
+	category = list(
+		RND_CATEGORY_EQUIPMENT + RND_SUBCATEGORY_EQUIPMENT_CHEMISTRY
+	)
+	build_path = /obj/item/reagent_containers/cup/beaker/organ_jar
+	departmental_flags = DEPARTMENT_BITFLAG_MEDICAL | DEPARTMENT_BITFLAG_SCIENCE
+
 /datum/design/meta_beaker
 	name = "Metamaterial Beaker"
 	id = "meta_beaker"

--- a/code/modules/research/techweb/nodes/medbay_nodes.dm
+++ b/code/modules/research/techweb/nodes/medbay_nodes.dm
@@ -29,6 +29,7 @@
 		"dropper",
 		"pillbottle",
 		"xlarge_beaker",
+		"organ_jar",
 		"jerrycan",
 		"reflex_hammer",
 		"blood_scanner",

--- a/tools/UpdatePaths/Scripts/92003_organ_jar_to_beaker.txt
+++ b/tools/UpdatePaths/Scripts/92003_organ_jar_to_beaker.txt
@@ -1,0 +1,3 @@
+#comment This repaths Organ Jars to be a beaker subtype https://github.com/tgstation/tgstation/pull/92003
+
+/obj/item/reagent_containers/cup/organ_jar : /obj/item/reagent_containers/cup/beaker/organ_jar{@OLD}


### PR DESCRIPTION
Original PR: 92003
-----

## About The Pull Request

A note to start: the coroner's mail goodie is untouched. They still get their brain-in-a-jar, prefilled with formaldehyde and with the ghostrole-brain.

**First part is fairly simple. It's printable now.**
![image](https://github.com/user-attachments/assets/e11d0845-9002-4707-8b12-80ab0f0ede65)

**Balance is hopefully also simple...**
Originally it could store 150u, which just made it an improvement over most of the other basic beakers... but it shouldn't even be useful in chemistry, it's rather unshapely for that!

So the balance is as follows:
- It stores 120u of chemicals, printable roundstart.
 _Identical to the X-Large Beaker - even in cost, needing some plastic (which makes it shatter-proof. i guess.)_
 - The unwieldy lip means it can only pour in large amounts (20, 40, 60, 120)
 _It's not ideal for mixing in chemistry... This will **hopefully** discourage using it where it'd look out-of-place. 
 Why juggle big numbers when you can use easier to handle, equivalent X-Large Beaker?_
 
 If players so choose they **can**, of course, still mix their spacedrugs soaking in a bottle with a Felinid Liver. It's just not a preferred shift-start beaker.

_Also it's a /beaker subtype now because I wanted to inherit some things, like the pickup/drop sounds. 
This technically means it works as a component in machines, but since it's equal to an X-Large beaker that doesn't really mean anything. Just a funny interaction._
## Why It's Good For The Game

I can finally torment my patients without having to hope the Mail Gods deem me (or the department Coroner) worthy.
The idea of gifting them their inflamed appendix in a preserved jar makes me happy.

![image](https://github.com/user-attachments/assets/fc0bc9db-28dd-4a13-a3b7-47c51389759f)
## Changelog
:cl:
add: Medical (and Science) can now print Organ Jars from their protolathes! Their shatter-proofing requires some plastic, though.
balance: Organ Jar capacity lowered to 120u, and they can only pour in large quantities (have you ever tried pouring out of a jar with a lip like that? Disaster. Such a mess.).
/:cl:
