### PR TITLE
[TG Mirror] GMM correctly adjusts ordered materials with proper feedback [MDB IGNORE]

### DIFF
--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -213,15 +213,11 @@
 	pack.cost += cost_increase
 
 /// Custom type of order who's supply pack can be safely deleted
-/datum/supply_order/disposable
-
 /datum/supply_order/disposable/Destroy(force)
 	QDEL_NULL(pack)
 	return ..()
 
 /// Custom material order to append cargo crate value to the final order cost
-/datum/supply_order/disposable/materials
-
 /datum/supply_order/disposable/materials/get_final_cost()
 	return (..() + CARGO_CRATE_VALUE)
 


### PR DESCRIPTION
Original PR: 92009
-----
## About The Pull Request
- Fixes #82910

Cargo now adjusts the material market quantity & prices when the shuttle is called from the order console itself instead of adjusting it after the shuttle arrives 1 minute later. This has 2 implications
- If the market crashes 1 minute after calling the shuttle i.e when it arrives, the ordered quantities are not affected because it retrieved those sheets from the market at the time of calling the shuttle from the order console
- If some orders could not be satisfied because there were not enough materials at the time of calling the shuttle then instead of arriving with an empty crate a detailed summary is displayed explaining which orders could not be delivered & why, even cancelling the order if needed

**a) Order adjusted**
![Screenshot (489)](https://github.com/user-attachments/assets/39aa8746-8848-4415-a23d-c0a7cbd433db)

**b) Order adjusted & cancelled**
![Screenshot (491)](https://github.com/user-attachments/assets/7a800f55-47d9-4d22-b871-c67858c8329a)

**c) Order fully cancelled**
![Screenshot (492)](https://github.com/user-attachments/assets/e3231156-aaa8-44f5-b50a-2a8bd34d9064)


## Changelog
:cl:
fix: ordering materials from the GMM won't result in empty crates & will display detailed feedback if there weren't enough sheets in the market
/:cl:

