### PR TITLE
[TG Mirror] Fix hard delete related to colossus final attack [MDB IGNORE]

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -92,6 +92,7 @@
 	random_shots = null
 	shotgun_blast = null
 	dir_shots = null
+	colossus_final = null
 	return ..()
 
 /mob/living/simple_animal/hostile/megafauna/colossus/OpenFire()


### PR DESCRIPTION
Original PR: 92047
-----
## About The Pull Request

The ref holding the cooldown action for colossus "Titan's Finale" is never nulled in `Destroy` which leads to it hard deleting

closes #87781 
c;pses #89643

## Why It's Good For The Game

Fixes hard delete

## Changelog

N/A
