### PR TITLE
[TG Mirror] Makes Catwalk's Atmos/Engi Bigger [MDB IGNORE]

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -291,6 +291,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
+"afo" = (
+/obj/structure/table,
+/obj/machinery/light/warm/directional/north,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/microwave/engineering/cell_included,
+/turf/open/floor/eighties,
+/area/station/engineering/break_room)
 "afr" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/cafeteria,
@@ -356,26 +365,19 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/prison/mess)
-"agj" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = -2;
-	pixel_y = 6
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "agy" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 4
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"agD" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "agF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -416,12 +418,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/openspace,
 /area/station/hallway/primary/aft)
-"ahT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "ahU" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/vending/snackvend,
@@ -746,6 +742,16 @@
 /obj/effect/spawner/random/maintenance/no_decals,
 /turf/open/floor/iron/smooth_large,
 /area/station/maintenance/department/medical)
+"alG" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "alT" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/spawner/random/structure/steam_vent,
@@ -848,6 +854,13 @@
 "anY" = (
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port/fore)
+"aof" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "aoh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/engineering/tank,
@@ -889,6 +902,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/ai_monitored/command/storage/eva)
+"apc" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/table,
+/obj/structure/cable,
+/obj/item/storage/medkit/toxin,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "apf" = (
 /obj/machinery/light/warm/dim/directional/north,
 /obj/structure/table/reinforced,
@@ -928,6 +948,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"apF" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/machinery/modular_computer/preset/engineering{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "apK" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
@@ -1079,11 +1107,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
-"arP" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/broken_flooring/singular/directional/east,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "arT" = (
 /turf/closed/wall/r_wall,
 /area/station/science/xenobiology)
@@ -1224,12 +1247,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"aua" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "aud" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1308,6 +1325,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/cargo/storage)
+"avg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "avG" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -1485,6 +1509,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"ayL" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "ayN" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction{
 	dir = 8
@@ -1553,10 +1586,6 @@
 	},
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
-"azJ" = (
-/obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/upper)
 "azS" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 1
@@ -1972,6 +2001,14 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/hallway/secondary/entry)
+"aGD" = (
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "aGR" = (
 /turf/open/floor/iron/dark/textured_large,
 /area/station/security/prison)
@@ -2254,10 +2291,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"aKY" = (
-/obj/item/trash/tray,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "aLa" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2415,6 +2448,11 @@
 /obj/machinery/light/small/broken/directional/east,
 /turf/open/floor/eighties,
 /area/station/maintenance/starboard/fore)
+"aNj" = (
+/obj/machinery/computer/atmos_control/air_tank,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "aNB" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 10
@@ -2902,19 +2940,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port/fore)
-"aVU" = (
-/obj/effect/spawner/random/trash/mess,
-/obj/structure/sign/clock/directional/north,
-/obj/item/trash/chips{
-	pixel_x = -10;
-	pixel_y = 14
-	},
-/obj/item/toy/katana{
-	pixel_x = 9;
-	pixel_y = 2
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "aWa" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/siding/wood,
@@ -3284,9 +3309,6 @@
 /obj/machinery/newscaster/directional/west,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/eva)
-"bbK" = (
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "bbV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -3313,14 +3335,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/bridge)
-"bch" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "bcj" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/landmark/start/hangover,
@@ -3418,15 +3432,6 @@
 "bdE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
-"bdH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/random/trash/graffiti{
-	pixel_y = 32
-	},
 /turf/open/floor/iron/smooth,
 /area/station/engineering/main)
 "bdL" = (
@@ -3571,13 +3576,19 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/interrogation)
-"bfL" = (
-/obj/structure/chair/office{
-	dir = 8
+"bfM" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
 	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+/obj/structure/ladder,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "bfN" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -3606,6 +3617,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
+"bgi" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "bgm" = (
 /obj/structure/stairs/south,
 /turf/open/floor/plating,
@@ -3954,6 +3972,12 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/virology)
+"bmc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "bmg" = (
 /obj/effect/turf_decal/trimline/dark_blue/line{
 	dir = 4
@@ -4544,6 +4568,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
+"bvy" = (
+/obj/machinery/door/airlock/engineering,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "bvz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -4788,6 +4818,13 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/carpet,
 /area/station/command/bridge)
+"byS" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/supply/visible,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "byU" = (
 /obj/structure/railing{
 	dir = 4
@@ -4902,10 +4939,6 @@
 /obj/effect/spawner/random/trash/graffiti,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"bAG" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "bAL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -5121,6 +5154,29 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
+"bEt" = (
+/obj/structure/table,
+/obj/item/hfr_box/corner{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/item/hfr_box/corner{
+	pixel_y = 6
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = -2;
+	pixel_y = 8
+	},
+/obj/item/hfr_box/corner{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/hfr_box/core{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/atmos/hfr_room)
 "bEw" = (
 /obj/effect/turf_decal/siding/purple,
 /obj/effect/turf_decal/siding/purple{
@@ -5532,13 +5588,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"bJH" = (
-/obj/structure/broken_flooring/corner/directional/south,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "bJI" = (
 /obj/structure/ladder,
 /obj/effect/turf_decal/bot,
@@ -5768,6 +5817,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/office)
+"bMT" = (
+/obj/machinery/meter{
+	name = "Mixed Air Tank In"
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/main)
 "bNk" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
@@ -6301,6 +6356,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"bUD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "bUO" = (
 /obj/machinery/computer/records/security,
 /obj/structure/cable,
@@ -6341,19 +6405,24 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"bVt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "bVB" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/plating,
 /area/station/medical/coldroom)
+"bVD" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
+"bVG" = (
+/obj/effect/spawner/random/entertainment/arcade{
+	dir = 8
+	},
+/turf/open/floor/eighties,
+/area/station/engineering/break_room)
 "bVI" = (
 /obj/machinery/requests_console/directional/north{
 	department = "Head of Security's Desk";
@@ -6424,10 +6493,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/mid_joiner,
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
-"bWD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "bWE" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
@@ -6500,12 +6565,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
-"bXP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "bYe" = (
 /obj/structure/table,
 /obj/item/paper_bin/carbon{
@@ -6703,14 +6762,6 @@
 	dir = 1
 	},
 /area/station/service/library)
-"bZY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "cac" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -6913,13 +6964,6 @@
 "ccN" = (
 /turf/closed/wall,
 /area/station/medical/surgery)
-"ccT" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 9
-	},
-/turf/open/openspace,
-/area/station/engineering/atmos/upper)
 "ccY" = (
 /obj/machinery/door/airlock/medical{
 	name = "Coroner's Office"
@@ -7045,13 +7089,6 @@
 /obj/machinery/newscaster/directional/north,
 /turf/open/floor/iron/freezer,
 /area/station/commons/toilet/restrooms)
-"cet" = (
-/obj/item/banner/engineering/mundane{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "cew" = (
 /obj/structure/table,
 /obj/item/aicard,
@@ -7326,6 +7363,13 @@
 /obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"cio" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "ciS" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -7561,6 +7605,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/security/courtroom)
+"cmW" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/break_room)
 "cmY" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 8
@@ -7920,14 +7969,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/commons/lounge)
-"csp" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/engine_smes)
 "cst" = (
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 1
@@ -8059,6 +8100,10 @@
 /obj/item/book/codex_gigas,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"ctC" = (
+/obj/structure/lattice/catwalk,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "ctD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/carbon_output{
 	dir = 4
@@ -8215,14 +8260,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"cxo" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing{
-	dir = 10
-	},
-/obj/structure/cable,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "cxq" = (
 /obj/structure/table/wood/fancy/red,
 /obj/effect/spawner/random/maintenance,
@@ -8725,6 +8762,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
+"cCZ" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "cDf" = (
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
@@ -8832,15 +8875,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/upper)
-"cEZ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "cFa" = (
 /turf/open/openspace,
 /area/station/service/kitchen)
@@ -8948,6 +8982,13 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"cGu" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "cGx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
 	dir = 4
@@ -9079,6 +9120,10 @@
 	dir = 1
 	},
 /area/station/medical/morgue)
+"cIf" = (
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "cIl" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/camera/autoname/directional/south,
@@ -9456,11 +9501,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/science)
-"cNV" = (
-/obj/structure/ladder,
-/obj/machinery/camera/autoname/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "cOe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -9486,6 +9526,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/station/solars/starboard/fore)
+"cOQ" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 4;
+	initialize_directions = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "cOS" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/directional/north{
@@ -9498,16 +9545,6 @@
 "cOU" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/oxygen_input,
 /turf/open/floor/engine/o2,
-/area/station/engineering/main)
-"cOY" = (
-/obj/structure/sign/poster/random/directional/north,
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/cable,
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/iron,
 /area/station/engineering/main)
 "cPa" = (
 /obj/machinery/light/small/directional/south,
@@ -9728,6 +9765,13 @@
 /obj/structure/ladder,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"cSz" = (
+/obj/machinery/vending/engivend,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "cSA" = (
 /obj/effect/turf_decal/tile/green/opposingcorners{
 	dir = 1
@@ -9834,11 +9878,6 @@
 /obj/effect/spawner/random/engineering/tank,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/aft)
-"cTU" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/directional/east,
-/turf/open/openspace,
-/area/station/engineering/atmos/upper)
 "cTW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -9996,6 +10035,14 @@
 "cVN" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/dorms)
+"cVW" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/light/directional/north,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "cWd" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -10122,6 +10169,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"cYg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "cYq" = (
 /obj/structure/table/reinforced,
 /obj/item/flashlight{
@@ -10218,6 +10271,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/security/interrogation)
+"dab" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "dag" = (
 /turf/open/floor/iron/dark/textured_corner{
 	dir = 8
@@ -10332,12 +10389,6 @@
 "dcE" = (
 /turf/open/space/basic,
 /area/space)
-"dcR" = (
-/obj/structure/tank_dispenser{
-	pixel_x = -1
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "dde" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -10373,9 +10424,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
-"ddM" = (
-/turf/closed/wall,
-/area/station/engineering/engine_smes)
 "ddN" = (
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/upper)
@@ -10923,15 +10971,6 @@
 "dmp" = (
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
-"dmq" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on/yellow/visible{
-	name = "O2 to Airmix"
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "dmJ" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom,
@@ -11051,6 +11090,15 @@
 	},
 /turf/open/openspace,
 /area/station/medical/storage)
+"dox" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/light_switch/directional/east,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "doy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11154,6 +11202,12 @@
 /obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
+"dqd" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "dqj" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -11238,14 +11292,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron,
 /area/station/hallway/primary/starboard)
-"drc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "SM_Outside_shutters";
-	name = "Outside Shutters"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "drk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -11279,6 +11325,11 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/service)
+"drF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light/directional/east,
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "drI" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/unres{
@@ -11342,14 +11393,6 @@
 /obj/machinery/telecomms/broadcaster/preset_left,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/tcommsat/server)
-"dsJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "dsQ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
@@ -11650,6 +11693,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
+"dxu" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "dxx" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -11948,6 +11997,11 @@
 	},
 /turf/open/floor/glass,
 /area/station/maintenance/starboard/fore)
+"dCI" = (
+/obj/structure/ladder,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "dCY" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine/hull/air,
@@ -12017,6 +12071,16 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/plating,
 /area/station/commons/toilet/auxiliary)
+"dEr" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "dEs" = (
 /obj/structure/railing{
 	dir = 8
@@ -12280,13 +12344,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"dHQ" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/obj/machinery/camera/autoname/directional/north,
-/obj/machinery/light_switch/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "dHS" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/effect/decal/cleanable/dirt,
@@ -12506,6 +12563,11 @@
 	},
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
+"dLl" = (
+/obj/machinery/atmospherics/pipe/multiz/supply/visible/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/visible/layer2,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/break_room)
 "dLo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12522,11 +12584,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/science/robotics/lab)
-"dLy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "dLM" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -12742,6 +12799,13 @@
 	},
 /turf/open/openspace,
 /area/station/commons/fitness/recreation)
+"dOn" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "dOq" = (
 /obj/structure/cable,
 /turf/open/floor/catwalk_floor,
@@ -13027,14 +13091,6 @@
 	},
 /turf/open/openspace,
 /area/station/science/xenobiology)
-"dTW" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/cable/multilayer/multiz,
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "dUb" = (
 /turf/open/openspace,
 /area/station/hallway/primary/central)
@@ -13272,6 +13328,14 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
+"dXl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "dXm" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas{
@@ -13968,6 +14032,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"efP" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/directional/north,
+/obj/machinery/airalarm/directional/north,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "ega" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating/airless,
@@ -14127,6 +14197,13 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"eig" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "eij" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/disposalpipe/segment{
@@ -14574,13 +14651,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
-"epF" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "epI" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14747,12 +14817,6 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/lesser)
-"erK" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "erM" = (
 /obj/structure/table/wood,
 /obj/structure/lattice/catwalk,
@@ -14771,10 +14835,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/medical)
-"esg" = (
-/obj/effect/decal/cleanable/blood/splatter/oil,
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "esh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/biogenerator,
@@ -14784,12 +14844,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
-"eso" = (
-/obj/item/trash/energybar{
-	pixel_y = 14
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "esu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mapping_helpers/burnt_floor,
@@ -14892,10 +14946,6 @@
 "euG" = (
 /turf/closed/wall,
 /area/station/cargo/bitrunning/den)
-"euH" = (
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "euI" = (
 /obj/effect/spawner/random/trash/moisture_trap,
 /turf/open/floor/carpet,
@@ -14909,6 +14959,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood/tile,
 /area/station/security/detectives_office/private_investigators_office)
+"euS" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/directional/north,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "eva" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/official/random/directional/west,
@@ -15015,6 +15070,11 @@
 	},
 /turf/open/floor/engine,
 /area/station/maintenance/disposal/incinerator)
+"ewW" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "ewY" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -15175,6 +15235,17 @@
 	},
 /turf/open/openspace,
 /area/station/engineering/lobby)
+"eAe" = (
+/obj/structure/table,
+/obj/item/stack/sheet/iron/fifty{
+	pixel_x = -9;
+	pixel_y = 9
+	},
+/obj/item/stack/sheet/glass/fifty{
+	pixel_y = 13
+	},
+/turf/open/floor/engine,
+/area/station/engineering/atmos/hfr_room)
 "eAg" = (
 /obj/structure/table/wood,
 /obj/item/clipboard{
@@ -15392,6 +15463,19 @@
 /obj/effect/landmark/start/detective,
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
+"eDt" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
+"eDv" = (
+/obj/machinery/meter,
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/visible,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "eDO" = (
 /obj/machinery/telecomms/bus/preset_four,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
@@ -15552,6 +15636,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"eHh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "eHu" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -15711,6 +15802,10 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
+"eKa" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "eKc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -16095,15 +16190,6 @@
 /obj/effect/turf_decal/tile/purple/full,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
-"ePz" = (
-/obj/structure/cable,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/camera/autoname/directional/east,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "ePM" = (
 /obj/structure/railing,
 /obj/effect/decal/cleanable/dirt,
@@ -16358,6 +16444,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"eTb" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 10
+	},
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "eTe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16375,12 +16468,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/department/medical)
-"eTx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/engine_smes)
 "eTD" = (
 /obj/structure/closet/secure_closet/chief_medical,
 /turf/open/floor/wood,
@@ -16568,6 +16655,14 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/station/service/lawoffice)
+"eWp" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/openspace,
+/area/station/engineering/atmos/upper)
 "eWt" = (
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -16736,6 +16831,13 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
+"eZI" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "eZL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -16750,6 +16852,10 @@
 	},
 /turf/open/openspace,
 /area/station/commons/fitness/recreation)
+"eZV" = (
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "eZW" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -17529,13 +17635,20 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/station/commons/dorms)
-"fmQ" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/shard{
-	icon_state = "medium"
+"fmR" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "fnm" = (
 /obj/structure/cable,
 /turf/closed/wall,
@@ -18023,19 +18136,6 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"ftU" = (
-/obj/item/radio/intercom/directional/west,
-/obj/machinery/light/small/directional/west,
-/obj/structure/guncase/ecase{
-	open = 0;
-	anchored = 1
-	},
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
 "fua" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/engine/hull/air,
@@ -18081,12 +18181,6 @@
 /obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/construction)
-"fuI" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/structure/sign/poster/official/moth_piping/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "fuP" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/glass,
@@ -18488,6 +18582,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
+"fAL" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/machinery/firealarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "fAV" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
@@ -18521,15 +18620,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"fBp" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "fBB" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18674,6 +18764,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/ordnance/storage)
+"fEt" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "fEy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -18698,6 +18794,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
+"fEM" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "fEO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/decal/cleanable/dirt,
@@ -19101,12 +19204,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/lesser)
-"fKW" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "fLb" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -19481,16 +19578,6 @@
 /obj/machinery/vending/games,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
-"fQU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/structure/ladder,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "fRd" = (
 /obj/machinery/disposal/bin{
 	desc = "A pneumatic waste disposal unit. This one leads to the morgue.";
@@ -19536,6 +19623,13 @@
 /obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"fRh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "fRn" = (
 /obj/machinery/newscaster/directional/west,
 /turf/closed/wall/r_wall,
@@ -19739,6 +19833,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
+"fUc" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "fUd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -20337,6 +20436,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/fore)
+"gbS" = (
+/obj/structure/sign/clock/directional/north,
+/turf/open/floor/eighties,
+/area/station/engineering/break_room)
 "gbT" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20807,6 +20910,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"giv" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "giB" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Secure Tech Storage"
@@ -20967,6 +21079,14 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/aisat/exterior)
+"glw" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "glz" = (
 /turf/open/floor/iron/chapel{
 	dir = 1
@@ -21052,6 +21172,9 @@
 	},
 /turf/open/openspace,
 /area/station/construction/storage_wing)
+"gmz" = (
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "gmA" = (
 /obj/structure/mirror/directional/north,
 /obj/structure/sink/directional/south,
@@ -21823,13 +21946,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
-"gyO" = (
-/obj/machinery/meter{
-	name = "Mixed Air Tank In"
-	},
-/obj/effect/spawner/structure/electrified_grille,
-/turf/closed/wall/r_wall,
-/area/station/engineering/main)
 "gyT" = (
 /obj/structure/railing/corner,
 /obj/effect/spawner/random/structure/chair_maintenance{
@@ -22219,13 +22335,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"gFy" = (
-/obj/structure/table,
-/obj/item/camera_film{
-	pixel_y = 9
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "gFB" = (
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/machinery/light_switch/directional/north,
@@ -22455,6 +22564,12 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/openspace,
 /area/station/maintenance/starboard/fore)
+"gJn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "gJp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/ladder,
@@ -22471,6 +22586,10 @@
 /obj/machinery/light/small/dim/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"gJL" = (
+/obj/effect/decal/cleanable/plasma,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "gKa" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -22740,10 +22859,6 @@
 /obj/item/pai_card,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"gOp" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "gOC" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners{
 	dir = 1
@@ -22793,15 +22908,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"gPv" = (
-/obj/structure/table,
-/obj/item/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/pen/red,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "gPy" = (
 /obj/machinery/computer/station_alert{
 	dir = 1
@@ -22815,6 +22921,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"gPD" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "gPE" = (
 /obj/machinery/light/directional/west,
 /turf/open/openspace,
@@ -23061,18 +23177,6 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/carpet,
 /area/station/medical/psychology)
-"gSC" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = 20;
-	pixel_y = 6
-	},
-/obj/item/flashlight/flare{
-	pixel_x = -14;
-	pixel_y = 12
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "gSG" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
@@ -23155,6 +23259,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"gUg" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "gUh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23691,17 +23804,6 @@
 "hcx" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
-"hcB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 1
-	},
-/obj/structure/window/spawner/directional/north,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "hcC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -23737,6 +23839,10 @@
 	},
 /turf/open/floor/eighties,
 /area/station/maintenance/starboard/fore)
+"hcT" = (
+/obj/effect/turf_decal/trimline/yellow/filled,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "hcZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -23871,6 +23977,10 @@
 /obj/structure/light_construct/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"hgd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "hgm" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -24148,11 +24258,6 @@
 "hkm" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/fore)
-"hkq" = (
-/obj/machinery/light/directional/north,
-/obj/machinery/atmospherics/components/unary/bluespace_sender,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "hkw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -24326,6 +24431,11 @@
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
+"hmR" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "hmT" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/toilet{
@@ -25091,11 +25201,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood/large,
 /area/station/service/library)
-"hyX" = (
-/obj/effect/decal/cleanable/glass,
-/obj/machinery/airalarm/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "hyZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -25119,23 +25224,11 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/iron/dark/textured,
 /area/station/cargo/warehouse)
-"hzs" = (
-/obj/structure/cable,
-/obj/machinery/computer/atmos_control/air_tank,
-/turf/open/floor/iron/white,
-/area/station/engineering/atmos/upper)
 "hzv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/wheelchair/gold,
 /turf/open/floor/iron/white,
 /area/station/maintenance/hallway/abandoned_recreation)
-"hzx" = (
-/obj/structure/closet/secure_closet/atmospherics,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/machinery/light/directional/north,
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "hzC" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/decal/cleanable/dirt,
@@ -25386,6 +25479,15 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
+"hCv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "hCy" = (
 /obj/effect/turf_decal/siding/red{
 	dir = 4
@@ -25420,14 +25522,6 @@
 	},
 /turf/open/openspace,
 /area/station/ai_monitored/turret_protected/ai)
-"hCT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "hCY" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Interrogation room";
@@ -25766,6 +25860,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"hHC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "hHE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
 	dir = 9
@@ -26252,10 +26355,6 @@
 	},
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/port/aft)
-"hOn" = (
-/obj/item/clothing/mask/gas,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "hOw" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 10
@@ -26599,6 +26698,12 @@
 "hSk" = (
 /turf/closed/wall,
 /area/station/security/checkpoint/medical)
+"hSt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "hSu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -26903,14 +27008,6 @@
 /obj/structure/window/reinforced/tinted/spawner/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms)
-"hXL" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
-"hXP" = (
-/obj/effect/decal/cleanable/plasma,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "hXT" = (
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
@@ -26925,17 +27022,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"hYj" = (
-/obj/structure/lattice/catwalk,
-/obj/item/cigbutt,
-/obj/structure/railing/corner/end{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "hYm" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -27322,12 +27408,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
-"iec" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible{
-	initialize_directions = 3
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "iee" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/headset,
@@ -27361,11 +27441,6 @@
 	dir = 4
 	},
 /area/station/medical/abandoned)
-"ieI" = (
-/obj/structure/ladder,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "ifn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/fueltank,
@@ -27431,6 +27506,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"ign" = (
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "igo" = (
 /obj/effect/turf_decal/siding/wideplating_new{
 	dir = 9
@@ -27501,13 +27582,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/command/heads_quarters/hos)
-"ihQ" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "ihS" = (
 /obj/structure/closet/crate/trashcart/filled,
 /obj/effect/spawner/random/medical/memeorgans,
@@ -27533,12 +27607,6 @@
 	},
 /turf/open/floor/iron/white/textured_corner,
 /area/station/science/robotics)
-"ihZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "iib" = (
 /obj/structure/lattice/catwalk,
 /obj/item/kirbyplants/random,
@@ -27599,6 +27667,9 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
+"ijs" = (
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "iju" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -27909,15 +27980,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/lockers)
-"ioy" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
-	dir = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "ioC" = (
 /obj/structure/chair/stool/bar/directional/south,
 /obj/effect/landmark/start/hangover,
@@ -27974,6 +28036,14 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/station/security/execution/education)
+"ipc" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "SM_Outside_shutters";
+	name = "Outside Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "ipd" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28164,6 +28234,10 @@
 /obj/structure/sign/flag/nanotrasen/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"isw" = (
+/obj/item/stack/sheet/plasteel/fifty,
+/turf/open/floor/engine,
+/area/station/engineering/atmos/hfr_room)
 "isy" = (
 /obj/machinery/newscaster/directional/west,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -28371,6 +28445,13 @@
 	},
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
+"ivQ" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "ivS" = (
 /obj/structure/table/reinforced,
 /obj/item/weldingtool,
@@ -28842,13 +28923,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"iCY" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
 "iDe" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -28924,15 +28998,6 @@
 	},
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
-"iDP" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "iDR" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/engine,
@@ -29240,10 +29305,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"iHg" = (
-/obj/effect/decal/cleanable/blood/splatter/oil,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "iHo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
@@ -29314,6 +29375,18 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
+"iIC" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/door/airlock/engineering,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "iIJ" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Service Hall Maintenance"
@@ -29329,6 +29402,25 @@
 /obj/machinery/flasher/portable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/office)
+"iIQ" = (
+/obj/item/hfr_box/body/waste_output{
+	pixel_x = -15;
+	pixel_y = 13
+	},
+/obj/item/hfr_box/body/interface{
+	pixel_y = 17
+	},
+/obj/item/hfr_box/body/moderator_input{
+	pixel_x = -8;
+	pixel_y = 8
+	},
+/obj/item/hfr_box/body/waste_output{
+	pixel_x = 10;
+	pixel_y = 9
+	},
+/obj/structure/table,
+/turf/open/floor/engine,
+/area/station/engineering/atmos/hfr_room)
 "iIS" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/deck,
@@ -29477,6 +29569,14 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
+"iKM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "iKT" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 4
@@ -29712,13 +29812,6 @@
 "iOk" = (
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
-"iOm" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/hidden,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "iOp" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 8
@@ -29754,6 +29847,10 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/general,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/customs)
+"iOI" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "iOK" = (
 /obj/machinery/shower/directional/west,
 /turf/open/floor/iron/freezer,
@@ -29771,14 +29868,6 @@
 /obj/item/shard,
 /turf/open/floor/iron/white,
 /area/station/maintenance/hallway/abandoned_recreation)
-"iPg" = (
-/obj/item/trash/can{
-	pixel_x = -13;
-	pixel_y = 10
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "iPk" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance,
@@ -29897,6 +29986,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/science/genetics)
+"iQY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 6
+	},
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "iRa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30010,15 +30107,6 @@
 	},
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/port)
-"iSN" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "iSX" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -30163,6 +30251,12 @@
 /obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"iVs" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/project)
 "iVW" = (
 /turf/open/floor/plating/elevatorshaft,
 /area/station/security/prison/rec)
@@ -30250,16 +30344,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/aft)
-"iXm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/shower/directional/west,
-/obj/machinery/camera/directional/north{
-	c_tag = "Engineering - Showers"
-	},
-/turf/open/floor/iron/freezer,
-/area/station/engineering/main)
 "iXw" = (
 /obj/structure/bed/dogbed/renault,
 /mob/living/basic/pet/fox/renault,
@@ -30615,6 +30699,21 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
+"jdz" = (
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/bot,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 10
+	},
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "jdB" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/mix_input{
 	dir = 1
@@ -31284,14 +31383,6 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
-"jne" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/directional/east,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "jni" = (
 /obj/structure/cable,
 /obj/item/crowbar,
@@ -31490,14 +31581,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
-"jqT" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "jqU" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 6
@@ -31539,6 +31622,9 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
+"jrh" = (
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "jrp" = (
 /obj/structure/window/reinforced/tinted/spawner/directional/south,
 /obj/structure/table,
@@ -33364,11 +33450,6 @@
 /obj/item/kirbyplants/random/fullysynthetic,
 /turf/open/floor/carpet/stellar,
 /area/station/maintenance/hallway/abandoned_recreation)
-"jQj" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "jQn" = (
 /obj/effect/turf_decal/siding/green/corner{
 	dir = 4
@@ -33417,6 +33498,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"jQQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "jRg" = (
 /obj/effect/turf_decal/trimline/red/filled/warning{
 	dir = 10
@@ -33487,11 +33574,6 @@
 /obj/structure/window/reinforced/plasma/spawner/directional/north,
 /turf/open/space/basic,
 /area/space/nearstation)
-"jSJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "jSV" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -33820,6 +33902,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"jXy" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "jXC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 5
@@ -33871,6 +33959,11 @@
 "jYp" = (
 /turf/open/floor/iron/dark/textured,
 /area/station/science/xenobiology)
+"jYr" = (
+/obj/structure/ladder,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "jYs" = (
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/machinery/photocopier/prebuilt,
@@ -33981,6 +34074,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"kaY" = (
+/obj/structure/cable,
+/obj/item/radio/intercom/directional/north,
+/obj/machinery/light/directional/north,
+/obj/machinery/camera/autoname/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "kbe" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner,
@@ -34397,12 +34497,6 @@
 /obj/machinery/computer/security/telescreen/ce/directional/east,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/ce)
-"khf" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "khi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34765,12 +34859,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/engineering/atmos/upper)
-"kmd" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "kmh" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner/end/flip{
@@ -34835,12 +34923,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"kmM" = (
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 1
-	},
-/turf/open/floor/engine/hull,
-/area/space/nearstation)
 "kmQ" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -35043,6 +35125,10 @@
 	},
 /turf/open/openspace,
 /area/station/medical/storage)
+"kpc" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/project)
 "kpe" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
@@ -36246,6 +36332,16 @@
 /obj/machinery/status_display/evac/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"kHO" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/item/kirbyplants/random/fullysynthetic,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "kHU" = (
 /obj/effect/spawner/random/trash/grille_or_waste,
 /turf/open/floor/plating,
@@ -36289,6 +36385,15 @@
 	},
 /turf/open/floor/carpet,
 /area/station/security/detectives_office)
+"kIJ" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/break_room)
 "kIW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -36300,6 +36405,13 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
+"kJm" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/yellow/visible,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "kJw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -36432,6 +36544,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/starboard/lesser)
+"kMh" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/upper)
 "kMj" = (
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance/burnchamber)
@@ -36574,6 +36690,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/station/science/ordnance)
+"kOU" = (
+/obj/machinery/vending/wardrobe/atmos_wardrobe,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "kOV" = (
 /obj/structure/railing/corner/end/flip{
 	dir = 8
@@ -36773,6 +36897,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"kRe" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "kRf" = (
 /obj/structure/cable/layer3,
 /obj/structure/cable,
@@ -36951,10 +37079,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/hallway/primary/central)
-"kUm" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "kUq" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/port)
@@ -37070,6 +37194,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
+"kWt" = (
+/obj/structure/ladder,
+/obj/machinery/camera/autoname/directional/north,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "kWv" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 6
@@ -37079,9 +37209,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
-"kWC" = (
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "kWF" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/firealarm/directional/east,
@@ -37237,6 +37364,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
+"kZw" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "kZJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
 	dir = 4
@@ -37393,6 +37526,13 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/carpet/stellar,
 /area/station/maintenance/hallway/abandoned_recreation)
+"lby" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/light/directional/south,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/break_room)
 "lbD" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 4
@@ -37592,13 +37732,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/ai_monitored/security/armory)
-"lfp" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "lfx" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/openspace,
@@ -38028,10 +38161,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/textured,
 /area/station/cargo/storage)
-"lnM" = (
-/obj/machinery/light/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "lnO" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -38317,16 +38446,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
-"lsj" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
-	initialize_directions = 8
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "lsp" = (
 /obj/structure/cable/multilayer/multiz,
 /turf/open/floor/glass/reinforced/airless,
@@ -38339,6 +38458,17 @@
 "lsQ" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/office)
+"lsV" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/camera/autoname/directional/east,
+/obj/machinery/light_switch/directional/east,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "lsW" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -38454,10 +38584,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/dorms)
-"lvx" = (
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "lvE" = (
 /obj/machinery/roulette,
 /turf/open/floor/carpet/royalblack,
@@ -39011,10 +39137,6 @@
 "lDE" = (
 /turf/closed/wall,
 /area/station/commons/vacant_room/commissary)
-"lDW" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "lEe" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -39038,6 +39160,15 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
+"lEy" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "lEB" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
@@ -39292,6 +39423,14 @@
 "lIr" = (
 /turf/closed/wall,
 /area/station/maintenance/port/aft)
+"lIB" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/closet/secure_closet/atmospherics,
+/turf/open/openspace,
+/area/station/engineering/atmos/upper)
 "lIC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39323,6 +39462,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
+"lJd" = (
+/obj/structure/railing{
+	dir = 10
+	},
+/obj/machinery/vending/donksnack,
+/turf/open/floor/eighties,
+/area/station/engineering/break_room)
 "lJe" = (
 /obj/effect/turf_decal/siding/thinplating_new/light/corner,
 /obj/effect/turf_decal/trimline/purple/corner,
@@ -39644,9 +39790,6 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
-"lNP" = (
-/turf/closed/wall,
-/area/station/maintenance/department/engine)
 "lNQ" = (
 /obj/structure/flora/bush/large,
 /turf/open/floor/grass,
@@ -39765,6 +39908,25 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"lOZ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/bottle/juice/orangejuice{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/obj/item/reagent_containers/cup/glass/bottle/vodka{
+	pixel_y = 15;
+	pixel_x = 6
+	},
+/obj/structure/railing,
+/obj/item/reagent_containers/cup/glass/flask{
+	pixel_x = -6
+	},
+/obj/item/reagent_containers/cup/glass/flask{
+	pixel_x = 11
+	},
+/turf/open/floor/eighties,
+/area/station/engineering/break_room)
 "lPc" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -39912,12 +40074,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"lRy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "lRz" = (
 /obj/structure/safe/floor,
 /obj/item/stack/spacecash/c1000,
@@ -39950,12 +40106,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"lRK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/vending/engivend,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "lRP" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
@@ -40037,16 +40187,6 @@
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
-"lTj" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/broken_flooring/pile/directional/east,
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "lTw" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/tile/dark_blue{
@@ -40127,6 +40267,12 @@
 /obj/item/clothing/gloves/latex,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/surgery)
+"lUK" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "lUV" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Prison Isolation Cell";
@@ -40144,15 +40290,6 @@
 /obj/structure/light_construct/directional/north,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
-"lVk" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/radio/intercom/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
-"lVm" = (
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "lVn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/cable,
@@ -40414,6 +40551,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
+"lYh" = (
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "lYj" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -40820,6 +40960,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"meh" = (
+/obj/structure/cable,
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "mek" = (
 /obj/effect/turf_decal/tile/green/full,
 /obj/machinery/biogenerator,
@@ -41201,6 +41346,10 @@
 "mjc" = (
 /turf/open/openspace,
 /area/station/service/library/private)
+"mje" = (
+/obj/structure/ladder,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "mjh" = (
 /obj/structure/broken_flooring/corner/directional/east,
 /turf/open/floor/plating,
@@ -41283,6 +41432,11 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/upper)
+"mlJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/break_room)
 "mlL" = (
 /obj/structure/kitchenspike,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -41501,17 +41655,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/iron/dark,
 /area/station/command/gateway)
-"mpP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/cigbutt,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 10
-	},
-/obj/structure/window/spawner/directional/north,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "mpT" = (
 /obj/structure/cable,
 /turf/open/floor/iron/dark/smooth_large,
@@ -41583,6 +41726,10 @@
 /obj/item/stack/rods/two,
 /turf/open/space/basic,
 /area/space/nearstation)
+"mqx" = (
+/obj/structure/railing,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "mqJ" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -41723,22 +41870,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/aft)
-"mst" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/structure/table,
-/obj/item/clothing/gloves/color/black{
-	pixel_y = 1
-	},
-/obj/item/geiger_counter{
-	pixel_x = -5;
-	pixel_y = 16
-	},
-/obj/item/clothing/suit/hooded/wintercoat/engineering{
-	pixel_y = 5
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "msx" = (
 /obj/structure/table/glass,
 /obj/structure/disposalpipe/segment{
@@ -42280,6 +42411,10 @@
 /obj/structure/railing,
 /turf/open/floor/glass,
 /area/station/science/zoo)
+"mAD" = (
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/station/engineering/main)
 "mAO" = (
 /obj/item/clothing/head/costume/shrine_wig,
 /turf/open/floor/plating/airless,
@@ -42420,13 +42555,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
-"mDD" = (
-/obj/structure/sign/warning/electric_shock/directional/east,
-/obj/machinery/light/directional/east,
-/obj/machinery/camera/autoname/directional/east,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "mDF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -42501,13 +42629,6 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter)
-"mEN" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "mEO" = (
 /obj/machinery/computer/monitor,
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners{
@@ -42990,14 +43111,6 @@
 /obj/effect/turf_decal/tile/green/fourcorners,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"mLW" = (
-/obj/structure/cable,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "mMb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -43125,6 +43238,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/central)
+"mOn" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "mOx" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/item/toy/figure/cmo{
@@ -43276,13 +43393,6 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/space/nearstation)
-"mRj" = (
-/obj/structure/girder,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "mRn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/cigbutt/cigarbutt,
@@ -43350,6 +43460,13 @@
 "mSd" = (
 /turf/closed/wall,
 /area/station/commons/lounge)
+"mSm" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "mSq" = (
 /obj/structure/cable,
 /obj/structure/disposalpipe/segment{
@@ -43534,32 +43651,6 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/space/openspace,
 /area/space/nearstation)
-"mVS" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
-"mVV" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
-"mWq" = (
-/obj/structure/table,
-/obj/item/stack/sheet/iron/fifty{
-	pixel_x = -7;
-	pixel_y = 7
-	},
-/obj/item/stack/sheet/glass/fifty{
-	pixel_y = 7
-	},
-/obj/item/stack/sheet/plasteel/fifty{
-	pixel_x = 7;
-	pixel_y = 7
-	},
-/turf/open/floor/engine,
-/area/station/engineering/atmos/hfr_room)
 "mWu" = (
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/glass,
@@ -43655,6 +43746,14 @@
 /obj/effect/spawner/random/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"mXR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 10
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "mXS" = (
 /obj/effect/turf_decal/trimline/red/filled/mid_joiner{
 	dir = 4
@@ -43943,6 +44042,12 @@
 "ncO" = (
 /turf/open/floor/glass/reinforced,
 /area/station/hallway/secondary/entry)
+"ndc" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "nde" = (
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
@@ -44194,6 +44299,9 @@
 /obj/effect/decal/cleanable/confetti,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
+"ngH" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/break_room)
 "ngQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -44278,6 +44386,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"nhU" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "nhY" = (
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/blood/old,
@@ -44394,6 +44509,12 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/hallway/primary/central)
+"njW" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/trinary/mixer/flipped,
+/obj/machinery/light/directional/north,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "nkh" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/smooth_large,
@@ -44889,6 +45010,12 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/cargo/bitrunning/den)
+"nqE" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/east,
+/turf/open/openspace,
+/area/station/engineering/atmos/upper)
 "nqG" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/airalarm/directional/west,
@@ -45510,6 +45637,10 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"nzt" = (
+/obj/structure/reagent_dispensers/fueltank/large,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "nzy" = (
 /obj/structure/closet/crate/trashcart/filled,
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -45600,6 +45731,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
+"nBk" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "nBl" = (
 /obj/machinery/airalarm/directional/north,
 /obj/structure/cable,
@@ -45665,6 +45803,14 @@
 	},
 /turf/open/floor/iron/white/smooth_corner,
 /area/station/hallway/secondary/entry)
+"nCb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "nCc" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating,
@@ -45744,6 +45890,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"nCN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "nCP" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -46530,6 +46682,14 @@
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/eva)
+"nPy" = (
+/obj/structure/ladder,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "nPA" = (
 /obj/item/storage/medkit/regular{
 	pixel_x = 3;
@@ -46685,6 +46845,13 @@
 /obj/structure/cable,
 /turf/open/floor/glass/reinforced,
 /area/station/solars/starboard/fore)
+"nSb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/item/cigbutt,
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "nSk" = (
 /obj/effect/turf_decal/siding/blue{
 	dir = 9
@@ -47102,6 +47269,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"nXv" = (
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 5
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "nXA" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -47673,6 +47846,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/lesser)
+"ogq" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/shower/directional/west,
+/obj/machinery/camera/directional/north{
+	c_tag = "Engineering - Showers"
+	},
+/obj/structure/closet/radiation,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/iron/freezer,
+/area/station/engineering/main)
 "ogB" = (
 /obj/machinery/power/turbine/core_rotor{
 	dir = 8;
@@ -48014,6 +48199,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"omF" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/machinery/light/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "omG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/siding/purple/corner{
@@ -48027,6 +48219,12 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/lab)
+"omO" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "omX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -48163,6 +48361,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/processing)
+"ope" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "opj" = (
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/carpet,
@@ -48508,20 +48713,6 @@
 /obj/effect/mapping_helpers/mail_sorting/service/kitchen,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
-"ouF" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line,
-/obj/structure/table,
-/obj/item/clothing/suit/hazardvest{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/paper_bin{
-	pixel_x = -10;
-	pixel_y = 7
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "ouH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -48805,9 +48996,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"oyP" = (
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "oyQ" = (
 /obj/machinery/atmospherics/pipe/multiz/cyan/visible{
 	dir = 1;
@@ -48995,6 +49183,10 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"oBM" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "oBT" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -49157,14 +49349,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/entry)
-"oEy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "oEA" = (
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/floor/plating,
@@ -49342,33 +49526,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison/rec)
-"oHB" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/power_store/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/item/clothing/glasses/meson/engine{
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/meson/engine{
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/meson/engine{
-	pixel_y = 4
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_y = 8
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_y = 8
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "oHE" = (
 /obj/machinery/holopad/secure,
 /obj/structure/disposalpipe/segment,
@@ -49411,13 +49568,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/wood/large,
 /area/station/medical/psychology)
-"oIA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/item/wrench,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "oID" = (
 /obj/structure/window/reinforced/plasma/spawner/directional/south,
 /obj/machinery/power/energy_accumulator/tesla_coil/anchored,
@@ -49611,10 +49761,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
-"oKT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "oLa" = (
 /obj/structure/table/wood,
 /obj/item/book/bible{
@@ -49748,24 +49894,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage_shared)
-"oMH" = (
-/obj/item/hfr_box/body/interface{
-	pixel_y = 17
-	},
-/obj/item/hfr_box/body/moderator_input{
-	pixel_x = -8;
-	pixel_y = 9
-	},
-/obj/item/hfr_box/body/fuel_input{
-	pixel_x = 7;
-	pixel_y = 9
-	},
-/obj/item/hfr_box/body/waste_output{
-	pixel_y = 3
-	},
-/obj/structure/table,
-/turf/open/floor/engine,
-/area/station/engineering/atmos/hfr_room)
 "oMI" = (
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access"
@@ -49937,6 +50065,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal/incinerator)
+"oOM" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "oOS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -50046,10 +50183,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/service/cafeteria)
-"oRw" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "oRG" = (
 /obj/structure/railing,
 /obj/structure/rack,
@@ -50165,12 +50298,6 @@
 	},
 /turf/open/floor/glass,
 /area/station/science/zoo)
-"oTm" = (
-/obj/effect/turf_decal/trimline/yellow/warning{
-	dir = 9
-	},
-/turf/open/floor/engine/hull,
-/area/space/nearstation)
 "oTn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50299,12 +50426,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"oUo" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/bot,
-/obj/item/radio/intercom/directional/south,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "oUC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -50412,13 +50533,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/engine/hull/reinforced/air,
 /area/station/maintenance/port)
-"oWD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
-	dir = 10
-	},
-/obj/structure/sign/poster/random/directional/north,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "oWL" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -50465,6 +50579,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/lesser)
+"oXj" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "oXn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing/corner{
@@ -50578,6 +50698,14 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"oZm" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/glass/plasma,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "oZn" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -50952,6 +51080,11 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
+"pdD" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/structure/cable,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "pdO" = (
 /turf/closed/wall,
 /area/station/medical/pharmacy)
@@ -51218,6 +51351,19 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/wood,
 /area/station/commons/dorms)
+"phc" = (
+/obj/item/radio/intercom/directional/west,
+/obj/machinery/light/small/directional/west,
+/obj/structure/guncase/ecase{
+	open = 0;
+	anchored = 1
+	},
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "phd" = (
 /obj/structure/chair/office{
 	name = "CE's Chair"
@@ -52181,16 +52327,6 @@
 	},
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
-"pzH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "pzQ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -52496,11 +52632,15 @@
 	},
 /turf/open/openspace,
 /area/station/science/xenobiology)
-"pFR" = (
-/obj/effect/spawner/random/maintenance,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+"pFF" = (
+/obj/structure/sign/poster/random/directional/north,
+/obj/structure/cable,
+/obj/machinery/camera/autoname/directional/north,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/main)
 "pFX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable,
@@ -52676,12 +52816,6 @@
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/virology)
-"pHH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "pHQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -53223,6 +53357,16 @@
 /obj/effect/turf_decal/tile/red/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"pNo" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 2
+	},
+/obj/machinery/light/directional/west,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "pNA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -53374,6 +53518,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/medical/medbay/central)
+"pPr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "pPt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -53705,6 +53855,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"pSJ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/cup/glass/bottle/wine_voltaic{
+	pixel_y = 5;
+	pixel_x = 7
+	},
+/obj/item/reagent_containers/cup/glass/shaker{
+	pixel_y = 6;
+	pixel_x = -6
+	},
+/obj/structure/railing,
+/turf/open/floor/eighties,
+/area/station/engineering/break_room)
 "pSK" = (
 /obj/effect/decal/cleanable/food/flour,
 /obj/item/storage/cans/sixbeer,
@@ -53736,21 +53899,6 @@
 	},
 /turf/open/floor/iron/kitchen,
 /area/station/maintenance/port/aft)
-"pTa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/button/elevator{
-	id = "catwalk_engi";
-	pixel_y = -24
-	},
-/obj/structure/closet/radiation,
-/obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "pTi" = (
 /obj/structure/railing{
 	dir = 1
@@ -53833,11 +53981,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
-"pUh" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/item/radio/intercom/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "pUj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/medical/emergency,
@@ -53849,6 +53992,16 @@
 /obj/effect/landmark/start/hangover/closet,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"pUs" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "pUD" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -54099,6 +54252,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
+"qaU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "qaV" = (
 /obj/structure/sign/poster/contraband/random/directional/north,
 /obj/structure/bed/maint,
@@ -54118,13 +54277,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter)
-"qbO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "qbT" = (
 /turf/closed/wall/r_wall,
 /area/station/security/prison/mess)
@@ -54348,6 +54500,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
+"qfy" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/engine_smes)
 "qfS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54757,6 +54916,13 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/engine/hull/air,
 /area/station/security/courtroom)
+"qlz" = (
+/obj/structure/cable/multilayer/multiz,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "qlI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured_large,
@@ -54816,6 +54982,13 @@
 /obj/effect/spawner/random/trash/box,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"qmr" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "qmB" = (
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark/textured_large,
@@ -54856,6 +55029,16 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/port)
+"qni" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/main)
 "qns" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
@@ -54925,12 +55108,6 @@
 	dir = 4
 	},
 /area/station/science/robotics)
-"qof" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "qom" = (
 /obj/machinery/teleport/hub,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -55084,13 +55261,6 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet,
 /area/station/service/lawoffice)
-"qqN" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "qqY" = (
 /obj/effect/turf_decal/trimline/yellow/warning{
 	dir = 1
@@ -55553,6 +55723,19 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/iron/textured_large,
 /area/station/medical/abandoned)
+"qzJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/button/elevator{
+	id = "catwalk_engi";
+	pixel_y = -24
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "qzZ" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -55660,14 +55843,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/courtroom)
-"qAZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/glass/plasma,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "qBe" = (
 /obj/machinery/door/airlock/wood{
 	name = "Curator Office"
@@ -55767,6 +55942,16 @@
 /obj/item/tank/internals/anesthetic,
 /turf/open/floor/iron/white,
 /area/station/maintenance/hallway/abandoned_recreation)
+"qBN" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "qCe" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -55818,18 +56003,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/brig)
-"qCV" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
-	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "qCY" = (
 /obj/effect/turf_decal/siding/dark/corner{
 	dir = 4
@@ -55906,13 +56079,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
-"qEq" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/upper)
 "qEE" = (
 /obj/structure/chair{
 	dir = 8
@@ -56301,12 +56467,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron/solarpanel/airless,
 /area/station/solars/starboard/aft)
-"qKJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "qKO" = (
 /turf/closed/wall,
 /area/station/maintenance/starboard/central)
@@ -57333,6 +57493,10 @@
 /obj/machinery/computer/order_console/mining,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"raM" = (
+/obj/machinery/light_switch/directional/north,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/upper)
 "raN" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -57759,6 +57923,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"riP" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "riR" = (
 /turf/open/openspace,
 /area/station/service/library)
@@ -58022,11 +58192,6 @@
 /obj/structure/sign/poster/official/obey/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"rlX" = (
-/obj/machinery/meter,
-/obj/effect/spawner/structure/electrified_grille,
-/turf/closed/wall/r_wall,
-/area/station/engineering/main)
 "rlY" = (
 /obj/effect/turf_decal/trimline/red/warning{
 	dir = 5
@@ -58174,10 +58339,6 @@
 	},
 /turf/closed/wall,
 /area/station/maintenance/starboard/fore)
-"rnr" = (
-/obj/structure/broken_flooring/singular/directional/east,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "rnC" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -58304,10 +58465,6 @@
 /obj/effect/mapping_helpers/broken_floor,
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
-"rpt" = (
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "rpB" = (
 /turf/closed/wall/r_wall,
 /area/station/command/corporate_showroom)
@@ -58371,6 +58528,9 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/lobby)
+"rqo" = (
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/project)
 "rqq" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/chapel,
@@ -58461,13 +58621,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/eighties,
 /area/station/maintenance/hallway/abandoned_recreation)
-"rrs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/broken_flooring/pile/directional/east,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "rrv" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/railing,
@@ -58752,14 +58905,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"rvQ" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 3;
-	pixel_y = 14
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "rvY" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/box/gloves{
@@ -58929,6 +59074,14 @@
 /obj/item/radio/intercom/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/engineering)
+"ryw" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "ryJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -58993,13 +59146,6 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/grass,
 /area/station/commons/dorms)
-"rzO" = (
-/obj/machinery/door/airlock/engineering/glass,
-/obj/structure/cable,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "rzQ" = (
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
@@ -59057,6 +59203,18 @@
 /obj/structure/table/glass,
 /turf/open/floor/carpet,
 /area/station/command/bridge)
+"rAP" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/n2{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "rAV" = (
 /obj/machinery/holopad,
 /obj/machinery/status_display/evac/directional/north,
@@ -59839,20 +59997,18 @@
 "rMj" = (
 /turf/open/floor/engine/hull/air,
 /area/station/maintenance/starboard/lesser)
-"rMr" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/effect/mapping_helpers/airlock/unres{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "rMv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/mid_joiner,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron/white/textured_large,
 /area/station/medical/medbay/central)
+"rMz" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "rMS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -60089,12 +60245,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
-"rQn" = (
-/obj/structure/chair/office{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "rQq" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
@@ -60134,14 +60284,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"rRf" = (
-/obj/machinery/modular_computer/preset/engineering{
-	dir = 8
-	},
-/obj/machinery/airalarm/directional/east,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "rRg" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/trimline/brown/filled/line{
@@ -60230,12 +60372,6 @@
 	dir = 4
 	},
 /area/station/medical/pharmacy)
-"rSN" = (
-/obj/effect/spawner/random/entertainment/arcade{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "rTa" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -60376,6 +60512,9 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
+"rUZ" = (
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "rVc" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 4
@@ -60608,29 +60747,6 @@
 /obj/machinery/status_display/evac/directional/west,
 /turf/open/floor/wood,
 /area/station/ai_monitored/command/storage/eva)
-"rYz" = (
-/obj/structure/table,
-/obj/item/hfr_box/corner{
-	pixel_x = 7;
-	pixel_y = 14
-	},
-/obj/item/hfr_box/corner{
-	pixel_y = 14;
-	pixel_x = -8
-	},
-/obj/item/hfr_box/core{
-	pixel_y = 8
-	},
-/obj/item/hfr_box/corner{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/item/hfr_box/corner{
-	pixel_x = 7;
-	pixel_y = 3
-	},
-/turf/open/floor/engine,
-/area/station/engineering/atmos/hfr_room)
 "rYF" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61178,6 +61294,12 @@
 	icon_state = "carpet-137"
 	},
 /area/station/service/abandoned_gambling_den)
+"sgS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable,
+/turf/open/floor/iron/dark/textured,
+/area/station/engineering/supermatter/room)
 "sgU" = (
 /obj/structure/table,
 /obj/item/flashlight{
@@ -61311,12 +61433,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
-"sji" = (
-/obj/structure/broken_flooring/side/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/engine_smes)
 "sjq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -61434,18 +61550,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/xenobiology)
-"sla" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/structure/window/spawner/directional/north,
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "sle" = (
 /obj/machinery/door/airlock/command{
 	name = "Gateway Atrium"
@@ -61540,6 +61644,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/medical/morgue)
+"smY" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/break_room)
 "snd" = (
 /obj/machinery/mecha_part_fabricator{
 	dir = 4
@@ -61727,6 +61837,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"spT" = (
+/obj/machinery/light/directional/north,
+/obj/structure/sign/warning/electric_shock/directional/north,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "sql" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/dirt,
@@ -61793,12 +61909,6 @@
 /obj/effect/turf_decal/tile/dark_blue/opposingcorners,
 /turf/open/floor/iron/cafeteria,
 /area/station/maintenance/starboard/lesser)
-"srz" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "srB" = (
 /obj/machinery/camera/directional/west,
 /obj/effect/turf_decal/trimline/red/filled/line{
@@ -61982,15 +62092,12 @@
 	},
 /turf/open/openspace,
 /area/station/command/bridge)
-"stG" = (
-/obj/structure/chair/office,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/iron,
-/area/station/engineering/lobby)
+"stw" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "stR" = (
 /obj/effect/turf_decal/siding{
 	dir = 5
@@ -62009,15 +62116,6 @@
 	},
 /turf/open/floor/engine/hull/air,
 /area/station/medical/chemistry)
-"stX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/crystallizer{
-	dir = 4
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "stY" = (
 /obj/item/storage/box/lights/mixed,
 /obj/structure/cable,
@@ -62076,6 +62174,14 @@
 /obj/structure/window/reinforced/spawner/directional/east,
 /turf/open/floor/plating,
 /area/station/solars/starboard/aft)
+"svl" = (
+/obj/structure/chair/office,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "svp" = (
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/storage/eva)
@@ -62214,6 +62320,11 @@
 /obj/structure/transit_tube/diagonal,
 /turf/open/space/openspace,
 /area/space/nearstation)
+"sym" = (
+/obj/machinery/airalarm/directional/east,
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "syw" = (
 /obj/structure/flora/bush/pale/style_random,
 /obj/structure/flora/bush/fullgrass/style_random,
@@ -62289,12 +62400,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/command/gateway)
+"szA" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/directional/west,
+/obj/machinery/firealarm/directional/west,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "szK" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"szN" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/directional/east,
+/obj/machinery/firealarm/directional/east,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "sAa" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/wood,
@@ -62414,10 +62537,6 @@
 	dir = 8
 	},
 /area/station/service/library)
-"sCv" = (
-/obj/structure/cable/multilayer/multiz,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "sCx" = (
 /turf/open/openspace,
 /area/station/command/meeting_room/council)
@@ -62621,19 +62740,14 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
-"sFC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
-"sFF" = (
-/obj/item/trash/chips{
-	pixel_x = -2;
-	pixel_y = -4
+"sFH" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "sFI" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 8
@@ -62643,10 +62757,6 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/science/zoo)
-"sFO" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "sFQ" = (
 /obj/machinery/light/floor,
 /turf/open/floor/iron/textured_large,
@@ -62868,14 +62978,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
-"sIP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "sIR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -62923,10 +63025,6 @@
 	},
 /turf/open/floor/iron/checker,
 /area/station/ai_monitored/command/storage/satellite)
-"sJr" = (
-/obj/effect/turf_decal/box,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "sJv" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner{
 	dir = 8
@@ -63073,6 +63171,10 @@
 "sLY" = (
 /turf/open/floor/engine/hull/air,
 /area/station/command/meeting_room/council)
+"sMo" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "sMt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -63121,6 +63223,10 @@
 	dir = 1
 	},
 /area/station/ai_monitored/turret_protected/aisat/teleporter)
+"sNA" = (
+/obj/structure/cable,
+/turf/open/floor/iron/white,
+/area/station/engineering/atmos/upper)
 "sNC" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -63417,6 +63523,13 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"sRP" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "sRY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -63654,6 +63767,13 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/central)
+"sVn" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "sVq" = (
 /obj/machinery/door/airlock{
 	id_tag = "restroom_2";
@@ -63710,12 +63830,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/construction/storage_wing)
-"sWu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "sWI" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/wood,
@@ -63730,11 +63844,6 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"sWO" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/random/maintenance,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "sWV" = (
 /obj/structure/transit_tube/station/dispenser{
 	dir = 4
@@ -63781,6 +63890,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/supply)
+"sXm" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "sXq" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/security/execution/transfer)
@@ -64168,14 +64283,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/station/command/corporate_showroom)
-"tef" = (
-/obj/item/clothing/head/utility/welding{
-	pixel_x = -9;
-	pixel_y = 4
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "tel" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/drone{
@@ -64340,13 +64447,6 @@
 "tgV" = (
 /turf/open/floor/carpet,
 /area/station/service/chapel)
-"tgX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "thb" = (
 /obj/effect/turf_decal/trimline/yellow/line{
 	dir = 4
@@ -64408,6 +64508,12 @@
 /obj/item/stock_parts/power_store/cell/high,
 /turf/open/floor/engine,
 /area/station/engineering/main)
+"thy" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "thz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -64979,12 +65085,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
-"tqG" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/construction,
-/obj/effect/mapping_helpers/airlock/unres,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "tqQ" = (
 /turf/open/floor/iron/dark,
 /area/station/commons/dorms)
@@ -65057,6 +65157,11 @@
 	target_pressure = 350
 	},
 /turf/open/openspace,
+/area/station/engineering/atmos/upper)
+"tsU" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/bluespace_sender,
+/turf/open/floor/engine/hull/reinforced/air,
 /area/station/engineering/atmos/upper)
 "ttj" = (
 /turf/open/floor/iron,
@@ -65561,6 +65666,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/cryo)
+"tBn" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "tBo" = (
 /obj/effect/turf_decal/siding/green{
 	dir = 4
@@ -65614,10 +65725,6 @@
 	dir = 1
 	},
 /area/station/cargo/bitrunning/den)
-"tCc" = (
-/obj/effect/spawner/random/structure/tank_holder,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "tCf" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -65789,15 +65896,6 @@
 /obj/structure/cable,
 /turf/closed/wall/r_wall,
 /area/station/medical/virology)
-"tEj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "tEl" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/engine/hull/air,
@@ -66415,12 +66513,6 @@
 "tNW" = (
 /turf/closed/wall/r_wall,
 /area/station/command/teleporter)
-"tNX" = (
-/obj/effect/decal/cleanable/glass,
-/obj/structure/cable,
-/obj/machinery/power/apc/auto_name/directional/north,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "tOg" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/yellow/visible,
@@ -66467,6 +66559,21 @@
 "tPe" = (
 /turf/open/floor/glass/reinforced/plasma,
 /area/station/engineering/supermatter)
+"tPq" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 9
+	},
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "tPr" = (
 /obj/structure/table_frame/wood,
 /turf/open/floor/iron/grimy,
@@ -66581,6 +66688,15 @@
 /obj/structure/cable/layer3,
 /turf/open/floor/iron/dark/textured_large,
 /area/station/ai_monitored/turret_protected/aisat/foyer)
+"tRe" = (
+/obj/effect/spawner/random/trash/graffiti{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/main)
 "tRi" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -66993,6 +67109,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"tXl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "tXs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable,
@@ -67178,6 +67298,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"tZg" = (
+/obj/machinery/atmospherics/components/binary/crystallizer{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "tZj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -67208,6 +67334,10 @@
 /obj/structure/window/spawner/directional/north,
 /turf/open/floor/plating,
 /area/station/service/kitchen/abandoned)
+"tZP" = (
+/obj/structure/cable/multilayer/multiz,
+/turf/open/floor/plating,
+/area/station/engineering/break_room)
 "tZU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
@@ -67240,6 +67370,15 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/iron/textured_large,
 /area/space/nearstation)
+"uar" = (
+/obj/structure/cable,
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "uaz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -67285,18 +67424,6 @@
 /obj/effect/spawner/random/engineering/atmospherics_portable,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"ubp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "ubs" = (
 /turf/open/openspace,
 /area/station/hallway/secondary/construction)
@@ -67386,6 +67513,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
+"ucW" = (
+/obj/machinery/camera/autoname/directional/east,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/directional/east,
+/obj/machinery/airalarm/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "ucX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 6
@@ -67401,10 +67535,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"udi" = (
-/obj/machinery/airalarm/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/engineering/atmos/upper)
 "udl" = (
 /turf/closed/wall,
 /area/station/engineering/storage/tech)
@@ -67414,11 +67544,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/service/abandoned_gambling_den)
-"udy" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "udE" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner{
@@ -67497,6 +67622,13 @@
 /obj/machinery/light_switch/directional/south,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
+"uff" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "ufi" = (
 /obj/machinery/door/airlock/command{
 	name = "Research Director's Office"
@@ -67662,10 +67794,6 @@
 /obj/effect/turf_decal/tile/purple/opposingcorners,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/fore)
-"uhv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "uhx" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
@@ -67852,6 +67980,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/starboard/fore)
+"uks" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "ukt" = (
 /obj/structure/railing{
 	dir = 9
@@ -67958,12 +68093,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"ulK" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "ulM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68506,6 +68635,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
+"usS" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/firealarm/directional/west,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "uta" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
@@ -68601,12 +68740,6 @@
 	},
 /turf/open/openspace,
 /area/station/construction/storage_wing)
-"uug" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "uuj" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner,
@@ -68777,6 +68910,11 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/wood/large,
 /area/station/hallway/secondary/service)
+"uwn" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "uwu" = (
 /obj/machinery/shower/directional/east,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -68986,6 +69124,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics)
+"uyi" = (
+/obj/effect/turf_decal/bot,
+/obj/item/radio/intercom/directional/south,
+/turf/closed/wall/r_wall,
+/area/station/engineering/main)
 "uyn" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -69001,12 +69144,6 @@
 	},
 /turf/open/floor/glass,
 /area/station/maintenance/starboard/fore)
-"uyE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/engine/hull,
-/area/space/nearstation)
 "uyN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -69724,17 +69861,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/port)
-"uJj" = (
-/obj/structure/broken_flooring/singular/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/engine_smes)
 "uJs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/holopad,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/office)
+"uJv" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix/inverse,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "uJw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -69946,9 +70081,6 @@
 	},
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/ordnance/storage)
-"uLG" = (
-/turf/closed/wall/r_wall,
-/area/station/maintenance/department/engine)
 "uLL" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -69997,6 +70129,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"uNc" = (
+/obj/machinery/light/directional/west,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "uNl" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 8
@@ -70017,15 +70153,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
-"uNt" = (
-/obj/structure/cable,
-/obj/machinery/door/airlock/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron,
-/area/station/engineering/main)
 "uND" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -70135,12 +70262,6 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/starboard/lesser)
-"uPB" = (
-/obj/item/cigbutt,
-/obj/effect/decal/cleanable/glass,
-/obj/structure/frame/computer,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "uPL" = (
 /obj/item/controller,
 /obj/item/compact_remote,
@@ -70333,6 +70454,37 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"uTj" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/power_store/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/item/clothing/glasses/meson/engine{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/meson/engine{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/meson/engine{
+	pixel_y = 4
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_y = 8
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "uTy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair,
@@ -70788,13 +70940,6 @@
 	},
 /turf/open/openspace,
 /area/station/engineering/atmos/upper)
-"vbU" = (
-/obj/structure/cable/multilayer/multiz,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "vbV" = (
 /obj/machinery/status_display/ai/directional/north,
 /turf/open/openspace,
@@ -70996,10 +71141,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/main)
-"veL" = (
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "veQ" = (
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
@@ -71422,15 +71563,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"vkP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "vkQ" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase/secure{
@@ -71644,14 +71776,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/textured_large,
 /area/station/security/prison)
-"vnu" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/railing/corner/end,
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "vnz" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
@@ -71665,13 +71789,6 @@
 "vnR" = (
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/xenobiology)
-"vnS" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable,
-/turf/open/floor/iron/dark/textured,
-/area/station/engineering/supermatter/room)
 "vnV" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L12"
@@ -72242,10 +72359,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
-"vwU" = (
-/obj/structure/girder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "vxc" = (
 /obj/machinery/door/airlock/security{
 	name = "Courtroom Cell"
@@ -72277,22 +72390,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
-"vya" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/obj/item/pipe_dispenser{
-	pixel_y = 8
-	},
-/obj/item/pipe_dispenser{
-	pixel_y = 8
-	},
-/obj/item/pipe_dispenser{
-	pixel_y = 8
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "vyt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -72763,6 +72860,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"vEJ" = (
+/obj/structure/cable,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/break_room)
 "vEU" = (
 /obj/machinery/skill_station,
 /obj/machinery/airalarm/directional/north,
@@ -72868,10 +72969,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/starboard/aft)
-"vGm" = (
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "vGr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner,
@@ -72946,6 +73043,26 @@
 /obj/machinery/air_sensor,
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
+"vHK" = (
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/pipe_dispenser{
+	pixel_y = 8
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 8
+	},
+/obj/item/pipe_dispenser{
+	pixel_y = 8
+	},
+/obj/structure/table,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/obj/structure/sign/poster/random/directional/north,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "vHO" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73010,14 +73127,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/research)
-"vID" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "vJe" = (
 /obj/structure/chair,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -73159,6 +73268,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/security/execution/education)
+"vLv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "vLx" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -73360,6 +73476,10 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
+"vNY" = (
+/obj/machinery/light/directional/south,
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "vOg" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -73402,16 +73522,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/sepia,
 /area/station/hallway/secondary/construction)
-"vOR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "vPp" = (
 /obj/machinery/microwave,
 /turf/open/floor/plating,
@@ -73760,6 +73870,11 @@
 /obj/effect/turf_decal/tile/brown/full,
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/lesser)
+"vTC" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/closet/firecloset,
+/turf/open/floor/iron,
+/area/station/engineering/engine_smes)
 "vTE" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/plating,
@@ -73794,6 +73909,10 @@
 /obj/effect/landmark/start/hangover,
 /turf/open/floor/wood,
 /area/station/service/chapel)
+"vUO" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/plating,
+/area/station/engineering/break_room)
 "vUQ" = (
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/structure/table/wood,
@@ -74119,11 +74238,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/service/janitor)
-"wbe" = (
-/obj/structure/ladder,
-/obj/structure/lattice/catwalk,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "wbf" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -74288,6 +74402,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
+"wdS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "web" = (
 /obj/effect/turf_decal/trimline/brown/filled/warning{
 	dir = 4
@@ -74989,6 +75109,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
+"wnb" = (
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/unres{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/station/engineering/break_room)
 "wng" = (
 /obj/docking_port/stationary{
 	dheight = 4;
@@ -75108,10 +75237,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/science/xenobiology)
-"woF" = (
-/obj/effect/decal/cleanable/glass,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "woP" = (
 /obj/structure/reagent_dispensers/foamtank,
 /obj/effect/turf_decal/bot,
@@ -75173,6 +75298,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"wpK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable,
+/turf/open/floor/engine/hull/reinforced/air,
+/area/station/engineering/atmos/upper)
 "wpW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/red/dim/directional/north,
@@ -75203,12 +75335,6 @@
 /obj/effect/turf_decal/trimline/green/filled/mid_joiner,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/service/hydroponics)
-"wqw" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "wqB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -75269,12 +75395,6 @@
 	dir = 1
 	},
 /area/station/science/ordnance/storage)
-"wrh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "wrs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible,
 /turf/open/floor/iron/dark,
@@ -75429,10 +75549,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"wtK" = (
-/obj/structure/frame,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "wtO" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -75762,15 +75878,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
+"wyz" = (
+/turf/open/floor/eighties,
+/area/station/engineering/break_room)
 "wyF" = (
 /obj/structure/flora/tree/palm/style_random,
 /turf/open/floor/iron/vaporwave,
 /area/station/maintenance/starboard/lesser)
-"wyZ" = (
-/obj/effect/decal/cleanable/glass,
-/obj/item/shard,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "wzj" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
@@ -75866,12 +75980,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/greater)
-"wAH" = (
-/obj/machinery/atmospherics/pipe/color_adapter{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "wAO" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/storage/toolbox/mechanical/old,
@@ -76073,6 +76181,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/commons/dorms)
+"wEs" = (
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/iron,
+/area/station/engineering/lobby)
 "wEt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/crate_loot,
@@ -76787,13 +76901,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/iron/white/textured,
 /area/station/medical/surgery)
-"wPh" = (
-/obj/item/trash/can{
-	pixel_x = 13;
-	pixel_y = -6
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "wPl" = (
 /obj/effect/decal/cleanable/blood/oil/slippery,
 /turf/open/floor/iron/dark/smooth_large,
@@ -76957,12 +77064,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/openspace,
 /area/station/engineering/atmos/upper)
-"wRV" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/iron/smooth,
-/area/station/engineering/main)
 "wSa" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 1
@@ -77352,11 +77453,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
-"wXQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "wXU" = (
 /obj/item/bedsheet/captain,
 /obj/structure/bed,
@@ -77865,11 +77961,6 @@
 /obj/effect/turf_decal/tile/brown/full,
 /turf/open/floor/iron/large,
 /area/station/maintenance/starboard/lesser)
-"xfn" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/structure/cable,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "xfq" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/yellow/opposingcorners{
@@ -78119,6 +78210,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
+"xkl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "xkn" = (
 /obj/structure/railing/corner,
 /obj/structure/cable,
@@ -78289,10 +78387,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/ordnance)
-"xnO" = (
-/obj/item/cigbutt,
-/turf/open/floor/iron,
-/area/station/maintenance/department/engine)
 "xnP" = (
 /obj/effect/turf_decal/siding/wood/end{
 	dir = 8
@@ -78306,10 +78400,6 @@
 	},
 /turf/open/floor/wood/tile,
 /area/station/science/robotics)
-"xnT" = (
-/obj/item/trash/candy,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "xnU" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -78726,6 +78816,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"xub" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 8
+	},
+/obj/structure/railing/corner,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "xut" = (
 /turf/closed/wall,
 /area/station/service/abandoned_gambling_den)
@@ -78750,13 +78850,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/purple/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos/upper)
-"xuJ" = (
-/obj/item/trash/pistachios{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "xuP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -79036,14 +79129,6 @@
 "xAu" = (
 /turf/closed/wall,
 /area/station/medical/chemistry)
-"xAF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "xAN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/blue/full,
@@ -79111,6 +79196,14 @@
 	},
 /turf/open/floor/carpet,
 /area/station/service/chapel/office)
+"xBQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/railing{
+	dir = 9
+	},
+/obj/structure/cable/multilayer/multiz,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "xBZ" = (
 /obj/effect/turf_decal/siding/dark{
 	dir = 8
@@ -79262,6 +79355,15 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/station/science/genetics)
+"xDL" = (
+/obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
+	dir = 8
+	},
+/obj/structure/tank_dispenser{
+	pixel_x = -1
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "xDM" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
@@ -79337,6 +79439,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"xEv" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 5
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "xEB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -79515,12 +79623,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
-"xGR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "xGU" = (
 /obj/structure/table/reinforced,
 /obj/item/tank/internals/oxygen,
@@ -79657,6 +79759,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"xJN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 4
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "xJV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/firecloset,
@@ -79718,12 +79827,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/station/medical/virology)
-"xKI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/engine_smes)
 "xKQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -79759,6 +79862,13 @@
 /obj/structure/sign/poster/abductor/ayy_cops,
 /turf/closed/wall,
 /area/station/maintenance/port)
+"xLN" = (
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/iron/smooth,
+/area/station/engineering/break_room)
 "xLQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
@@ -80110,15 +80220,6 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
-"xRP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/generic,
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/bot,
-/obj/item/radio/intercom/directional/north,
-/obj/machinery/light_switch/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/engine_smes)
 "xRR" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
@@ -80267,17 +80368,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"xTK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/north,
-/obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/main)
 "xTT" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/disposal/bin,
@@ -80602,10 +80692,6 @@
 /obj/structure/broken_flooring/singular/always_floorplane/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
-"xXO" = (
-/obj/structure/ladder,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "xXQ" = (
 /obj/item/toy/plush/moth{
 	name = "Spanner 2, her sibling";
@@ -80767,12 +80853,6 @@
 /obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
 /turf/open/floor/iron/large,
 /area/station/hallway/primary/central)
-"yan" = (
-/obj/structure/broken_flooring/corner/directional/south,
-/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "yav" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/engine/hull/air,
@@ -80868,11 +80948,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/space_hut)
-"ybM" = (
-/obj/structure/broken_flooring/pile/directional/east,
-/obj/effect/mapping_helpers/broken_floor,
-/turf/open/floor/plating,
-/area/station/maintenance/department/engine)
 "ybO" = (
 /obj/structure/rack,
 /obj/structure/window/reinforced/spawner/directional/north{
@@ -80991,21 +81066,10 @@
 	},
 /turf/open/floor/carpet,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"ycL" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "ycM" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"yda" = (
-/obj/structure/broken_flooring/singular/directional/east,
-/obj/item/cigbutt,
-/turf/open/floor/engine/hull/reinforced/air,
-/area/station/maintenance/department/engine)
 "ydo" = (
 /obj/structure/railing/corner/end{
 	dir = 8
@@ -81066,11 +81130,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/fore)
-"yen" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/ladder,
-/turf/open/openspace,
-/area/station/maintenance/department/engine)
 "yer" = (
 /turf/open/openspace,
 /area/station/science/genetics)
@@ -81130,6 +81189,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/herringbone,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"yeQ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/project)
 "yeT" = (
 /obj/structure/cable,
 /obj/structure/lattice/catwalk,
@@ -81353,6 +81418,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/maintenance/starboard/lesser)
+"yiM" = (
+/obj/structure/cable,
+/obj/machinery/power/apc/auto_name/directional/north,
+/turf/open/floor/iron/dark,
+/area/station/engineering/atmos/upper)
 "yiP" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/white/textured_half,
@@ -122466,7 +122536,7 @@ pRi
 obz
 nxD
 jSf
-cOY
+pFF
 woP
 fJL
 jAH
@@ -122955,18 +123025,18 @@ dcE
 kOx
 dcE
 dcE
-lNP
-jqT
-lNP
-lNP
-rMr
-lNP
-lNP
-uLG
-uLG
+ngH
+wnb
+ngH
+ngH
+giv
+ngH
+ngH
+jSf
+jSf
 jSf
 eCn
-oUo
+uyi
 jSf
 qWL
 pvp
@@ -123211,20 +123281,20 @@ dcE
 dcE
 kOx
 heR
-lNP
-lNP
-hXL
-lNP
-sFO
-xnO
-khf
-khf
-khf
-bJH
-uNt
-ePz
-bXP
-qCV
+ngH
+ngH
+eDt
+uks
+usS
+fEt
+jdz
+kIJ
+iIC
+ayL
+pNo
+lsV
+fmR
+tPq
 ouD
 caM
 vMf
@@ -123247,7 +123317,7 @@ sUC
 lsc
 jrx
 rIU
-iCY
+wEs
 tPR
 nlv
 vCG
@@ -123468,31 +123538,31 @@ dcE
 dcE
 kOx
 dcE
-mVS
-iPg
-pFR
-lNP
-sWO
-bbK
-khf
-oyP
-ehR
-ehR
+vUO
+aof
+ndc
+mqx
+tZP
+vEJ
+vEJ
+smY
+jSf
+jSf
 jSf
 dgu
 dHc
-ioy
-iDP
+rAP
+hHC
 wrQ
 wrQ
 wrQ
-wRV
-uhv
-uhv
-uhv
-iOm
-uhv
-fKW
+dxu
+iOI
+iOI
+iOI
+kJm
+iOI
+nXv
 iUJ
 fWH
 jSf
@@ -123725,31 +123795,31 @@ dcE
 dcE
 kOx
 dcE
-mVS
-oyP
-lNP
-lNP
-erK
-oyP
-khf
-gOp
-rlX
+vUO
+uff
+jrh
+mqx
+mje
+jrh
+mOn
+lby
+mAD
 clr
 clr
 akV
 jSf
-fQU
-cEZ
-mEN
-euH
-euH
-lfp
-agj
+bfM
+qBN
 wOw
-mst
-mLW
 wOw
-pzH
+wOw
+wOw
+wOw
+wOw
+wOw
+glw
+wOw
+qni
 aat
 lWI
 oxn
@@ -123759,7 +123829,7 @@ qIY
 dSD
 tVv
 xRj
-stG
+svl
 qAy
 wXn
 uvz
@@ -123982,35 +124052,35 @@ dcE
 dcE
 kOx
 dcE
-mVS
-oyP
-sFF
-lNP
-tNX
-tef
-khf
-bbK
-ehR
+vUO
+ope
+jXy
+mqx
+cmW
+mlJ
+mlJ
+smY
+pvp
 clr
 qiI
 cwT
 pvp
-xTK
+gPD
+mXR
+hSt
+nCN
+hSt
+hSt
+hSt
+dXl
 hBv
-bch
-qKJ
-qof
-vkP
-qof
-sIP
-hBv
-bVt
+iKM
 mfG
-xAF
+nCb
 dfI
 pSh
 nLQ
-iXm
+ogq
 vja
 nLX
 uAl
@@ -124239,31 +124309,31 @@ dcE
 dcE
 kOx
 heR
-lNP
-lNP
-oyP
-lDW
-uPB
-oyP
-khf
-rnr
-ehR
+ngH
+ngH
+kOU
+bVD
+dqd
+eKa
+mOn
+smY
+jSf
 bck
 clr
 bct
 xdR
 cBn
-oRw
+nXv
 xrn
-lRK
-utf
-epF
-vya
-wqw
-oHB
-wqw
 bdE
-wqw
+utf
+wrQ
+wrQ
+beI
+wrQ
+beI
+bdE
+beI
 wrQ
 cqm
 pCb
@@ -124274,7 +124344,7 @@ rct
 lTe
 fjy
 fBX
-bfL
+tBn
 mwk
 tQq
 bAW
@@ -124497,30 +124567,30 @@ dcE
 kOx
 dcE
 dcE
-lNP
-hXL
-lDW
-woF
-oyP
-ulK
-xXO
-ehR
+ngH
+vHK
+jrh
+mqx
+kRe
+hmR
+smY
 jSf
 jSf
 jSf
 jSf
-vOR
-oRw
-oRw
-oRw
-iec
-oRw
+jSf
+gUg
+dxu
+pPr
+iOI
+iOI
+nXv
 wrQ
-wqw
+beI
 uBp
-wqw
+beI
 bdE
-bdH
+tRe
 qFt
 eNk
 pCb
@@ -124753,15 +124823,15 @@ dcE
 dcE
 kOx
 heR
-lNP
-lNP
-eso
-lNP
-oyP
-bbK
-ulK
-oyP
-rlX
+ngH
+ngH
+xLN
+dab
+mqx
+eKa
+mOn
+smY
+mAD
 bww
 bww
 cOU
@@ -124779,7 +124849,7 @@ qBn
 xbQ
 vRm
 keB
-ouF
+apc
 pCb
 qRc
 kfG
@@ -125010,24 +125080,24 @@ dcE
 dcE
 kOx
 dcE
-mVS
-hXL
-rpt
-lNP
-cet
-bbK
-khf
-fmQ
-ehR
+vUO
+dOn
+ndc
+jrh
+dEr
+thy
+mOn
+smY
+pvp
 bww
 nWL
 cPa
 pvp
 uJw
-tEj
-tgX
-fBp
-wAH
+bUD
+pUs
+cGu
+ign
 rxH
 mmN
 rxH
@@ -125267,24 +125337,24 @@ dcE
 dcE
 kOx
 dcE
-mVS
-lvx
-lNP
-lNP
-oyP
-oyP
-khf
-oyP
-ehR
+vUO
+bgi
+jrh
+fRh
+hcT
+kHO
+mOn
+smY
+jSf
 neI
 bww
 cTQ
 xdR
-dmq
-ahT
-bAG
-ihQ
-uug
+byS
+cYg
+uJv
+wdS
+rxH
 rxH
 eKk
 oUa
@@ -125293,7 +125363,7 @@ rxH
 rxH
 rGv
 gvc
-udy
+meh
 pCb
 ybg
 rLE
@@ -125524,23 +125594,23 @@ dcE
 dcE
 kOx
 dcE
-mVS
-oyP
-xnT
-lNP
-oyP
-oyP
-mRj
-wyZ
-ehR
+vUO
+cio
+jXy
+jrh
+xub
+cCZ
+mOn
+smY
+jSf
 jSf
 jSf
 jSf
 jSf
 mFg
-aua
-kUm
-rBz
+rxH
+rxH
+fmw
 aup
 rxH
 hDq
@@ -125550,7 +125620,7 @@ tqs
 ita
 frg
 iyG
-xfn
+bhF
 pCb
 qMm
 xOD
@@ -125781,23 +125851,23 @@ dcE
 dcE
 kOx
 heR
-lNP
-lNP
-hXL
-tqG
-oyP
-oyP
-mRj
-oyP
-gyO
+ngH
+ngH
+cSz
+jrh
+mqx
+cIf
+mOn
+lby
+bMT
 bGv
 bGv
 cWI
 pvb
 dwv
+tXl
+tXl
 rBz
-rxH
-rxH
 eaV
 gXJ
 xBE
@@ -126039,14 +126109,14 @@ dcE
 kOx
 dcE
 dcE
-lNP
-hXL
-lNP
-wtK
-oyP
-khf
-oyP
-ehR
+ngH
+uTj
+jrh
+mqx
+kRe
+mOn
+smY
+pvp
 bGv
 ubf
 eCN
@@ -126064,7 +126134,7 @@ tvR
 nYD
 umy
 pNQ
-pTa
+qzJ
 pCb
 pCb
 wSZ
@@ -126295,15 +126365,15 @@ dcE
 dcE
 kOx
 heR
-lNP
-lNP
-aKY
-lDW
-sCv
-veL
-khf
-vwU
-ehR
+ngH
+ngH
+aGD
+dab
+mqx
+cIf
+ewW
+smY
+jSf
 eCW
 bGv
 vqS
@@ -126552,18 +126622,18 @@ dcE
 dcE
 kOx
 dcE
-mVS
-hXL
-wPh
-lNP
-xXO
-oyP
-jSJ
-oyP
-ehR
-ehR
-ehR
-ehR
+vUO
+sVn
+ndc
+jrh
+dEr
+thy
+mOn
+smY
+jSf
+jSf
+jSf
+jSf
 jSf
 oHa
 bSO
@@ -126809,19 +126879,19 @@ dcE
 dcE
 kOx
 dcE
-mVS
-oyP
-lNP
-lNP
-yan
-jSJ
-jSJ
-oyP
+vUO
+mSm
+jrh
+fRh
+hcT
+kHO
+mOn
+smY
 xqs
 fHs
-kmd
+vTC
 ivS
-xqs
+cDf
 vDA
 rxH
 gKq
@@ -127066,19 +127136,19 @@ dcE
 dcE
 kOx
 dcE
-mVS
-xuJ
-hXL
-lNP
-hyX
-ybM
-wXQ
-wXQ
-csp
-sji
-hXP
-oKT
-ycz
+vUO
+vLv
+jXy
+jrh
+hCv
+jrh
+dLl
+smY
+bvy
+rUZ
+gJL
+hgd
+sFH
 gWx
 hiW
 mco
@@ -127323,19 +127393,19 @@ dcE
 dcE
 kOx
 heR
-lNP
-lNP
-oyP
-lDW
-gPv
-xnO
-oyP
-vwU
-cDf
-uJj
-ieI
-qAZ
-ycz
+ngH
+ngH
+afo
+wyz
+lJd
+mje
+mOn
+smY
+xqs
+rUZ
+jYr
+oZm
+xqs
 njF
 hra
 rHM
@@ -127581,18 +127651,18 @@ dcE
 kOx
 dcE
 dcE
-lNP
-aVU
-lDW
-gSC
-rQn
-oyP
-oyP
-xqs
-bZY
-vbU
-srz
-rzO
+ngH
+gbS
+wyz
+lOZ
+jrh
+pdD
+smY
+qfy
+xkl
+qlz
+fUc
+uar
 gqU
 hAQ
 wUW
@@ -127838,17 +127908,17 @@ dcE
 kOx
 kOx
 dcE
-lNP
-rSN
-lNP
-rvQ
-gFy
-erK
-oyP
+ngH
+bVG
+bVG
+pSJ
+avg
+iQY
+jrh
 xqs
-xRP
-jne
-tCc
+dox
+ryw
+rUZ
 xqs
 shr
 ghB
@@ -128095,17 +128165,17 @@ dcE
 dcE
 dcE
 dcE
-lNP
-lNP
-lNP
-lNP
-lNP
-lNP
-lNP
-ddM
-ddM
-ddM
-ddM
+ngH
+ngH
+ngH
+ngH
+ngH
+ngH
+ngH
+xqs
+xqs
+xqs
+xqs
 xqs
 eaV
 eaV
@@ -128370,7 +128440,7 @@ oJp
 eaV
 sHd
 nIQ
-vnS
+sgS
 mwJ
 mwJ
 unz
@@ -128624,7 +128694,7 @@ xXv
 heR
 bWY
 ilR
-drc
+ipc
 kLD
 uHZ
 nlt
@@ -128632,7 +128702,7 @@ xtQ
 ezq
 uHZ
 xXV
-drc
+ipc
 tWn
 tWn
 dcE
@@ -128881,7 +128951,7 @@ xXv
 heR
 heR
 heR
-drc
+ipc
 sij
 sNC
 nlt
@@ -128889,7 +128959,7 @@ nlt
 nlt
 sNC
 ttQ
-drc
+ipc
 tWn
 dcE
 dcE
@@ -129138,7 +129208,7 @@ xXv
 kOx
 dcE
 dcE
-drc
+ipc
 sNC
 sNC
 kLD
@@ -129146,7 +129216,7 @@ nlt
 nlt
 sNC
 sNC
-drc
+ipc
 dcE
 dcE
 dcE
@@ -129395,15 +129465,15 @@ dcE
 kOx
 dcE
 dcE
-drc
+ipc
 sNC
 xPB
 nlt
 nlt
 nlt
-esg
+kLD
 sNC
-drc
+ipc
 dcE
 dcE
 dcE
@@ -129652,7 +129722,7 @@ dcE
 kOx
 dcE
 dcE
-drc
+ipc
 sNC
 kLD
 fsQ
@@ -129660,7 +129730,7 @@ nlt
 sxY
 kLD
 nWe
-drc
+ipc
 dcE
 dcE
 dcE
@@ -129909,7 +129979,7 @@ dcE
 kOx
 dcE
 dcE
-drc
+ipc
 tdx
 qWl
 nlt
@@ -129917,7 +129987,7 @@ xtQ
 kLD
 kLD
 nWe
-drc
+ipc
 dcE
 dcE
 dcE
@@ -130166,15 +130236,15 @@ dcE
 kOx
 dcE
 dcE
-drc
-drc
-drc
-drc
-drc
-drc
-drc
-drc
-drc
+ipc
+ipc
+ipc
+ipc
+ipc
+ipc
+ipc
+ipc
+ipc
 heR
 heR
 heR
@@ -164382,7 +164452,7 @@ nlm
 gRG
 cyb
 ujJ
-ftU
+phc
 vdh
 kbz
 gRG
@@ -188243,7 +188313,7 @@ xLY
 xLY
 xLY
 xLY
-uyE
+xLY
 xLY
 xLY
 eSu
@@ -188491,17 +188561,17 @@ nlm
 xIe
 nlm
 nlm
-cTR
-hRj
-lNP
-lNP
-mVS
-mVS
-mVS
-lNP
-mVS
-xGR
-lNP
+rqo
+kpc
+kpc
+rqo
+kpc
+kpc
+rqo
+mTz
+mTz
+mTz
+unl
 unl
 ayN
 mTz
@@ -188747,21 +188817,21 @@ nlm
 nlm
 xIe
 dDL
-oTm
-kmM
-hRj
-lNP
-kWC
-arP
-kWC
-kWC
-kWC
-kWC
-vID
-lVm
-unl
-dKQ
+rqo
+rqo
+ctC
+ctC
+szA
+ctC
+jQQ
+uwn
 ddN
+ddN
+ddN
+uNc
+ddN
+dKQ
+hPb
 naP
 bqQ
 eNx
@@ -189004,20 +189074,20 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-lNP
-kWC
-vGm
-kWC
-kWC
-oIA
-pHH
-hCT
-yda
-unl
-oWD
+kpc
+oBM
+ctC
+ctC
+xBQ
+sRP
+rMz
+eZV
+fEM
+wpK
+nBk
+wpK
+eHh
+eTb
 uNl
 dKo
 ffm
@@ -189261,22 +189331,22 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-lNP
-vGm
-ycL
-ycL
-ycL
-oEy
-dLy
-dLy
-unl
-unl
-cNV
-cuz
-ddN
+kpc
+oBM
+ctC
+ctC
+nPy
+nhU
+bmc
+ijs
+gJn
+xxv
+xxv
+xxv
+sMo
+kWt
+xDL
+aNj
 ddN
 cuz
 ddN
@@ -189518,22 +189588,22 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-lNP
-kWC
-ycL
-kWC
-kWC
-lRy
-lVm
-dLy
-unl
-hkq
+kpc
+oBM
+ctC
+ctC
+lEy
+nhU
+ijs
+ijs
+gJn
+xxv
+xxv
+xxv
+tsU
 qFI
 kCL
-hzs
+sNA
 laE
 xCr
 laE
@@ -189775,19 +189845,19 @@ nlm
 nlm
 xIe
 dDL
-pgw
-uDE
-hRj
-mVS
-kWC
-ycL
-kWC
-vGm
-lRy
-lVm
-ihZ
-qEq
-laE
+rqo
+rqo
+efP
+eZV
+eZV
+eZV
+ijs
+ijs
+gJn
+xxv
+xxv
+xxv
+sMo
 laE
 vMy
 cEX
@@ -190032,21 +190102,21 @@ nlm
 nlm
 xIe
 nlm
-nlm
-cTR
-hRj
-mVS
-kWC
-ycL
-kWC
-yen
-lRy
-lVm
-sFC
-unl
-hPb
-laE
-hOn
+dcE
+rqo
+ctC
+eZV
+ijs
+stw
+stw
+qaU
+gJn
+lYh
+lYh
+vNY
+kMh
+kaY
+ddN
 klR
 oLD
 hAJ
@@ -190289,19 +190359,19 @@ nlm
 nlm
 xIe
 dDL
-oTm
-kmM
-hRj
-mVS
-kWC
-ycL
-kWC
-vGm
-qbO
-lVm
-sFC
-unl
-unl
+rqo
+rqo
+cVW
+cOQ
+ijs
+riP
+riP
+riP
+gJn
+xxv
+xxv
+xxv
+sMo
 laE
 ddN
 wAf
@@ -190546,19 +190616,19 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-lNP
-kWC
-ycL
-kWC
-kWC
-ubp
-lVm
-lsj
-unl
-lVk
+kpc
+eDv
+ivQ
+omO
+ijs
+stw
+oXj
+riP
+gJn
+xxv
+xxv
+xxv
+sMo
 laE
 laE
 uoi
@@ -190803,20 +190873,20 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-lNP
-kWC
-ycL
-kWC
-kWC
-sla
-bWD
-wrh
-unl
-dHQ
-ddN
+kpc
+tZg
+eig
+yeQ
+ijs
+oXj
+oXj
+riP
+gJn
+xxv
+xxv
+xxv
+sMo
+laE
 ddN
 mgf
 xKm
@@ -191060,20 +191130,20 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-lNP
-kWC
-ycL
-kWC
-kWC
-stX
-sJr
-lVm
+kpc
+xJN
+eZI
+kZw
+ijs
+qmr
+oXj
+qaU
+gJn
+lYh
+lYh
+vNY
 unl
-qqN
-ddN
+yiM
 qUJ
 nQl
 xKm
@@ -191317,19 +191387,19 @@ nlm
 nlm
 xIe
 dDL
-pgw
-uDE
-hRj
-lNP
-kWC
-ycL
-kWC
-kWC
-hcB
-sWu
-iSN
-unl
-hzx
+rqo
+iVs
+njW
+lUK
+ijs
+oOM
+oXj
+riP
+gJn
+xxv
+xxv
+xxv
+sMo
 iYr
 jKe
 pDk
@@ -191575,18 +191645,18 @@ nlm
 xIe
 nlm
 nlm
-cTR
-hRj
-mVS
-kWC
-ycL
-kWC
-kWC
-mpP
-sWu
-iSN
-unl
-fuI
+rqo
+ctC
+ijs
+ijs
+xEv
+sXm
+qaU
+nSb
+xxv
+xxv
+xxv
+sMo
 jKe
 vZF
 luN
@@ -191831,19 +191901,19 @@ nlm
 nlm
 xIe
 dDL
-oTm
-kmM
-hRj
-mVS
-dTW
-vnu
-cxo
-kWC
-rrs
-lVm
-lVm
-unl
-dcR
+rqo
+rqo
+euS
+ijs
+ijs
+riP
+ijs
+omF
+gJn
+xxv
+xxv
+xxv
+drF
 jKe
 duw
 cTC
@@ -191855,7 +191925,7 @@ tPe
 tPe
 tPe
 xxv
-ccT
+lIB
 vbN
 vqa
 tjU
@@ -192088,19 +192158,19 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-mVS
-wbe
-ycL
-dsJ
+kpc
+oBM
+ctC
+ijs
+ijs
+ijs
+ijs
 xqs
-xKI
-eTx
-eTx
 xqs
-azJ
+xqs
+xqs
+xqs
+raM
 tsT
 vZF
 tvs
@@ -192112,7 +192182,7 @@ tPe
 tPe
 tPe
 xxv
-vkL
+eWp
 nNr
 vqa
 cFw
@@ -192345,14 +192415,14 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-lNP
-lTj
-hYj
-jQj
-wHc
+kpc
+oBM
+ctC
+ijs
+ijs
+ijs
+ijs
+dqJ
 xba
 bSq
 qNj
@@ -192369,7 +192439,7 @@ tAb
 tAb
 tAb
 vMh
-vkL
+eWp
 rfv
 bbn
 bsW
@@ -192602,13 +192672,13 @@ nlm
 nlm
 xIe
 nlm
-cTR
-hRj
-hRj
-lNP
-kWC
-mVV
-kWC
+kpc
+oBM
+ctC
+ctC
+ctC
+ctC
+alG
 dqJ
 jPK
 uKi
@@ -192859,19 +192929,19 @@ nlm
 nlm
 xIe
 dDL
-pgw
-uDE
-hRj
-lNP
-vGm
-mVV
-mVV
+rqo
+rqo
+ctC
+ctC
+ctC
+dCI
+agD
 pKg
 jsB
-iHg
+gmz
 bJI
 xqs
-lnM
+spT
 pLo
 vZF
 oQW
@@ -193117,18 +193187,18 @@ nlm
 xIe
 nlm
 nlm
-cTR
-hRj
-lNP
-kWC
-vGm
-kWC
+rqo
+ctC
+ctC
+szN
+ctC
+agD
 wHc
-rRf
-mDD
-pUh
+apF
+ucW
+fAL
 ycz
-ddN
+nzt
 vZF
 vZF
 oQW
@@ -193374,20 +193444,20 @@ nlm
 xIe
 xIe
 nlm
-cTR
-hRj
-lNP
-lNP
-mVS
-mVS
+rqo
+kpc
+kpc
+rqo
+kpc
+kpc
 xqs
 xqs
 xqs
 xqs
 xqs
-udi
+sym
 hKr
-cTU
+nqE
 pNK
 oQW
 oQW
@@ -194161,13 +194231,13 @@ xIe
 nlm
 nlm
 ydS
-bNX
+isw
 ovn
 bNX
 qGp
 bNX
 wIm
-rYz
+bEt
 ydS
 nlm
 nlm
@@ -194424,7 +194494,7 @@ ayg
 pDG
 tHd
 bNX
-mWq
+eAe
 ydS
 nlm
 nlm
@@ -194681,7 +194751,7 @@ gct
 ewI
 sUM
 bNX
-oMH
+iIQ
 bxd
 nlm
 nlm


### PR DESCRIPTION
Original PR: 91650
-----

## About The Pull Request

Catwalk, despite my initial dislike for it, has quickly grown on me. However, as someone who plays engi a lot, the biggest complaint is that it's cramped, and atmos has zero room to place pipes. This is despite there being a massive maints room to the north of engi. As such, this PR repurposes that area into an expanded atmos pipe-laying area (top floor), and a new equipment room (bottom floor.) As for the maints it replaces, the only thing of note was an arcade machine in the corner. Said arcade machine hasn't moved, and as such serves as the engi mini breakroom, complete with a microwave, donk vendor, and makings for screwdriver cocktails.

![Screenshot 2025-06-14 185718](https://github.com/user-attachments/assets/1dea74ea-eaeb-4199-a716-90e07214ca50)
![Screenshot 2025-06-14 185817](https://github.com/user-attachments/assets/5a687a4e-3c2a-4271-8776-77f909f3cbaa)


## Why It's Good For The Game

Atmos needs as much real estate to build in as chemistry for their piping, and despite the nearby rooms being empty, atmos on catwalk is cramped. Additionally, Catwalk's SM room has a LOT of stuff making it hard to work in (e.g. lockers, vendors. random tables in the middle of the room) so this moves much of that into a new area.

## Changelog
:cl: WebcomicArtist
map: The engineering staff has converted the maintenance north of catwalk's supermatter into a new gear storage room.
/:cl:
