### PR TITLE
[TG Mirror] Material sheets show their proper amounts on crate manifests [MDB IGNORE]

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -141,8 +141,12 @@
 	manifest_text += "Contents: <br/>"
 	manifest_text += "<ul>"
 	var/container_contents = list() // Associative list with the format (item_name = nº of occurrences, ...)
-	for(var/atom/movable/AM in container.contents - manifest_paper)
-		container_contents[AM.name]++
+	for(var/obj/item/stuff in container.contents - manifest_paper)
+		if(isstack(stuff))
+			var/obj/item/stack/thing = stuff
+			container_contents[thing.singular_name] += thing.amount
+			continue
+		container_contents[stuff.name]++
 	if((manifest_paper.errors & MANIFEST_ERROR_CONTENTS) && container_contents)
 		if(HAS_TRAIT(container, TRAIT_NO_MANIFEST_CONTENTS_ERROR))
 			manifest_paper.errors &= ~MANIFEST_ERROR_CONTENTS
@@ -150,7 +154,7 @@
 			for(var/iteration in 1 to rand(1, round(container.contents.len * 0.5))) // Remove anywhere from one to half of the items
 				var/missing_item = pick(container_contents)
 				container_contents[missing_item]--
-				if(container_contents[missing_item] == 0) // To avoid 0s and negative values on the manifest
+				if(!container_contents[missing_item]) // To avoid 0s and negative values on the manifest
 					container_contents -= missing_item
 
 


### PR DESCRIPTION
Original PR: 92033
-----
## About The Pull Request
- Fixes #76802

![Screenshot (493)](https://github.com/user-attachments/assets/dbf03ab9-38a4-48e3-8067-f1a20da63cbf)

## Changelog
:cl:
fix: material sheets show their proper amounts on crate manifests
/:cl:

