### PR TITLE
[TG Mirror] Fixes gibs not containing any actual gibs in them [MDB IGNORE]

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -94,7 +94,7 @@
 	if (!istype(tool, /obj/item/reagent_containers/cup) || istype(tool, /obj/item/rag))
 		return NONE
 
-	if (!lazy_init_reagents())
+	if (!lazy_init_reagents()?.total_volume)
 		to_chat(user, span_notice("[src] isn't thick enough to scoop up!"))
 		return ITEM_INTERACT_BLOCKING
 

--- a/code/game/objects/effects/decals/cleanable/blood.dm
+++ b/code/game/objects/effects/decals/cleanable/blood.dm
@@ -517,6 +517,18 @@
 	RegisterSignal(src, COMSIG_MOVABLE_PIPE_EJECTING, PROC_REF(on_pipe_eject))
 	update_appearance(UPDATE_OVERLAYS)
 
+/// Don't override our reagents with our bloodtype ones, if bloodtypes want unique reagents they need to do it themselves (like oil)
+/obj/effect/decal/cleanable/blood/gibs/lazy_init_reagents()
+	if (reagents)
+		return reagents
+
+	if (!decal_reagent)
+		return
+
+	create_reagents(reagent_amount)
+	reagents.add_reagent(decal_reagent, reagent_amount)
+	return reagents
+
 /obj/effect/decal/cleanable/blood/gibs/update_overlays()
 	. = ..()
 	if(!has_overlay)


### PR DESCRIPTION
Original PR: 92110
-----

## About The Pull Request

Also fixes the issue where some empty decals (like dry gibs) claim that the beaker is full when you try picking them up.

Closes #91831 
Closes #91486

## Changelog
:cl:
fix: Fixed gibs not containing any actual gibs in them
/:cl:
