### PR TITLE
[TG Mirror] Cult banned or DNRed players no longer can become constructs [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -388,7 +388,7 @@
 /obj/item/melee/blood_magic/attack(mob/living/M, mob/living/carbon/user)
 	if(!cast_spell(M, user))
 		return
-	log_combat(user, M, "used a cult spell on", source.name, "")
+	log_combat(user, M, "used a cult spell on", src, "")
 	SSblackbox.record_feedback("tally", "cult_spell_invoke", 1, "[name]")
 	M.lastattacker = user.real_name
 	M.lastattackerckey = user.ckey
@@ -665,7 +665,7 @@
 				candidate.color = prev_color
 				return
 			candidate.grab_ghost()
-			user.visible_message(span_danger("The dark cloud recedes from what was formerly [candidate], revealing a\n [construct_class]!"))
+			user.visible_message(span_danger("The dark cloud recedes from what was formerly [candidate], revealing a [construct_class]!"))
 			make_new_construct_from_class(construct_class, THEME_CULT, candidate, user, FALSE, T)
 			uses--
 			qdel(candidate)

--- a/code/modules/antagonists/wizard/equipment/soulstone.dm
+++ b/code/modules/antagonists/wizard/equipment/soulstone.dm
@@ -348,7 +348,8 @@
 				return FALSE
 
 		if(grab_sleeping ? victim.stat == CONSCIOUS : victim.stat != DEAD)
-			to_chat(user, "[span_userdanger("Capture failed!")]: Kill or maim the victim first!")
+			to_chat(user, span_userdanger("Capture failed!"))
+			to_chat(user, span_danger("Kill or maim the victim first!"))
 			return FALSE
 
 	victim.grab_ghost()
@@ -356,7 +357,8 @@
 		init_shade(victim, user)
 		return TRUE
 
-	to_chat(user, "[span_userdanger("Capture failed!")]: The soul has already fled its mortal frame. You attempt to bring it back...")
+	to_chat(user, span_userdanger("Capture failed!"))
+	to_chat(user, span_warning("The soul has already fled its mortal frame. You attempt to bring it back..."))
 	var/mob/chosen_one = SSpolling.poll_ghosts_for_target(
 		check_jobban = ROLE_CULTIST,
 		poll_time = 20 SECONDS,
@@ -377,7 +379,8 @@
 		to_chat(user, span_userdanger("Your body is wracked with debilitating pain!"))
 		return
 	if(contents.len)
-		to_chat(user, "[span_userdanger("Capture failed!")]: [src] is full! Free an existing soul to make room.")
+		to_chat(user, span_userdanger("Capture failed!"))
+		to_chat(user, span_danger("[src] is full! Free an existing soul to make room."))
 		return FALSE
 	shade.AddComponent(/datum/component/soulstoned, src)
 	update_appearance()
@@ -557,10 +560,36 @@
 		var/datum/action/innate/seek_master/seek_master = new
 		seek_master.Grant(newstruct)
 
-	if (isnull(target.mind))
-		newstruct.PossessByPlayer(target.key)
+	if (!target.ckey || isnull(target.mind) || is_banned_from(target.ckey, ROLE_CULTIST))
+		to_chat(stoner, span_userdanger("Shell imbuement failed!"))
+		to_chat(stoner, span_warning("The soul has already fled its mortal frame. You attempt to bring it back..."))
+		target = SSpolling.poll_ghosts_for_target(
+			"Do you want to play as [span_danger(newstruct.real_name)]?",
+			check_jobban = ROLE_CULTIST,
+			role = ROLE_CULTIST,
+			poll_time = 10 SECONDS,
+			checked_target = newstruct,
+			alert_pic = newstruct,
+			role_name_text = "inactive construct",
+			ignore_category = POLL_IGNORE_SHADE
+		)
+
+		if (QDELETED(newstruct))
+			return
+
+		if (!target?.client)
+			if (!QDELETED(stoner))
+				to_chat(stoner, span_danger("There were no spirits willing to become a construct."))
+			new /obj/structure/constructshell(newstruct.drop_location())
+			qdel(newstruct)
+			return
+
+		if (!QDELETED(stoner))
+			to_chat(stoner, span_notice("A new soul has possessed [newstruct]!"))
+		newstruct.PossessByPlayer(target.ckey)
 	else
 		target.mind.transfer_to(newstruct, force_key_move = TRUE)
+
 	var/atom/movable/screen/alert/bloodsense/sense_alert
 	if(newstruct.mind && !IS_CULTIST(newstruct) && ((stoner && IS_CULTIST(stoner)) || cultoverride) && SSticker.HasRoundStarted())
 		newstruct.mind.add_antag_datum(/datum/antagonist/cult/construct)


### PR DESCRIPTION
Original PR: 92064
-----

## About The Pull Request

Half YOLOing this because I can't fully test it due to BYOND being DDOSed and I don't wanna get locked out, but the code seems good to me and successfully fails to put a ghost in if there's noone else around.
When trying to create a construct from a DNRed/banned borg or spirit, be it via soulstones, twisted construction or conversion runes, ghosts will be polled for potential players. If no willing player is found, the construct is turned back into a shell.

- Closes #92062

## Changelog
:cl:
fix: Cult banned or DNRed players no longer can become constructs
/:cl:
