### PR TITLE
[TG Mirror] Fix "shatter on floor" behavior failing on stacks with only 1 left [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -66,10 +66,11 @@
  * This is used for crafting by hitting the floor with items.
  * The initial use case is glass sheets breaking in to shards when the floor is hit.
  * Args:
+ * * target: The floor that was hit
  * * user: The user that did the action
- * * params: paramas passed in from attackby
+ * * modifiers: The modifiers passed in from attackby
  */
-/obj/item/stack/sheet/proc/on_attack_floor(mob/user, params)
+/obj/item/stack/sheet/proc/on_attack_floor(turf/open/floor/target, mob/user, list/modifiers)
 	var/list/shards = list()
 	for(var/datum/material/mat in custom_materials)
 		if(mat.shard_type)
@@ -81,14 +82,14 @@
 		if(!is_cyborg)
 			stack_trace("A stack of sheet material was attempted to be shattered into shards while having less than 1 sheets remaining.")
 		return FALSE
-	user.do_attack_animation(src, ATTACK_EFFECT_BOOP)
-	playsound(src, SFX_SHATTER, 70, TRUE)
+	user.do_attack_animation(target, ATTACK_EFFECT_BOOP)
+	playsound(target, SFX_SHATTER, 70, TRUE)
 	var/list/shards_created = list()
 	for(var/shard_to_create in shards)
-		var/obj/item/new_shard = new shard_to_create(drop_location())
+		var/obj/item/new_shard = new shard_to_create(target)
 		new_shard.add_fingerprint(user)
 		shards_created += "[new_shard.name]"
-	user.visible_message(span_notice("[user] shatters the sheet of [name] on the floor, leaving [english_list(shards_created)]."), \
-		span_notice("You shatter the sheet of [name] on the floor, leaving [english_list(shards_created)]."))
+	user.visible_message(span_notice("[user] shatters the sheet of [name] on [target], leaving [english_list(shards_created)]."), \
+		span_notice("You shatter the sheet of [name] on [target], leaving [english_list(shards_created)]."))
 	return TRUE
 

--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -132,7 +132,7 @@
 		return TRUE
 	if(user.combat_mode && istype(object, /obj/item/stack/sheet))
 		var/obj/item/stack/sheet/sheets = object
-		return sheets.on_attack_floor(user, modifiers)
+		return sheets.on_attack_floor(src, user, modifiers)
 	return FALSE
 
 /turf/open/floor/crowbar_act(mob/living/user, obj/item/I)


### PR DESCRIPTION
Original PR: 92049
-----

## About The Pull Request

This code was not dropping a shard because calling `use(1)` on a stack with only one left meant the stack got qdeled and sent to nullspace, leading to no shard and no breaking sfx.

Reworks the code a little to pass the turf being hit into the proc, and use that as the reference point for playing the sound effect, attack animation, and the location to spawn the shard (it makes more sense to drop the shard on the turf you hit, as opposed to underneath the player like it would before).

Also update the proc to `list/modifiers` instead of `params`, because the former is what is actually passed by `attackby` now

## Why It's Good For The Game

Fixes #91971 

## Changelog
:cl:
fix: fixed shattering glass sheets on the floor not dropping a shard if the stack only had 1
/:cl:
