### PR TITLE
[TG Mirror] Extends Integer scaling range, corrects some info [MDB IGNORE]

### DIFF
--- a/.github/guides/VISUALS.md
+++ b/.github/guides/VISUALS.md
@@ -228,8 +228,9 @@ Otherwise, any other numbers will lead to pixels being scaled by some multiple.
 This effect can only really result in nice clean edges if you pass in whole numbers which is why most of the constant scaling we give players are whole numbers.
 
 `zoom-mode` controls how a pixel will be up-scaled, if it needs to be.
-See the ref for more details, but `normal` is gonna have the sharpest output, `distort` uses nearest neighbor,
-which causes some blur, and `blur` uses bilinear sampling, which causes a LOT of blur.
+See the ref for more details, but `normal` is fairly sharp, with a little blur, `distort` uses nearest neighbor, which is the sharpest option, but introduces heavier distortion some might find distracting, and `blur` uses bilinear sampling, which causes a LOT of blur.
+
+If you are using integer scaling, `distort` provides a perfect image, while the other two are not recommended to be used.
 
 ## Eye
 

--- a/code/modules/client/preferences/pixel_size.dm
+++ b/code/modules/client/preferences/pixel_size.dm
@@ -4,7 +4,7 @@
 	savefile_identifier = PREFERENCE_PLAYER
 
 	minimum = 0
-	maximum = 5
+	maximum = 9
 
 	step = 0.5
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pixel_size.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/pixel_size.tsx
@@ -12,5 +12,9 @@ export const pixel_size: Feature<number> = {
     4: 'Pixel Perfect 4x',
     4.5: 'Pixel Perfect 4.5x',
     5: 'Pixel Perfect 5x',
+    6: 'Pixel Perfect 6x',
+    7: 'Pixel Perfect 7x',
+    8: 'Pixel Perfect 8x',
+    9: 'Pixel Perfect 9x',
   }),
 };


### PR DESCRIPTION
Original PR: 92130
-----


## About The Pull Request

Extends the max range for integer scaling up to 9x, corrects some misinfo in the visuals guide

## Why It's Good For The Game

This allows proper integer scaling up to 8k resolution, which not only is generally the highest consumer-available resolution currently, but also the next resolution that is able to perfectly display a 480p image on it via integer scaling.

Also corrects misinfo because misinfo is bad.

## Changelog

:cl:
qol: Increased the integer scaling range up to 9x
/:cl:
