### PR TITLE
[TG Mirror] Healium bolts now heal people instead of damaging them. [MDB IGNORE]

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -143,7 +143,7 @@
 	var/obj/item/ammo_casing/rebar/healium/casing = parent
 	casing.heals_left -= seconds_per_tick * 1 SECONDS
 	var/update_health = FALSE
-	var/healing = healing_per_second * seconds_per_tick
+	var/healing = -healing_per_second * seconds_per_tick
 	update_health += owner.adjustBruteLoss(healing, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)
 	update_health += owner.adjustFireLoss(healing, updating_health = FALSE, required_bodytype = BODYTYPE_ORGANIC)
 	update_health += owner.adjustToxLoss(healing, updating_health = FALSE, required_biotype = BODYTYPE_ORGANIC)


### PR DESCRIPTION
Original PR: 92137
-----
## About The Pull Request
Fixes healium bolts

## Why It's Good For The Game
Healium bolts are supposed to heal people

## Changelog

:cl:
fix: Healium bolts now heal instead of dealing damage
/:cl:
