### PR TITLE
[TG Mirror] Radial Info is shown in tooltip rather than necessitating you click on them + action button fix [MDB IGNORE]

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -23,6 +23,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	var/choice
 	var/next_page = FALSE
 	var/tooltips = FALSE
+	var/tooltip_theme
 
 /atom/movable/screen/radial/slice/set_parent(new_value)
 	. = ..()
@@ -36,7 +37,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	else
 		icon_state = "[parent.radial_slice_icon]_focus"
 	if(tooltips)
-		openToolTip(usr, src, params, title = name)
+		openToolTip(usr, src, params, title = name, theme = tooltip_theme)
 	if (click_on_hover && !isnull(usr) && !isnull(parent))
 		Click(location, control, params)
 
@@ -258,12 +259,15 @@ GLOBAL_LIST_EMPTY(radial_menus)
 			var/atom/movable/AM = choices_values[choice_id] //Movables only
 			E.name = AM.name
 		E.choice = choice_id
+		E.tooltip_theme = choice_datum?.tooltip_theme
 		E.maptext = null
 		E.next_page = FALSE
 		if(choices_icons[choice_id])
 			E.add_overlay(choices_icons[choice_id])
 		if (choice_datum?.info)
 			var/obj/effect/abstract/info/info_button = new(E, choice_datum.info)
+			info_button.name = "Info: [E.name]"
+			info_button.tooltip_theme = choice_datum.tooltip_theme
 			SET_PLANE_EXPLICIT(info_button, ABOVE_HUD_PLANE, anchor)
 			info_button.layer = RADIAL_CONTENT_LAYER
 			E.vis_contents += info_button
@@ -432,6 +436,9 @@ GLOBAL_LIST_EMPTY(radial_menus)
 
 	/// If provided, will display an info button that will put this text in your chat
 	var/info
+
+	/// If provided, changes the tooltip theme for this choice
+	var/tooltip_theme
 
 /datum/radial_menu_choice/Destroy(force)
 	. = ..()

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -229,6 +229,8 @@
 	if(!button)
 		return
 
+	button.actiontooltipstyle = buttontooltipstyle
+
 	if(update_flags & UPDATE_BUTTON_NAME)
 		update_button_name(button, force)
 

--- a/code/game/objects/effects/info.dm
+++ b/code/game/objects/effects/info.dm
@@ -7,6 +7,9 @@
 	/// What should the info button display when clicked?
 	var/info_text
 
+	/// What theme should the tooltip use?
+	var/tooltip_theme
+
 /obj/effect/abstract/info/Initialize(mapload, info_text)
 	. = ..()
 
@@ -20,6 +23,7 @@
 /obj/effect/abstract/info/MouseEntered(location, control, params)
 	. = ..()
 	icon_state = "info_hovered"
+	openToolTip(usr, src, params, title = name, content = info_text, theme = tooltip_theme)
 
 /obj/effect/abstract/info/MouseExited()
 	. = ..()

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -172,7 +172,16 @@
 
 	var/list/choices = list()
 	for(var/item in options)
+<<<<<<< HEAD
 		choices[item] = options[item][PREVIEW_IMAGE]
+=======
+		var/datum/radial_menu_choice/cultitem = new()
+		cultitem.name = item
+		cultitem.info = span_cult_italic(options[item][RADIAL_DESC])
+		cultitem.image = options[item][PREVIEW_IMAGE]
+		cultitem.tooltip_theme = "cult"
+		choices[item] = cultitem
+>>>>>>> 45ad64053c9 (Radial Info is shown in tooltip rather than necessitating you click on them + action button fix (#92082))
 
 	var/picked_choice = show_radial_menu(
 		user,


### PR DESCRIPTION
Original PR: 92082
-----
## About The Pull Request

1. Fix action buttons not getting their set tooltip style

2. Radials can now specify what tooltip theme to use on a per-slice basis

3. The "Info" button now has a tooltip showing you the info text

<img width="370" height="496" alt="image" src="https://github.com/user-attachments/assets/caff9d97-4ccd-4611-9135-1f39b72f9237" />

## Why It's Good For The Game

1. Wow this has been broken for some time

2. Allows for theming of radials according to context, like cult radials. Next step would be to allow changing the background but that's for later.

3. You don't need to click it -> look at chat -> look back at the radial, you can just hover over it. A lot more convenient

## Changelog

:cl: Melbert
fix: Cult spell action buttons have their unique tooltip style again
qol: Radial tooltips can now have unique styles
qol: Radial "info" buttons now have tooltips with the info text, meaning you don't have to click on the button and read chat
/:cl:
