### PR TITLE
[TG Mirror] Fixes nonhuman blood bloodpacks spawning non-blood blood [MDB IGNORE]

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -4,40 +4,25 @@
 	icon = 'icons/obj/medical/bloodpack.dmi'
 	icon_state = "bloodpack"
 	volume = 200
-	var/blood_type = null
-	var/unique_blood = null
-	var/labelled = FALSE
 	fill_icon_thresholds = list(10, 20, 30, 40, 50, 60, 70, 80, 90, 100)
+	var/blood_type = null
+	var/labelled = FALSE
 
 /obj/item/reagent_containers/blood/Initialize(mapload, vol)
 	. = ..()
-	if(blood_type != null)
-		reagents.add_reagent(unique_blood ? unique_blood : /datum/reagent/blood, 200, list("viruses"=null,"blood_DNA"=null,"blood_type"=get_blood_type(blood_type),"resistances"=null,"trace_chem"=null))
-		update_appearance()
+	if (!blood_type)
+		return
+	var/datum/blood_type/bloodtype = get_blood_type(blood_type)
+	reagents.add_reagent(bloodtype.reagent_type, volume, list("blood_type" = bloodtype, "blood_DNA" = bloodtype.dna_string), creation_callback = CALLBACK(src, PROC_REF(on_blood_created)))
 
-/// Handles updating the container when the reagents change.
-/obj/item/reagent_containers/blood/on_reagent_change(datum/reagents/holder, ...)
-	var/datum/reagent/blood/new_reagent = holder.has_reagent(/datum/reagent/blood)
-	if(new_reagent && new_reagent.data && new_reagent.data["blood_type"])
-		var/datum/blood_type/blood_type = new_reagent.data["blood_type"]
-		blood_type = blood_type.name
-	else if(holder.has_reagent(/datum/reagent/consumable/liquidelectricity))
-		blood_type = BLOOD_TYPE_ETHEREAL
-	else if(holder.has_reagent(/datum/reagent/lube))
-		blood_type = BLOOD_TYPE_SNAIL
-	else if(holder.has_reagent(/datum/reagent/water))
-		blood_type = BLOOD_TYPE_H2O
-	else if(holder.has_reagent(/datum/reagent/toxin/slimejelly))
-		blood_type = BLOOD_TYPE_TOX
-	else
-		blood_type = null
-	return ..()
+/obj/item/reagent_containers/blood/proc/on_blood_created(datum/reagent/new_blood)
+	new_blood.AddElement(/datum/element/blood_reagent, null, get_blood_type(blood_type))
+	update_appearance()
 
 /obj/item/reagent_containers/blood/update_name(updates)
 	. = ..()
-	if(labelled)
-		return
-	name = "blood pack[blood_type ? " - [blood_type]" : null]"
+	if(!labelled)
+		name = "blood pack[blood_type ? " - [blood_type]" : ""]"
 
 /obj/item/reagent_containers/blood/random
 	icon_state = "random_bloodpack"
@@ -70,11 +55,9 @@
 
 /obj/item/reagent_containers/blood/ethereal
 	blood_type = BLOOD_TYPE_ETHEREAL
-	unique_blood = /datum/reagent/consumable/liquidelectricity
 
 /obj/item/reagent_containers/blood/snail
 	blood_type = BLOOD_TYPE_SNAIL
-	unique_blood = /datum/reagent/lube
 
 /obj/item/reagent_containers/blood/snail/examine()
 	. = ..()
@@ -82,7 +65,6 @@
 
 /obj/item/reagent_containers/blood/podperson
 	blood_type = BLOOD_TYPE_H2O
-	unique_blood = /datum/reagent/water
 
 /obj/item/reagent_containers/blood/podperson/examine()
 	. = ..()
@@ -91,7 +73,6 @@
 // for slimepeople
 /obj/item/reagent_containers/blood/toxin
 	blood_type = BLOOD_TYPE_TOX
-	unique_blood = /datum/reagent/toxin/slimejelly
 
 /obj/item/reagent_containers/blood/toxin/examine()
 	. = ..()
@@ -100,22 +81,27 @@
 /obj/item/reagent_containers/blood/universal
 	blood_type = BLOOD_TYPE_UNIVERSAL
 
-/obj/item/reagent_containers/blood/attackby(obj/item/tool, mob/user, list/modifiers, list/attack_modifiers)
-	if (IS_WRITING_UTENSIL(tool))
-		if(!user.can_write(tool))
-			return
-		var/custom_label = tgui_input_text(user, "What would you like to label the blood pack?", "Blood Pack", name, max_length = MAX_NAME_LEN)
-		if(!user.can_perform_action(src))
-			return
-		if(user.get_active_held_item() != tool)
-			return
-		if(custom_label)
-			labelled = TRUE
-			name = "blood pack - [custom_label]"
-			playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
-			balloon_alert(user, "new label set")
-		else
-			labelled = FALSE
-			update_name()
-	else
-		return ..()
+/obj/item/reagent_containers/blood/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!IS_WRITING_UTENSIL(tool))
+		return NONE
+
+	if(!user.can_write(tool))
+		return ITEM_INTERACT_BLOCKING
+
+	var/custom_label = tgui_input_text(user, "What would you like to label the blood pack?", "Blood Pack", name, max_length = MAX_NAME_LEN)
+	if(!user.can_perform_action(src))
+		return ITEM_INTERACT_BLOCKING
+
+	if(user.get_active_held_item() != tool)
+		return ITEM_INTERACT_BLOCKING
+
+	if(!custom_label)
+		labelled = FALSE
+		update_name()
+		return ITEM_INTERACT_SUCCESS
+
+	labelled = TRUE
+	name = "blood pack - [custom_label]"
+	playsound(src, SFX_WRITING_PEN, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE, SOUND_FALLOFF_EXPONENT + 3, ignore_walls = FALSE)
+	balloon_alert(user, "new label set")
+	return ITEM_INTERACT_SUCCESS


### PR DESCRIPTION
Original PR: 92063
-----
## About The Pull Request

Blood pack code is abyssmal and I somehow missed it during my refactor. Refactored how they spawn blood which should fix it not actually doing anything when splashed/used in reactions, and also lizard blood not getting its green color.

- Closes #92008

## Changelog
:cl:
fix: Fixed lizard blood bloodpacks being red instead of green
refactor: Refactored blood packs
/:cl:
