### PR TITLE
[TG Mirror] Refactor iv drip attackby to item interaction, update screentips [MDB IGNORE]

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -27,20 +27,26 @@
 
 	/// Information and effects about where the IV drip is attached to
 	var/datum/iv_drip_attachment/attachment
-	///Are we donating or injecting?
+	/// Are we donating or injecting?
 	var/mode = IV_INJECTING
-	///The chemicals flow speed
+	/// The chemicals flow speed
 	var/transfer_rate = DEFAULT_IV_TRANSFER_RATE
-	///Internal beaker
+	/// Internal beaker
 	var/obj/item/reagent_container
-	///Set false to block beaker use and instead use an internal reagent holder
+	/// Set false to block beaker use and instead use an internal reagent holder
 	var/use_internal_storage = FALSE
-	///If we're using the internal container, fill us UP with the below : list(/datum/reagent/water = 5000)
+	/// If we're using the internal container, fill us UP with the below : list(/datum/reagent/water = 5000)
 	var/internal_list_reagents
-	///How many reagents can we hold?
+	/// How many reagents can we hold?
 	var/internal_volume_maximum = 100
-	// If the blood draining tab should be greyed out
+	/// If the blood draining tab should be greyed out
 	var/inject_only = FALSE
+	/// Typecache of containers we accept.
+	var/static/list/drip_containers = typecacheof(list(
+		/obj/item/reagent_containers/blood,
+		/obj/item/reagent_containers/cup,
+		/obj/item/reagent_containers/chem_pack,
+	))
 
 /obj/machinery/iv_drip/Initialize(mapload)
 	. = ..()
@@ -65,12 +71,17 @@
 		ui.open()
 
 /obj/machinery/iv_drip/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
-	if(attachment)
-		context[SCREENTIP_CONTEXT_RMB] = "Take needle out"
-	else if(reagent_container && !use_internal_storage)
-		context[SCREENTIP_CONTEXT_RMB] = "Eject container"
-	else if(!inject_only)
-		context[SCREENTIP_CONTEXT_RMB] = "Change direction"
+	if(isnull(held_item))
+		if(attachment)
+			context[SCREENTIP_CONTEXT_RMB] = "Take needle out"
+		else if(reagent_container && !use_internal_storage)
+			context[SCREENTIP_CONTEXT_RMB] = "Eject container"
+		else if(!inject_only)
+			context[SCREENTIP_CONTEXT_RMB] = "Set to [mode == IV_INJECTING ? "take blood" : "inject"]"
+	else
+		if(!use_internal_storage)
+			if(is_type_in_typecache(held_item, drip_containers) || IS_EDIBLE(held_item))
+				context[SCREENTIP_CONTEXT_LMB] = "Load container"
 
 	if(transfer_rate > MIN_IV_TRANSFER_RATE)
 		context[SCREENTIP_CONTEXT_ALT_LMB] = "Set flow to min"
@@ -179,35 +190,32 @@
 	user.visible_message(span_warning("[user] attaches [src] to [target]."), span_notice("You attach [src] to [target]."))
 	attach_iv(target, user)
 
-/obj/machinery/iv_drip/attackby(obj/item/item, mob/user, list/modifiers, list/attack_modifiers)
+/obj/machinery/iv_drip/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	if(use_internal_storage)
-		return ..()
+		return NONE
+	if(!is_type_in_typecache(tool, drip_containers) && !IS_EDIBLE(tool))
+		return NONE
+	if(reagent_container)
+		balloon_alert(user, "not empty!")
+		return ITEM_INTERACT_BLOCKING
+	if(!user.transferItemToLoc(tool, src))
+		return ITEM_INTERACT_BLOCKING
 
-	//Typecache of containers we accept
-	var/static/list/drip_containers = typecacheof(list(
-		/obj/item/reagent_containers/blood,
-		/obj/item/reagent_containers/cup,
-		/obj/item/reagent_containers/chem_pack,
-	))
-
-	if(is_type_in_typecache(item, drip_containers) || IS_EDIBLE(item))
-		if(reagent_container)
-			to_chat(user, span_warning("[reagent_container] is already loaded on [src]!"))
-			return
-		if(!user.transferItemToLoc(item, src))
-			return
-		reagent_container = item
-		to_chat(user, span_notice("You attach [item] to [src]."))
-		user.log_message("attached a [item] to [src] at [AREACOORD(src)] containing ([reagent_container.reagents.get_reagent_log_string()])", LOG_ATTACK)
-		add_fingerprint(user)
-		update_appearance(UPDATE_ICON)
-		return
-	else
-		return ..()
-
+	reagent_container = tool
+	balloon_alert(user, "attached")
+	user.log_message("attached a [tool] to [src] at [AREACOORD(src)] containing ([reagent_container.reagents.get_reagent_log_string()])", LOG_ATTACK)
+	add_fingerprint(user)
+	update_appearance(UPDATE_ICON)
+	return ITEM_INTERACT_SUCCESS
 
 /obj/machinery/iv_drip/click_alt(mob/user)
-	set_transfer_rate(transfer_rate > MIN_IV_TRANSFER_RATE ? MIN_IV_TRANSFER_RATE : MAX_IV_TRANSFER_RATE)
+	if(transfer_rate > MIN_IV_TRANSFER_RATE)
+		balloon_alert(user, "flow minimized")
+		set_transfer_rate(MIN_IV_TRANSFER_RATE)
+	else
+		balloon_alert(user, "flow maximized")
+		set_transfer_rate(MAX_IV_TRANSFER_RATE)
+	playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 	return CLICK_ACTION_SUCCESS
 
 /obj/machinery/iv_drip/on_deconstruction(disassembled = TRUE)

--- a/code/modules/plumbing/plumbers/iv_drip.dm
+++ b/code/modules/plumbing/plumbers/iv_drip.dm
@@ -14,13 +14,10 @@
 	AddComponent(/datum/component/simple_rotation)
 
 /obj/machinery/iv_drip/plumbing/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
-	if(attachment)
-		context[SCREENTIP_CONTEXT_RMB] = "Take needle out"
-	else if(reagent_container && !use_internal_storage)
-		context[SCREENTIP_CONTEXT_RMB] = "Eject container"
-	else if(!inject_only)
-		context[SCREENTIP_CONTEXT_RMB] = "Change direction"
-
+	. = ..()
+	if(held_item.tool_behaviour != TOOL_WRENCH)
+		return
+	context[SCREENTIP_CONTEXT_LMB] = "[anchored ? "Una" : "A"]nchor"
 	return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/iv_drip/plumbing/plunger_act(obj/item/plunger/attacking_plunger, mob/living/user, reinforced)
@@ -31,13 +28,10 @@
 		reagents.clear_reagents()
 
 /obj/machinery/iv_drip/plumbing/wrench_act(mob/living/user, obj/item/tool)
-	if(user.combat_mode)
-		return NONE
-
-	. = ITEM_INTERACT_BLOCKING
-	if(default_unfasten_wrench(user, tool) == SUCCESSFUL_UNFASTEN)
-		if(anchored)
-			begin_processing()
-		else
-			end_processing()
-		return ITEM_INTERACT_SUCCESS
+	if(default_unfasten_wrench(user, tool) != SUCCESSFUL_UNFASTEN)
+		return ITEM_INTERACT_BLOCKING
+	if(anchored)
+		begin_processing()
+	else
+		end_processing()
+	return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION
Original PR: 91940
-----

## About The Pull Request

Most of this is just the standard refactoring `attackby(...) > item_interaction(...)`, and adding associated screentips.
The plumbing subtype doesn't need its own separate context code, because the missing alt-click parts get overridden and thus aren't present anyway.
The alt-click felt very unclear without feedback, so now makes the standard clicking sound and plays a balloon alert.
The plumbing iv-drip wrench act no longer needs to check for combat mode, as that's assumed for tool acts, and we use early returns instead of that odd order of operations.
## Why It's Good For The Game

Less `attackby`
More screentips
More interaction feedback
## Changelog
:cl:
refactor: Refactored IV drip item interactions. Please report any issues.
sound: IV drip alt-click flow minimization/maximization makes the click sound.
qol: IV drip alt-click flow minimization/maximization gives feedback.
qol: Updated IV drip screentips.
/:cl:
