### PR TITLE
[TG Mirror] Refactors a large chunk of xenobio console code. [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_xeno_control.dm
+++ b/code/__DEFINES/dcs/signals/signals_xeno_control.dm
@@ -1,6 +1,0 @@
-//Xenobio hotkeys
-
-///from slime ShiftClickOn(): (/mob)
-#define COMSIG_XENO_SLIME_CLICK_SHIFT "xeno_slime_click_shift"
-///from turf ShiftClickOn(): (/mob)
-#define COMSIG_XENO_TURF_CLICK_SHIFT "xeno_turf_click_shift"

--- a/code/modules/food_and_drinks/machinery/monkeyrecycler.dm
+++ b/code/modules/food_and_drinks/machinery/monkeyrecycler.dm
@@ -12,7 +12,6 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 
 	var/stored_matter = 0
 	var/cube_production = 0.2
-	var/list/connected = list() //Keeps track of connected xenobio consoles, for deletion in /Destroy()
 
 /obj/machinery/monkey_recycler/Initialize(mapload)
 	. = ..()
@@ -22,10 +21,6 @@ GLOBAL_LIST_EMPTY(monkey_recyclers)
 
 /obj/machinery/monkey_recycler/Destroy()
 	GLOB.monkey_recyclers -= src
-	for(var/thing in connected)
-		var/obj/machinery/computer/camera_advanced/xenobio/console = thing
-		console.connected_recycler = null
-	connected.Cut()
 	return ..()
 
 /obj/machinery/monkey_recycler/RefreshParts() //Ranges from 0.2 to 0.8 per monkey recycled

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -31,23 +31,23 @@
 	networks = list(CAMERANET_NETWORK_SS13)
 	circuit = /obj/item/circuitboard/computer/xenobiology
 
-	///The recycler connected to the camera console
-	var/obj/machinery/monkey_recycler/connected_recycler
-	///The slimes stored inside the console
-	var/list/stored_slimes
-	///The single slime potion stored inside the console
-	var/obj/item/slimepotion/slime/current_potion
-	///The maximum amount of slimes that fit in the machine
-	var/max_slimes = 5
-	///The amount of monkey cubes inside the machine
-	var/monkeys = 0
-	/// The HUD for this console
-	var/atom/movable/screen/xenobio_console/xeno_hud
-
 	icon_screen = "slime_comp"
 	icon_keyboard = "rd_key"
 
 	light_color = LIGHT_COLOR_PINK
+
+	/// Weakref to the monkey recycler connected to this console.
+	var/datum/weakref/connected_recycler_ref
+	/// The slimes stored inside this console.
+	var/list/stored_slimes
+	/// The slime potion stored inside this console.
+	var/obj/item/slimepotion/slime/current_potion
+	/// The maximum amount of slimes that fit in this machine.
+	var/max_slimes = 5
+	/// The amount of monkey cubes inside this machine.
+	var/stored_monkeys = 0
+	/// The HUD for this console.
+	var/atom/movable/screen/xenobio_console/xeno_hud
 
 /obj/machinery/computer/camera_advanced/xenobio/Initialize(mapload)
 	. = ..()
@@ -61,14 +61,15 @@
 
 	stored_slimes = list()
 	xeno_hud = new(null, src)
-	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
+	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), stored_monkeys, max_slimes)
+	register_context()
 
 /obj/machinery/computer/camera_advanced/xenobio/post_machine_initialize()
 	. = ..()
 	for(var/obj/machinery/monkey_recycler/recycler in GLOB.monkey_recyclers)
-		if(get_area(recycler.loc) == get_area(loc))
-			connected_recycler = recycler
-			connected_recycler.connected += src
+		if(get_area(recycler) == get_area(src))
+			connected_recycler_ref = WEAKREF(recycler)
+			break
 
 /obj/machinery/computer/camera_advanced/xenobio/Destroy()
 	QDEL_NULL(current_potion)
@@ -76,11 +77,24 @@
 		var/mob/living/basic/slime/stored_slime = thing
 		stored_slime.forceMove(drop_location())
 	stored_slimes.Cut()
-	if(connected_recycler)
-		connected_recycler.connected -= src
-	connected_recycler = null
 	QDEL_NULL(xeno_hud)
 	return ..()
+
+/obj/machinery/computer/camera_advanced/xenobio/add_context(atom/source, list/context, obj/item/held_item, mob/living/user)
+	. = ..()
+
+	if(istype(held_item, /obj/item/slimepotion/slime))
+		context[SCREENTIP_CONTEXT_LMB] = "[current_potion ? "Swap" : "Insert"] potion"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/food/monkeycube))
+		context[SCREENTIP_CONTEXT_LMB] = "Insert monkey cubes"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/storage/bag) || istype(held_item, /obj/item/storage/box/monkeycubes))
+		context[SCREENTIP_CONTEXT_LMB] = "Load monkey cubes"
+		return CONTEXTUAL_SCREENTIP_SET
+	if(istype(held_item, /obj/item/multitool))
+		context[SCREENTIP_CONTEXT_LMB] = "Link monkey recycler"
+		return CONTEXTUAL_SCREENTIP_SET
 
 /obj/machinery/computer/camera_advanced/xenobio/Exited(atom/movable/gone, direction)
 	. = ..()
@@ -96,10 +110,9 @@
 
 /obj/machinery/computer/camera_advanced/xenobio/GrantActions(mob/living/user)
 	. = ..()
-	RegisterSignal(user, COMSIG_MOB_CTRL_CLICKED, PROC_REF(XenoClickCtrl))
-	RegisterSignal(user, COMSIG_MOB_ALTCLICKON, PROC_REF(XenoSlimeClickAlt))
-	RegisterSignal(user, COMSIG_XENO_SLIME_CLICK_SHIFT, PROC_REF(XenoSlimeClickShift))
-	RegisterSignal(user, COMSIG_XENO_TURF_CLICK_SHIFT, PROC_REF(XenoTurfClickShift))
+	RegisterSignal(user, COMSIG_MOB_CTRL_CLICKED, PROC_REF(user_ctrl_click))
+	RegisterSignal(user, COMSIG_MOB_ALTCLICKON, PROC_REF(user_alt_click))
+	RegisterSignal(user, COMSIG_CLICK_SHIFT, PROC_REF(user_shift_click))
 	if(!user.hud_used)
 		return
 	user.hud_used.static_inventory += xeno_hud
@@ -109,8 +122,7 @@
 	UnregisterSignal(user, list(
 		COMSIG_MOB_CTRL_CLICKED,
 		COMSIG_MOB_ALTCLICKON,
-		COMSIG_XENO_SLIME_CLICK_SHIFT,
-		COMSIG_XENO_TURF_CLICK_SHIFT,
+		COMSIG_CLICK_SHIFT,
 	))
 	if(user.hud_used)
 		if(xeno_hud)
@@ -118,63 +130,83 @@
 			user.hud_used.show_hud(user.hud_used.hud_version)
 	return ..()
 
-/obj/machinery/computer/camera_advanced/xenobio/attackby(obj/item/used_item, mob/user, list/modifiers, list/attack_modifiers)
-	if(istype(used_item, /obj/item/food/monkeycube))
-		monkeys++
-		to_chat(user, span_notice("You feed [used_item] to [src]. It now has [monkeys] monkey cubes stored."))
-		qdel(used_item)
-		xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
-		return
-
-	if(istype(used_item, /obj/item/storage/bag) || istype(used_item, /obj/item/storage/box/monkeycubes))
-		var/obj/item/storage/storage_container = used_item
-		var/loaded = FALSE
-		for(var/obj/storage_item in storage_container.contents)
-			if(istype(storage_item, /obj/item/food/monkeycube))
-				loaded = TRUE
-				monkeys++
-				qdel(storage_item)
-		if(loaded)
-			to_chat(user, span_notice("You fill [src] with the monkey cubes stored in [used_item]. [src] now has [monkeys] monkey cubes stored."))
-			xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
-		return
-
-	if(istype(used_item, /obj/item/slimepotion/slime))
-		var/replaced = FALSE
-		if(user && !user.transferItemToLoc(used_item, src))
-			return
-		if(!QDELETED(current_potion))
-			current_potion.forceMove(drop_location())
-			replaced = TRUE
-		current_potion = used_item
-		xeno_hud.update_potion(current_potion)
-		to_chat(user, span_notice("You load [used_item] in the console's potion slot[replaced ? ", replacing the previous" : ""]."))
-
-		return
-
-	..()
-
-/obj/machinery/computer/camera_advanced/xenobio/multitool_act(mob/living/user, obj/item/multitool/used_multitool)
+/obj/machinery/computer/camera_advanced/xenobio/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
 	. = ..()
-	if (istype(used_multitool) && istype(used_multitool.buffer,/obj/machinery/monkey_recycler))
-		to_chat(user, span_notice("You link [src] with [used_multitool.buffer] in [used_multitool] buffer."))
-		connected_recycler = used_multitool.buffer
-		connected_recycler.connected += src
-		return TRUE
+	if(.)
+		return .
 
-/*
-Boilerplate check for a valid area to perform a camera action in.
-Checks if the AI eye is on a valid turf and then checks if the target turf is xenobiology compatible
-Due to keyboard shortcuts, the second one is not necessarily the remote eye's location.
-*/
-/obj/machinery/computer/camera_advanced/xenobio/proc/validate_area(mob/living/user, mob/eye/camera/remote/xenobio/remote_eye, turf/open/target_turf)
-	if(!GLOB.cameranet.checkTurfVis(remote_eye.loc))
-		to_chat(user, span_warning("Target is not near a camera. Cannot proceed."))
+	if(istype(tool, /obj/item/slimepotion/slime))
+		return slimepotion_act(user, tool)
+	if(istype(tool, /obj/item/food/monkeycube))
+		return monkeycube_act(user, tool)
+	if(istype(tool, /obj/item/storage/bag) || istype(tool, /obj/item/storage/box/monkeycubes))
+		return storage_act(user, tool)
+	return NONE
+
+/// Handles inserting a slime potion into the console, potentially swapping out an existing one.
+/obj/machinery/computer/camera_advanced/xenobio/proc/slimepotion_act(mob/living/user, obj/item/slimepotion/slime/used_potion)
+	if(!user.transferItemToLoc(used_potion, src))
+		balloon_alert(user, "can't insert!")
+		return ITEM_INTERACT_BLOCKING
+
+	if(!QDELETED(current_potion))
+		try_put_in_hand(current_potion, user)
+		balloon_alert(user, "swapped")
+	else
+		balloon_alert(user, "inserted")
+
+	current_potion = used_potion
+	xeno_hud.update_potion(current_potion)
+	return ITEM_INTERACT_SUCCESS
+
+/// Handles inserting a monkey cube into the console.
+/obj/machinery/computer/camera_advanced/xenobio/proc/monkeycube_act(mob/living/user, obj/item/food/monkeycube/used_cube)
+	stored_monkeys += 1
+	balloon_alert(user, "[stored_monkeys] cube\s stored")
+	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), stored_monkeys, max_slimes)
+	qdel(used_cube)
+	return ITEM_INTERACT_SUCCESS
+
+/// Handles inserting any monkey cubes stored in the tool into the console.
+/obj/machinery/computer/camera_advanced/xenobio/proc/storage_act(mob/living/user, obj/item/tool)
+	var/loaded_any = FALSE
+	for(var/obj/storage_item in tool.contents)
+		if(istype(storage_item, /obj/item/food/monkeycube))
+			loaded_any = TRUE
+			stored_monkeys += 1
+			qdel(storage_item)
+	if(!loaded_any)
+		balloon_alert(user, "no monkey cubes!")
+		return ITEM_INTERACT_BLOCKING
+
+	balloon_alert(user, "[stored_monkeys] cube\s stored")
+	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), stored_monkeys, max_slimes)
+	return ITEM_INTERACT_SUCCESS
+
+/obj/machinery/computer/camera_advanced/xenobio/multitool_act(mob/living/user, obj/item/multitool/tool)
+	if(!istype(tool)) // Needed as long as this uses a var on the multitool.
+		return NONE
+	if(QDELETED(tool.buffer))
+		balloon_alert(user, "buffer empty!")
+		return ITEM_INTERACT_BLOCKING
+	if(!istype(tool.buffer, /obj/machinery/monkey_recycler))
+		balloon_alert(user, "can only link recyclers!")
+		return ITEM_INTERACT_BLOCKING
+
+	balloon_alert(user, "linked recycler")
+	connected_recycler_ref = WEAKREF(tool.buffer)
+	return ITEM_INTERACT_SUCCESS
+
+/// Validates whether the target turf can be interacted with.
+/obj/machinery/computer/camera_advanced/xenobio/proc/validate_turf(mob/living/user, turf/open/target_turf)
+	if(!GLOB.cameranet.checkTurfVis(target_turf))
+		target_turf.balloon_alert(user, "outside of view!")
 		return FALSE
 
 	var/area/turfarea = get_area(target_turf)
+	var/mob/eye/camera/remote/xenobio/remote_eye = user.remote_control
 	if(turfarea.name != remote_eye.allowed_area && !(turfarea.area_flags & XENOBIOLOGY_COMPATIBLE))
-		to_chat(user, span_warning("Invalid area. Cannot proceed."))
+		target_turf.balloon_alert(user, "invalid area!")
 		return FALSE
 
 	return TRUE
@@ -192,7 +224,7 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 		stored_slime.forceMove(target_turf)
 		REMOVE_TRAIT(stored_slime, TRAIT_STASIS, XENOBIO_CONSOLE_TRAIT)
 		stored_slime.handle_slime_stasis(0)
-	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
+	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), stored_monkeys, max_slimes)
 
 ///Places every slime not controlled by a player into the internal storage, respecting its limits
 ///Returns TRUE to signal it hitting the limit, in case its being called from a loop and we want it to stop
@@ -211,14 +243,14 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 	target_slime.forceMove(src)
 	stored_slimes += target_slime
 	ADD_TRAIT(target_slime, TRAIT_STASIS, XENOBIO_CONSOLE_TRAIT)
-	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
+	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), stored_monkeys, max_slimes)
 
 	return FALSE
 
 ///Places one monkey, if possible
 /obj/machinery/computer/camera_advanced/xenobio/proc/feed_slime(mob/living/user, turf/open/target_turf)
-	if(monkeys < 1)
-		to_chat(user, span_warning("[src] needs to have at least 1 monkey stored. Currently has [monkeys] monkeys stored."))
+	if(stored_monkeys < 1)
+		to_chat(user, span_warning("[src] needs to have at least 1 monkey stored. Currently has [stored_monkeys] stored_monkeys stored."))
 		target_turf.balloon_alert(user, "not enough monkeys")
 		return
 
@@ -227,25 +259,72 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 		return
 	food.apply_status_effect(/datum/status_effect/slime_food, user)
 
-	monkeys--
-	monkeys = round(monkeys, 0.1) //Prevents rounding errors
+	stored_monkeys--
+	stored_monkeys = round(stored_monkeys, 0.1) //Prevents rounding errors
 	spit_out(food, target_turf)
-	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
+	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), stored_monkeys, max_slimes)
 
-///Recycles the target monkey
-/obj/machinery/computer/camera_advanced/xenobio/proc/monkey_recycle(mob/living/user, mob/living/target_mob)
-	if(!ismonkey(target_mob))
-		return
-	if(!target_mob.stat)
+/// Check whether we can recycle monkeys at all. Optionally, displays a balloon alert over a target atom for feedback.
+/obj/machinery/computer/camera_advanced/xenobio/proc/can_recycle_monkeys(mob/living/user, atom/target_atom)
+	PRIVATE_PROC(TRUE)
+	var/obj/machinery/monkey_recycler/connected_recycler = connected_recycler_ref?.resolve()
+	if(isnull(connected_recycler))
+		to_chat(user, span_warning("There is no connected monkey recycler. Use a multitool to link one."))
+		if(target_atom)
+			target_atom.balloon_alert(user, "no recycler linked!")
+		return FALSE
+	return TRUE
+
+/// Check whether we can recycle the target monkey. Optionally takes in a user to display errors to.
+/obj/machinery/computer/camera_advanced/xenobio/proc/can_recycle_target_monkey(mob/living/carbon/human/target_human, mob/living/user)
+	PRIVATE_PROC(TRUE)
+	if(!ismonkey(target_human))
+		if(user)
+			target_human.balloon_alert(user, "not a monkey!")
+		return FALSE
+	if(target_human.stat < DEAD)
+		if(user)
+			target_human.balloon_alert(user, "not dead!")
+		return FALSE
+	return TRUE
+
+/// Attempts to recycle any monkeys on the targeted turf.
+/obj/machinery/computer/camera_advanced/xenobio/proc/try_recycle_monkeys_on_turf(mob/living/user, turf/target_turf)
+	if(!can_recycle_monkeys(user, target_turf))
+		return FALSE
+
+	var/monkey_found = FALSE
+	for(var/mob/living/carbon/human/target_human in target_turf)
+		if(!can_recycle_target_monkey(target_human))
+			continue
+		recycle_monkey(target_human)
+		monkey_found = TRUE
+
+	return monkey_found
+
+/// Attempts to recycle the targeted human.
+/obj/machinery/computer/camera_advanced/xenobio/proc/try_recycle_target_monkey(mob/living/user, mob/living/carbon/human/target_human, silence_errors = FALSE)
+	if(!can_recycle_target_monkey(target_human, user))
+		return FALSE
+	if(!can_recycle_monkeys(user, target_human))
+		return FALSE
+
+	recycle_monkey(target_human)
+	return TRUE
+
+/// Recycles a given monkey.
+/obj/machinery/computer/camera_advanced/xenobio/proc/recycle_monkey(mob/living/carbon/human/target_monkey)
+	var/obj/machinery/monkey_recycler/connected_recycler = connected_recycler_ref?.resolve()
+	if(isnull(connected_recycler))
 		return
 
-	suck_up(target_mob)
-	target_mob.visible_message(span_notice("The monkey shoots up as [p_theyre()] reclaimed for recycling!"))
+	suck_up(target_monkey)
+	target_monkey.visible_message(span_notice("The monkey shoots up as [target_monkey.p_theyre()] reclaimed for recycling!"))
 	connected_recycler.use_energy(500 JOULES)
-	monkeys += connected_recycler.cube_production
-	monkeys = round(monkeys, 0.1) //Prevents rounding errors
-	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), monkeys, max_slimes)
-	qdel(target_mob)
+	stored_monkeys += connected_recycler.cube_production
+	stored_monkeys = round(stored_monkeys, 0.1) //Prevents rounding errors
+	xeno_hud.on_update_hud(LAZYLEN(stored_slimes), stored_monkeys, max_slimes)
+	qdel(target_monkey)
 
 /datum/action/innate/slime_place
 	name = "Place Slimes"
@@ -255,14 +334,14 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 /datum/action/innate/slime_place/Activate()
 	if(!target || !isliving(owner))
 		return
-	var/mob/living/owner_mob = owner
-	var/mob/eye/camera/remote/xenobio/remote_eye = owner_mob.remote_control
+	var/mob/living/living_owner = owner
+	var/turf/eye_turf = get_turf(living_owner.remote_control)
 	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = target
 
-	if(!xeno_console.validate_area(owner, remote_eye, remote_eye.loc))
+	if(!xeno_console.validate_turf(owner, eye_turf))
 		return
 
-	xeno_console.slime_place(remote_eye.loc)
+	xeno_console.slime_place(eye_turf)
 
 /datum/action/innate/slime_pick_up
 	name = "Pick up Slime"
@@ -272,15 +351,15 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 /datum/action/innate/slime_pick_up/Activate()
 	if(!target || !isliving(owner))
 		return
-	var/mob/living/owner_mob = owner
-	var/mob/eye/camera/remote/xenobio/remote_eye = owner_mob.remote_control
+	var/mob/living/living_owner = owner
+	var/turf/eye_turf = get_turf(living_owner.remote_control)
 	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = target
 
-	if(!xeno_console.validate_area(owner, remote_eye, remote_eye.loc))
+	if(!xeno_console.validate_turf(living_owner, eye_turf))
 		return
 
-	for(var/mob/living/basic/slime/target_slime in remote_eye.loc)
-		if(xeno_console.slime_pickup(owner_mob, target_slime)) ///Returns true if we hit our slime pickup limit
+	for(var/mob/living/basic/slime/target_slime in eye_turf)
+		if(xeno_console.slime_pickup(living_owner, target_slime)) ///Returns true if we hit our slime pickup limit
 			break
 
 /datum/action/innate/feed_slime
@@ -292,13 +371,13 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 	if(!target || !isliving(owner))
 		return
 	var/mob/living/living_owner = owner
-	var/mob/eye/camera/remote/xenobio/remote_eye = living_owner.remote_control
+	var/turf/eye_turf = get_turf(living_owner.remote_control)
 	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = target
 
-	if(!xeno_console.validate_area(owner, remote_eye, remote_eye.loc))
+	if(!xeno_console.validate_turf(living_owner, eye_turf))
 		return
 
-	xeno_console.feed_slime(living_owner, remote_eye.loc)
+	xeno_console.feed_slime(living_owner, eye_turf)
 
 
 /datum/action/innate/monkey_recycle
@@ -309,20 +388,14 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 /datum/action/innate/monkey_recycle/Activate()
 	if(!target || !isliving(owner))
 		return
-	var/mob/living/owner_mob = owner
-	var/mob/eye/camera/remote/xenobio/remote_eye = owner_mob.remote_control
+	var/mob/living/living_owner = owner
+	var/turf/eye_turf = get_turf(living_owner.remote_control)
 	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = target
-	var/obj/machinery/monkey_recycler/recycler = xeno_console.connected_recycler
 
-	if(!xeno_console.validate_area(owner, remote_eye, remote_eye.loc))
+	if(!xeno_console.validate_turf(living_owner, eye_turf))
 		return
 
-	if(!recycler)
-		to_chat(owner, span_warning("There is no connected monkey recycler. Use a multitool to link one."))
-		return
-
-	for(var/mob/living/carbon/human/target_mob in remote_eye.loc)
-		xeno_console.monkey_recycle(owner, target_mob)
+	xeno_console.try_recycle_monkeys_on_turf(living_owner, eye_turf)
 
 /datum/action/innate/slime_scan
 	name = "Scan Slime"
@@ -332,15 +405,15 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 /datum/action/innate/slime_scan/Activate()
 	if(!target || !isliving(owner))
 		return
-	var/mob/living/owner_mob = owner
-	var/mob/eye/camera/remote/xenobio/remote_eye = owner_mob.remote_control
+	var/mob/living/living_owner = owner
+	var/turf/eye_turf = get_turf(living_owner.remote_control)
 	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = target
 
-	if(!xeno_console.validate_area(owner, remote_eye, remote_eye.loc))
+	if(!xeno_console.validate_turf(living_owner, eye_turf))
 		return
 
-	for(var/mob/living/basic/slime/scanned_slime in remote_eye.loc)
-		slime_scan(scanned_slime, owner_mob)
+	for(var/mob/living/basic/slime/scanned_slime in eye_turf)
+		slime_scan(scanned_slime, living_owner)
 
 /datum/action/innate/feed_potion
 	name = "Apply Potion"
@@ -351,20 +424,20 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 	if(!target || !isliving(owner))
 		return
 
-	var/mob/living/owner_mob = owner
-	var/mob/eye/camera/remote/xenobio/remote_eye = owner_mob.remote_control
+	var/mob/living/living_owner = owner
+	var/turf/eye_turf = get_turf(living_owner.remote_control)
 	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = target
 
-	if(!xeno_console.validate_area(owner, remote_eye, remote_eye.loc))
+	if(!xeno_console.validate_turf(owner, eye_turf))
 		return
 
 	if(QDELETED(xeno_console.current_potion))
 		to_chat(owner, span_warning("No potion loaded."))
 		return
 
-	for(var/mob/living/basic/slime/potioned_slime in remote_eye.loc)
-		xeno_console.spit_atom(xeno_console.current_potion, get_turf(remote_eye))
-		xeno_console.current_potion.attack(potioned_slime, owner_mob)
+	for(var/mob/living/basic/slime/potioned_slime in eye_turf)
+		xeno_console.spit_atom(xeno_console.current_potion, eye_turf)
+		xeno_console.current_potion.attack(potioned_slime, living_owner)
 		xeno_console.xeno_hud.update_potion(xeno_console.current_potion)
 		break
 
@@ -386,127 +459,96 @@ Due to keyboard shortcuts, the second one is not necessarily the remote eye's lo
 
 	to_chat(owner, boxed_message(jointext(render_list, "\n")))
 
-//
-// Alternate clicks for slime, monkey and open turf if using a xenobio console
-
-/mob/living/basic/slime/ShiftClick(mob/user)
-	SEND_SIGNAL(user, COMSIG_XENO_SLIME_CLICK_SHIFT, src)
-	..()
-
-/turf/open/ShiftClick(mob/user)
-	SEND_SIGNAL(user, COMSIG_XENO_TURF_CLICK_SHIFT, src)
-	..()
-
-///Feeds a stored potion to a slime
-/obj/machinery/computer/camera_advanced/xenobio/proc/XenoSlimeClickAlt(mob/living/user, mob/living/basic/slime/target_slime)
+/// Handles console user alt-clicking, forwards to other procs based on target type.
+/obj/machinery/computer/camera_advanced/xenobio/proc/user_alt_click(mob/living/user, atom/target)
 	SIGNAL_HANDLER
 
-	. = COMSIG_MOB_CANCEL_CLICKON
-	if(!isslime(target_slime))
+	if(isslime(target))
+		alt_click_slime(user, target)
+		return COMSIG_MOB_CANCEL_CLICKON
+	return NONE
+
+///Feeds a stored potion to a slime
+/obj/machinery/computer/camera_advanced/xenobio/proc/alt_click_slime(mob/living/user, mob/living/basic/slime/target_slime)
+	var/turf/slime_turf = get_turf(target_slime)
+	if(!validate_turf(user, slime_turf))
 		return
 
-	var/mob/eye/camera/remote/xenobio/remote_eye = user.remote_control
-	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = remote_eye.origin_ref.resolve()
-
-	if(!xeno_console.validate_area(user, remote_eye, target_slime.loc))
-		return
-
-	if(QDELETED(xeno_console.current_potion))
+	if(QDELETED(current_potion))
 		to_chat(user, span_warning("No potion loaded."))
 		return
 
-	spit_atom(current_potion, get_turf(target_slime))
-	INVOKE_ASYNC(xeno_console.current_potion, TYPE_PROC_REF(/obj/item/slimepotion/slime, attack), target_slime, user)
-	xeno_hud.update_potion(xeno_console.current_potion)
+	spit_atom(current_potion, slime_turf)
+	INVOKE_ASYNC(current_potion, TYPE_PROC_REF(/obj/item/slimepotion/slime, attack), target_slime, user)
+	xeno_hud.update_potion(current_potion)
 
-///Picks up a slime, and places them in the internal storage
-/obj/machinery/computer/camera_advanced/xenobio/proc/XenoSlimeClickShift(mob/living/user, mob/living/basic/slime/target_slime)
+/// Handles console user shift-clicking, forwards to other procs based on target type.
+/obj/machinery/computer/camera_advanced/xenobio/proc/user_shift_click(mob/living/user, atom/target)
 	SIGNAL_HANDLER
 
-	var/mob/eye/camera/remote/xenobio/remote_eye = user.remote_control
-	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = remote_eye.origin_ref.resolve()
+	if(isslime(target))
+		shift_click_slime(user, target)
+		return COMSIG_MOB_CANCEL_CLICKON
+	else if(isopenturf(target))
+		shift_click_turf(user, target)
+		return COMSIG_MOB_CANCEL_CLICKON
+	return NONE
 
-	if(!xeno_console.validate_area(user, remote_eye, target_slime.loc))
+/// Picks up a slime, and places them in the internal storage.
+/obj/machinery/computer/camera_advanced/xenobio/proc/shift_click_slime(mob/living/user, mob/living/basic/slime/target_slime)
+	if(!validate_turf(user, get_turf(target_slime)))
 		return
 
-	xeno_console.slime_pickup(user, target_slime)
+	slime_pickup(user, target_slime)
 
-///Places all slimes from the internal storage
-/obj/machinery/computer/camera_advanced/xenobio/proc/XenoTurfClickShift(mob/living/user, turf/open/target_turf)
-	SIGNAL_HANDLER
-
-	var/mob/living/user_mob = user
-	var/mob/eye/camera/remote/xenobio/remote_eye = user_mob.remote_control
-	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = remote_eye.origin_ref.resolve()
-
-	if(!xeno_console.validate_area(user, remote_eye, target_turf))
+/// Places all slimes from the internal storage.
+/obj/machinery/computer/camera_advanced/xenobio/proc/shift_click_turf(mob/living/user, turf/open/target_turf)
+	if(!validate_turf(user, target_turf))
 		return
 
 	slime_place(target_turf, user)
 
-/obj/machinery/computer/camera_advanced/xenobio/proc/XenoClickCtrl(mob/living/user, atom/target)
+/// Handles console user ctrl-clicking, forwards to other procs based on target type.
+/obj/machinery/computer/camera_advanced/xenobio/proc/user_ctrl_click(mob/living/user, atom/target)
 	SIGNAL_HANDLER
 
 	if(isopenturf(target))
-		XenoTurfClickCtrl(user, target)
+		ctrl_click_turf(user, target)
+		return COMSIG_MOB_CANCEL_CLICKON
 	else if(ismonkey(target))
-		XenoMonkeyClickCtrl(user, target)
+		ctrl_click_monkey(user, target)
+		return COMSIG_MOB_CANCEL_CLICKON
 	else if(isslime(target))
-		XenoSlimeClickCtrl(user, target)
+		ctrl_click_slime(user, target)
+		return COMSIG_MOB_CANCEL_CLICKON
+	return NONE
 
-	return COMSIG_MOB_CANCEL_CLICKON
-
-///Places a monkey from the internal storage
-/obj/machinery/computer/camera_advanced/xenobio/proc/XenoTurfClickCtrl(mob/living/user, turf/open/target_turf)
-	if(!isopenturf(target_turf))
+/// Attempts to recycle all monkeys on the turf, otherwise places a monkey from the internal storage.
+/obj/machinery/computer/camera_advanced/xenobio/proc/ctrl_click_turf(mob/living/user, turf/open/target_turf)
+	if(!validate_turf(user, target_turf))
 		return
 
-	var/cleanup = FALSE
-	var/mob/eye/camera/remote/xenobio/remote_eye = user.remote_control
-	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = remote_eye.origin_ref.resolve()
-
-	if(!xeno_console.validate_area(user, remote_eye, target_turf))
+	// Attempt to recycle any monkeys on the turf first.
+	if(try_recycle_monkeys_on_turf(user, target_turf))
 		return
 
-	for(var/mob/monkey in target_turf)
-		if(ismonkey(monkey) && monkey.stat == DEAD)
-			cleanup = TRUE
-			xeno_console.monkey_recycle(user, monkey)
+	feed_slime(user, target_turf)
 
-	if(!cleanup)
-		xeno_console.feed_slime(user, target_turf)
-
-///Picks up a dead monkey for recycling
-/obj/machinery/computer/camera_advanced/xenobio/proc/XenoMonkeyClickCtrl(mob/living/user, mob/living/carbon/human/target_mob)
-	if(!ismonkey(target_mob))
+/// Picks up a dead monkey for recycling.
+/obj/machinery/computer/camera_advanced/xenobio/proc/ctrl_click_monkey(mob/living/user, mob/living/carbon/human/target_human)
+	if(!validate_turf(user, get_turf(target_human)))
 		return
 
-	var/mob/eye/camera/remote/xenobio/remote_eye = user.remote_control
-	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = remote_eye.origin_ref.resolve()
+	try_recycle_target_monkey(user, target_human)
 
-	if(!xeno_console.connected_recycler)
-		to_chat(user, span_warning("There is no connected monkey recycler. Use a multitool to link one."))
-		return
-
-	if(!xeno_console.validate_area(user, remote_eye, target_mob.loc))
-		return
-
-	xeno_console.monkey_recycle(user, target_mob)
-
-/// Scans the target slime
-/obj/machinery/computer/camera_advanced/xenobio/proc/XenoSlimeClickCtrl(mob/living/user, mob/living/basic/slime/target_slime)
-	if(!isslime(target_slime))
-		return
-
-	var/mob/eye/camera/remote/xenobio/remote_eye = user.remote_control
-	var/obj/machinery/computer/camera_advanced/xenobio/xeno_console = remote_eye.origin_ref.resolve()
-
-	if(!xeno_console.validate_area(user, remote_eye, target_slime.loc))
+/// Scans the target slime.
+/obj/machinery/computer/camera_advanced/xenobio/proc/ctrl_click_slime(mob/living/user, mob/living/basic/slime/target_slime)
+	if(!validate_turf(user, get_turf(target_slime)))
 		return
 
 	slime_scan(target_slime, user)
 
-/// Sucks the target mob up into the console
+/// Sucks the target mob up into the console.
 /obj/machinery/computer/camera_advanced/xenobio/proc/suck_up(mob/living/target_mob)
 	if(!isliving(target_mob))
 		return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -384,7 +384,6 @@
 #include "code\__DEFINES\dcs\signals\signals_vehicle.dm"
 #include "code\__DEFINES\dcs\signals\signals_wash.dm"
 #include "code\__DEFINES\dcs\signals\signals_wizard.dm"
-#include "code\__DEFINES\dcs\signals\signals_xeno_control.dm"
 #include "code\__DEFINES\dcs\signals\uplink.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_attack.dm"
 #include "code\__DEFINES\dcs\signals\signals_atom\signals_atom_explosion.dm"


### PR DESCRIPTION
Original PR: 91628
-----
## About The Pull Request

So a previous pr of mine caused #91625, because xenobio consoles actually implement their own weird shift click signals:
https://github.com/tgstation/tgstation/blob/9447820886ea5f1063a7ae161a4527d734cefed2/code/modules/research/xenobiology/xenobio_camera.dm#L389-L398
So! I decided I might as well clean up some of the related code!
...And then I continued doing so, as I found more issues.

Anyhow, this is broadly just a cleanup of some old code, trying to avoid some of the older issues.

Notable changes:
- We no longer keep a list of all connected xenobio consoles on the monkey recycler, and instead use weakrefs on the xenobio console. Much cleaner, and lets us easily avoid some of the bugs not properly the old system not properly cleaning up after itself had caused.
- There was a lot of unnecessary getting of the user's remote control eye followed by getting the associated xenobio console followed by calling procs on that var: https://github.com/tgstation/tgstation/blob/9447820886ea5f1063a7ae161a4527d734cefed2/code/modules/research/xenobiology/xenobio_camera.dm#L408-L412
This tries to minimize that to places where it's actually necessary, and moves getting the `remote_eye` to the `validate_area(...)` proc itself. This is now called `validate_turf(...)`, and no longer has the eye parameter.
- A lot of `to_chat(...)` messages have been kept, just supplemented with balloon alerts, because the additional information oftentimes feed better to have.
- `attackby(...)` has been refactored to `item_interaction(...)` and split into three `[item]_act(...)` procs.
- The click interactions have all been renamed into snake_case into the format of `[type]_click_[target](...)`, with a core signal handler proc selecting between such based on the clicked target. Good riddance `COMSIG_XENO_SLIME_CLICK_SHIFT` and `COMSIG_XENO_TURF_CLICK_SHIFT`
- Moved checking for the connected recycler to a new `can_recycle_monkeys(...)` proc, and checking whether we can recycle a monkey to `can_recycle_target_monkey(...)` to keep those checks in one place, instead of scattered wherever. For similar reasons the monkey handling code has been split off into `try_recycle_monkeys_on_turf(...)`, `try_recycle_target_monkey(...)`, and `recycle_monkey(...)`

## Why It's Good For The Game

Fixes #91625.
Less jank.

## Changelog

:cl:
refactor: Refactored xenobio console item interaction and click code. Please report any issues!
fix: When using the xenobio console, you no longer examine slimes/turfs when trying to deposit or pick up slimes.
fix: Xenobio consoles properly check whether the turf they're interacting with is visible to cameras when deciding whether to block interaction, rather than whether the turf of the remote control eye itself is obscured by static.
fix: Using a xenobio console and ctrl-clicking on a tile with dead monkeys on it without a connected monkey recycler no longer runtimes.
fix: Destroying a monkey recycler that was once linked to a xenobio console but no longer is no longer disconnects the currently linked monkey recycler from those xenobio consoles.
fix: Multiple monkey recyclers mapped into the same xenobiology area no longer enter a weird state of half-connection with the mapped in xenobio consoles.
qol: Adds screentips to the xenobio console's item interactions.
qol: More xenobio console item or click interactions have balloon alert feedback.
/:cl:
