### PR TITLE
[TG Mirror] Expand Catwalk dorms hallway to be 2 tiles [MDB IGNORE]

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -2595,14 +2595,10 @@
 /turf/open/floor/iron/dark/textured,
 /area/station/science/xenobiology)
 "aQM" = (
+/obj/structure/extinguisher_cabinet/directional/west,
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "aRa" = (
@@ -6483,10 +6479,11 @@
 /turf/closed/wall/r_wall,
 /area/station/security/warden)
 "bXH" = (
-/obj/structure/table,
-/obj/item/pen,
-/obj/item/pen,
-/turf/open/floor/wood,
+/obj/machinery/camera/autoname/directional/west,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "bXO" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -8253,14 +8250,11 @@
 /turf/open/floor/wood/large,
 /area/station/service/library/private)
 "cxQ" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
+/area/station/commons/dorms)
 "cxU" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
@@ -9994,7 +9988,10 @@
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
 "cVN" = (
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/siding/brown{
+	dir = 8
+	},
+/turf/open/floor/iron,
 /area/station/commons/dorms)
 "cWd" = (
 /obj/structure/chair/comfy/brown{
@@ -11470,17 +11467,14 @@
 /turf/open/openspace,
 /area/station/engineering/atmos/upper)
 "dux" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/brown{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 1
 	},
 /turf/open/floor/iron,
 /area/station/commons/dorms)
@@ -37340,9 +37334,6 @@
 /turf/open/floor/engine,
 /area/station/engineering/atmos/hfr_room)
 "laK" = (
-/obj/effect/turf_decal/siding/brown/corner{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -41234,14 +41225,12 @@
 /turf/open/floor/glass,
 /area/station/commons/fitness/recreation)
 "mkI" = (
-/obj/effect/turf_decal/siding/brown/corner{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
+/area/station/commons/dorms)
 "mkK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/vending/colavend,
@@ -47998,9 +47987,6 @@
 /turf/open/floor/iron,
 /area/station/science/breakroom)
 "olU" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -52374,8 +52360,10 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/rd)
 "pDt" = (
-/obj/effect/turf_decal/siding/brown,
 /obj/effect/landmark/start/hangover,
+/obj/effect/turf_decal/siding/brown/corner{
+	dir = 8
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "pDG" = (
@@ -67113,14 +67101,10 @@
 /turf/open/openspace,
 /area/station/service/library)
 "tYz" = (
+/obj/machinery/door/firedoor,
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/extinguisher_cabinet/directional/west,
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "tYC" = (
@@ -68627,13 +68611,10 @@
 /turf/open/floor/wood,
 /area/station/service/library)
 "uus" = (
+/obj/structure/sign/poster/official/random/directional/west,
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "uuA" = (
@@ -69686,6 +69667,7 @@
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
 /obj/structure/sign/poster/official/no_erp/directional/north,
+/obj/machinery/light/directional/north,
 /turf/open/openspace,
 /area/station/commons/dorms)
 "uIi" = (
@@ -80372,9 +80354,6 @@
 /turf/closed/wall,
 /area/station/medical/storage)
 "xUV" = (
-/obj/effect/turf_decal/siding/brown{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -118091,7 +118070,7 @@ pRO
 pmn
 tFy
 pIr
-bXH
+noC
 gPA
 pRO
 kqF
@@ -118345,13 +118324,13 @@ lOh
 bIS
 mLH
 pRO
-vTH
-hXE
+rPs
 kdG
-noC
-kdG
-pRO
-sKT
+iNK
+jOT
+iQR
+fVj
+xWy
 aQj
 dhL
 sfq
@@ -118602,13 +118581,13 @@ jcz
 bIS
 wcL
 pRO
-rPs
-kdG
-iNK
-jOT
-iQR
-fVj
-xWy
+wIK
+ekB
+bDQ
+lvv
+pWh
+pRO
+err
 qac
 lMe
 rzK
@@ -118859,13 +118838,13 @@ jkR
 bIS
 ibc
 pRO
-wIK
-ekB
-bDQ
-lvv
-pWh
 pRO
-err
+pRO
+pRO
+pRO
+pRO
+pRO
+gmh
 qAd
 lMe
 epE
@@ -119116,13 +119095,13 @@ lOh
 uVY
 dFT
 pRO
+mcY
+tFy
+qNn
+doU
+clF
 pRO
-pRO
-pRO
-pRO
-pRO
-pRO
-gmh
+ntw
 qAd
 emE
 iOp
@@ -119373,13 +119352,13 @@ jcz
 bIS
 dpT
 pRO
-mcY
-tFy
-qNn
-doU
-clF
+vTH
+hXE
+ogG
+wDQ
+pgQ
 pRO
-ntw
+sKT
 qAd
 vfe
 beb
@@ -119630,13 +119609,13 @@ jcz
 bIS
 kQf
 pRO
-vTH
-hXE
-ogG
-wDQ
-pgQ
-pRO
-sKT
+rPs
+kdG
+iNK
+jOT
+iQR
+hPL
+xWy
 qAd
 vfe
 hpo
@@ -119887,13 +119866,13 @@ lOh
 bIS
 qnN
 pRO
-rPs
-kdG
-iNK
-jOT
-iQR
-hPL
-xWy
+fZq
+ekB
+bDQ
+lvv
+aHe
+pRO
+tqQ
 ccZ
 qMN
 tcW
@@ -120144,13 +120123,13 @@ hCB
 bIS
 tYb
 pRO
-fZq
-ekB
-bDQ
-lvv
-aHe
 pRO
-tqQ
+pRO
+pRO
+pRO
+pRO
+pRO
+gnw
 qAd
 vfe
 rwe
@@ -120400,14 +120379,14 @@ jcz
 jcz
 bIS
 pDt
-pRO
-pRO
-pRO
-pRO
-pRO
-pRO
-pRO
-gnw
+tYz
+uus
+cVN
+cVN
+bXH
+aQM
+cVN
+cVN
 dux
 ezT
 tcW
@@ -120656,13 +120635,13 @@ laQ
 laQ
 jjn
 hfx
+jjn
 mkI
 cxQ
 cxQ
-uus
 xUV
-aQM
-tYz
+olU
+olU
 olU
 olU
 laK
@@ -183115,7 +183094,7 @@ ojZ
 auA
 fUJ
 uxz
-cVN
+pRO
 tZV
 afu
 afu
@@ -185686,7 +185665,7 @@ eRm
 bJs
 jeX
 pRO
-kvo
+eza
 afu
 afu
 afu
@@ -185943,7 +185922,7 @@ dCm
 dCm
 dCm
 dCm
-eza
+afu
 afu
 afu
 afu


### PR DESCRIPTION
Original PR: 92021
-----
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This squishes the middle dorm room by 1 tile so that the hallway connecting dorms/holodeck can be 2 tiles wide.

![StrongDMM_NEfpkfUTCV](https://github.com/user-attachments/assets/d9a4d5a1-fec3-4d60-9ab4-1c4e69f85eda)

I also moved the ladder slightly so it wouldn't be sticking out of place and fixed a single reinforced wall that got placed on the dorm upstairs room. Also shifted the firelocks to be on the edge of the room instead of the middle of the hallway.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

One tile hallways should only be a maintenance thing.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
map: Expand Catwalk dorms hallway that connects to holodeck to be 2 tiles wide. The middle dorm room was squished by 1 tile. The ladder in the dorms top/bottom area was slightly shifted. One of the top dorm rooms had a single tile of reinforced wall that was hidden behind a poster that has been fixed to be regular. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
