### PR TITLE
[TG Mirror] You can wring out damp rags to get slightly more mileage out of it [MDB IGNORE]

### DIFF
--- a/code/modules/reagents/reagent_containers/misc.dm
+++ b/code/modules/reagents/reagent_containers/misc.dm
@@ -126,6 +126,8 @@
 	resistance_flags = FLAMMABLE
 	/// How bloody is this rag?
 	var/blood_level = 0
+	/// How many times has this rag been wrung out since last clean?
+	var/wrings = 0
 
 /obj/item/rag/Initialize(mapload)
 	. = ..()
@@ -147,6 +149,18 @@
 			. += span_warning("This [name] is dirty! But it still probably has a few wipes left in it.")
 		if(10 to INFINITY)
 			. += span_warning("This [name] is filthy! I couldn't clean a thing with it!")
+
+/obj/item/rag/interact(mob/user)
+	. = ..()
+	if(loc != user || blood_level <= 4)
+		return
+
+	balloon_alert(user, "wringing out...")
+	if(!do_after(user, (wrings + 2) * 1 SECONDS, src))
+		return
+
+	wrings += 1
+	blood_level *= 0.75
 
 /obj/item/rag/pickup(mob/user)
 	. = ..()
@@ -204,6 +218,7 @@
 	. = ..()
 	if(!(clean_types & CLEAN_TYPE_BLOOD))
 		return
+	wrings = 0
 	if(blood_level)
 		blood_level = 0
 		update_appearance()


### PR DESCRIPTION
Original PR: 92112
-----
## About The Pull Request

Using damp rag in hand lets you wring it out, clearing 1/4th of the bloodiness.

Takes 2 seconds, plus 1 second per previous wring until it's cleaned

## Why It's Good For The Game

Suggested in the community meeting, I thought it was cool

## Changelog

:cl: Melbert
qol: Using a damp rag in hand will wring it out, making it usable for a bit longer.
/:cl:
