### PR TITLE
[TG Mirror] Cult item printers now have `?` tooltips explaining what do [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/cult.dm
+++ b/code/__DEFINES/cult.dm
@@ -36,6 +36,7 @@
 /// Defines for cult item_dispensers.
 #define PREVIEW_IMAGE "preview"
 #define OUTPUT_ITEMS "output"
+#define RADIAL_DESC "radial_desc"
 
 /// The global Nar'sie that the cult's summoned
 GLOBAL_DATUM(cult_narsie, /obj/narsie)
@@ -60,3 +61,6 @@ GLOBAL_LIST(sacrificed)
 #define CURSED_BLADE_UNLOCKED "Cursed Blade"
 #define CRIMSON_MEDALLION_UNLOCKED "Crimson Medallion"
 #define PROTEON_ORB_UNLOCKED "Proteon Orb"
+
+///how many times can the shuttle be cursed?
+#define MAX_SHUTTLE_CURSES 3

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -598,8 +598,6 @@ Striking a noncultist, however, will tear their flesh."}
 	. = ..()
 	ADD_TRAIT(src, TRAIT_CONTRABAND, INNATE_TRAIT)
 
-///how many times can the shuttle be cursed?
-#define MAX_SHUTTLE_CURSES 3
 ///if the max number of shuttle curses are used within this duration, the entire cult gets an achievement
 #define SHUTTLE_CURSE_OMFG_TIMESPAN (10 SECONDS)
 
@@ -675,8 +673,6 @@ Striking a noncultist, however, will tear their flesh."}
 					iter_player.client?.give_award(/datum/award/achievement/misc/cult_shuttle_omfg, iter_player)
 
 		qdel(src)
-
-#undef MAX_SHUTTLE_CURSES
 
 #define GATEWAY_TURF_SCAN_RANGE 40
 

--- a/code/modules/antagonists/cult/cult_structure_altar.dm
+++ b/code/modules/antagonists/cult/cult_structure_altar.dm
@@ -18,14 +18,20 @@
 		ELDRITCH_WHETSTONE = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/antags/cult/items.dmi', icon_state = "cult_sharpener"),
 			OUTPUT_ITEMS = list(/obj/item/sharpener/cult),
+			RADIAL_DESC = "Provides \a [/obj/item/sharpener/cult::name] usable to increase the damage of swords and daggers. One use only.",
 			),
 		CONSTRUCT_SHELL = list(
 			PREVIEW_IMAGE = image(icon = 'icons/mob/shells.dmi', icon_state = "construct_cult"),
 			OUTPUT_ITEMS = list(/obj/structure/constructshell),
+			RADIAL_DESC = "Produces \a [/obj/structure/constructshell::name], which - once supplied a shade via a soulstone - will birth a construct. \
+				Constructs bring strength, agility, or utility to your team.",
 			),
 		UNHOLY_WATER = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/drinks/bottles.dmi', icon_state = "unholyflask"),
 			OUTPUT_ITEMS = list(/obj/item/reagent_containers/cup/beaker/unholywater),
+			RADIAL_DESC = "Provides \a [/obj/item/reagent_containers/cup/beaker/unholywater::name], \
+				which can be sipped to heal all damage types, including blood loss. \
+				Also acts as a coagulant and mild stimulant (providing token resistance to stuns and stamina damage).",
 			),
 	)
 
@@ -41,6 +47,7 @@
 	return list(PROTEON_ORB = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/antags/cult/items.dmi', icon_state = "summoning_orb"),
 			OUTPUT_ITEMS = list(/obj/item/proteon_orb),
+			RADIAL_DESC = "Provides \a [/obj/item/proteon_orb::name] which can be used to create a portal, releasing minor constructs into the station."
 			),
 	)
 

--- a/code/modules/antagonists/cult/cult_structure_archives.dm
+++ b/code/modules/antagonists/cult/cult_structure_archives.dm
@@ -20,14 +20,20 @@
 		CULT_BLINDFOLD = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/clothing/glasses.dmi', icon_state = "blindfold"),
 			OUTPUT_ITEMS = list(/obj/item/clothing/glasses/hud/health/night/cultblind),
+			RADIAL_DESC = "Creates \a [/obj/item/clothing/glasses/hud/health/night/cultblind::name], a special blindfold which does not blind cultists. \
+				Additionally, it reports the health of friends and foes alike, offers night vision, and even protects from bright lights.",
 			),
 		CURSE_ORB = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/antags/cult/items.dmi', icon_state = "shuttlecurse"),
 			OUTPUT_ITEMS = list(/obj/item/shuttle_curse),
+			RADIAL_DESC = "Produces a delicate [/obj/item/shuttle_curse::name] which can be shattered to curse the shuttle if it has been called, \
+				delaying its arrival by some time. Only [MAX_SHUTTLE_CURSES] can be used.",
 			),
 		VEIL_WALKER = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/antags/cult/items.dmi', icon_state = "shifter"),
 			OUTPUT_ITEMS = list(/obj/item/cult_shift, /obj/item/flashlight/flare/culttorch),
+			RADIAL_DESC = "Creates \a [/obj/item/cult_shift::name], a small wand that teleports the user \
+				- and anyone the user is dragging - forward some distance.  Has [/obj/item/cult_shift::uses] uses.",
 			),
 	)
 
@@ -43,6 +49,8 @@
 	return list(CRIMSON_MEDALLION = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/clothing/neck.dmi', icon_state = "crimson_medallion"),
 			OUTPUT_ITEMS = list(/obj/item/clothing/neck/heretic_focus/crimson_medallion),
+			RADIAL_DESC = "Creates a [/obj/item/clothing/neck/heretic_focus/crimson_medallion::name], a powerful artifact that provides passive healing and the ability to prepare an additional spell. \
+				It can also be squished in hand, consuming it for a powerful healing effect.",
 			),
 	)
 

--- a/code/modules/antagonists/cult/cult_structure_forge.dm
+++ b/code/modules/antagonists/cult/cult_structure_forge.dm
@@ -20,14 +20,17 @@
 		NARSIE_ARMOR = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/clothing/suits/armor.dmi', icon_state = "cult_armor"),
 			OUTPUT_ITEMS = list(/obj/item/clothing/suit/hooded/cultrobes/hardened),
+			RADIAL_DESC = "Smiths a set of [/obj/item/clothing/suit/hooded/cultrobes/hardened::name], a robust suit of armor that can withstand space.",
 			),
 		FLAGELLANT_ARMOR = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/clothing/suits/armor.dmi', icon_state = "cultrobes"),
 			OUTPUT_ITEMS = list(/obj/item/clothing/suit/hooded/cultrobes/berserker),
+			RADIAL_DESC = "Smiths a set of [/obj/item/clothing/suit/hooded/cultrobes/berserker::name], a robe which makes you far more vulnerable to damage, but drastically increases your speed.",
 			),
 		ELDRITCH_SWORD = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/weapons/sword.dmi', icon_state = "cultblade"),
 			OUTPUT_ITEMS = list(/obj/item/melee/cultblade),
+			RADIAL_DESC = "Smiths \a [/obj/item/melee/cultblade::name], a powerful blade that can cleave through the toughest of armor.",
 			),
 	)
 
@@ -43,6 +46,7 @@
 	return list(CURSED_BLADE = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/weapons/khopesh.dmi', icon_state = "cursed_blade"),
 			OUTPUT_ITEMS = list(/obj/item/melee/sickly_blade/cursed),
+			RADIAL_DESC = "Smiths a [/obj/item/melee/sickly_blade/cursed::name], an upgraded dagger that can be broken for an emergency teleport.",
 			),
 	)
 

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -172,7 +172,11 @@
 
 	var/list/choices = list()
 	for(var/item in options)
-		choices[item] = options[item][PREVIEW_IMAGE]
+		var/datum/radial_menu_choice/cultitem = new()
+		cultitem.name = item
+		cultitem.info = span_cult_italic(options[item][RADIAL_DESC])
+		cultitem.image = options[item][PREVIEW_IMAGE]
+		choices[item] = cultitem
 
 	var/picked_choice = show_radial_menu(
 		user,
@@ -181,7 +185,7 @@
 		custom_check = CALLBACK(src, PROC_REF(check_menu), user),
 		require_near = TRUE,
 		tooltips = TRUE,
-		)
+	)
 
 	if(!picked_choice)
 		return


### PR DESCRIPTION
Original PR: 92076
-----
## About The Pull Request

Altars, Archives, and Forges now have a `?` next to their options reporting what each of the objects actually does

## Why It's Good For The Game

A little bit more info not requiring the wiki

## Changelog

:cl: Melbert
qol: Altars, Archives, and Forges now have a ? explaining what the items do
/:cl:
