### PR TITLE
[TG Mirror] Fixes individual turfs like water and lava all having their own fishing loot tables. [MDB IGNORE]

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -821,7 +821,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 /turf/proc/add_fishing_spot_comp(datum/source, obj/item/fishing_rod/rod, mob/user)
 	SIGNAL_HANDLER
-	var/datum/component/fishing_spot/spot = source.AddComponent(/datum/component/fishing_spot, fish_source)
+	var/datum/component/fishing_spot/spot = source.AddComponent(/datum/component/fishing_spot, GLOB.preset_fish_sources[fish_source])
 	remove_lazy_fishing()
 	return spot.handle_cast(arglist(args))
 


### PR DESCRIPTION
Original PR: 91999
-----
## About The Pull Request
Big oversight from that one PR where I refactored lazy fishing spots to halve the time spent initializing water and lava turfs that resulted in generating new fish source datums everytime the fishing component is added to a turf, instead of using the presets.

## Why It's Good For The Game
This will fix #91847.

## Changelog

:cl:
fix: Fixed an issue with fishing turfs like water and lava having multiple fish source datums, making it possible to fish the same limited, rare loot more times than you should.
/:cl:
