### PR TITLE
[TG Mirror] Bandaid for zombie decap runtiming [MDB IGNORE]

### DIFF
--- a/code/modules/zombie/organs.dm
+++ b/code/modules/zombie/organs.dm
@@ -36,7 +36,9 @@
 	. = ..()
 	STOP_PROCESSING(SSobj, src)
 	if(iszombie(new_owner) && old_species && !special)
-		new_owner.set_species(old_species)
+		// There isn't a clean way to change species during organ or bodypart removals. In lieau of a beter solution, this will do
+		spawn(0)
+			new_owner.set_species(old_species)
 	if(timer_id)
 		deltimer(timer_id)
 	UnregisterSignal(new_owner, COMSIG_LIVING_DEATH)


### PR DESCRIPTION
Original PR: 92055
-----

## About The Pull Request

Fixes #89823

Sort of

The species is changed in decapitation, which goes something like this:
- Decapitate
  - Remove the organs
    -  Change the species, and thus change the head
- Finish decapitaiton, but we now have a different head???
- The world is burning the world is burning the world is burning

I cheated by using a 0 time addtimer to move the species change to the end of the callstack. This fixes most interactions, but doesn't fix removing the tumor from the seperated head, which will just leave it as a zombie head. 

I'm not sure how we'd change the organ removal pipeline to prevent this from happening. Ideally zombies stop being a race and then this wouldn't be an issue

## Changelog
:cl:
runtime: Fixes zombie decap regrowing the persons head
/:cl:
