### PR TITLE
[TG Mirror] Rewrites description of agent IDs, splits limited-slot and unlimited-slot IDs more cleanly [MDB IGNORE]

### DIFF
--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -269,7 +269,7 @@
 	pixel_x = 6;
 	pixel_y = -6
 	},
-/obj/item/card/id/advanced/chameleon,
+/obj/item/card/id/advanced/chameleon/elite,
 /obj/item/card/id/advanced/gold/captains_spare{
 	pixel_x = -6;
 	pixel_y = 6

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -1650,10 +1650,9 @@
 
 /obj/item/card/id/advanced/chameleon
 	name = "agent card"
-	desc = "A highly advanced chameleon ID card. Touch this card on another ID card or player to choose which accesses to copy. \
+	desc = "An advanced chameleon ID card. Swipe this card on another ID card, or a person wearing one, to copy access. \
 		Has special magnetic properties which force it to the front of wallets."
 	trim = /datum/id_trim/chameleon
-	wildcard_slots = WILDCARD_LIMIT_GOLD
 	trim_changeable = FALSE
 	actions_types = list(/datum/action/item_action/chameleon/change/id, /datum/action/item_action/chameleon/change/id_trim)
 	action_slots = ALL
@@ -1664,10 +1663,6 @@
 	var/anyone = FALSE
 	/// Weak ref to the ID card we're currently attempting to steal access from.
 	var/datum/weakref/theft_target
-
-/obj/item/card/id/advanced/chameleon/crummy
-	desc = "A surplus version of a chameleon ID card. Can only hold a limited number of access codes."
-	wildcard_slots = WILDCARD_LIMIT_CHAMELEON
 
 /obj/item/card/id/advanced/chameleon/Destroy()
 	theft_target = null
@@ -1970,8 +1965,17 @@
 		return CONTEXTUAL_SCREENTIP_SET
 	return .
 
-/// A special variant of the classic chameleon ID card which is black. Cool!
 /obj/item/card/id/advanced/chameleon/black
+	icon_state = "card_black"
+	assigned_icon_state = "assigned_syndicate"
+
+/// Upgraded variant of agent id, can hold unlimited amount of accesses.
+/obj/item/card/id/advanced/chameleon/elite
+	desc = "A highly advanced chameleon ID card. Swipe this card on another ID card, or a person wearing one, to copy access. \
+		Has special magnetic properties which force it to the front of wallets, and an embedded high-end microchip to hold unlimited access codes."
+	wildcard_slots = WILDCARD_LIMIT_GOLD
+
+/obj/item/card/id/advanced/chameleon/elite/black
 	icon_state = "card_black"
 	assigned_icon_state = "assigned_syndicate"
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -53,7 +53,7 @@
 			new /obj/item/flashlight/emp(src) // 4 tc
 
 		if(KIT_BLOODY_SPAI)
-			new /obj/item/card/id/advanced/chameleon(src) // 2 tc
+			new /obj/item/card/id/advanced/chameleon/elite(src) // 2 tc
 			new /obj/item/clothing/under/chameleon(src) // 2 tc since it's not the full set
 			new /obj/item/clothing/mask/chameleon(src) // Goes with above
 			new /obj/item/clothing/shoes/chameleon/noslip(src) // 2 tc
@@ -124,7 +124,7 @@
 			new /obj/item/storage/toolbox/syndicate(src) // 1 tc
 			new /obj/item/computer_disk/syndicate/camera_app(src) // 1 tc
 			new /obj/item/clothing/glasses/thermal/syndi(src) // 4 tc
-			new /obj/item/card/id/advanced/chameleon(src) // 2 tc
+			new /obj/item/card/id/advanced/chameleon/elite(src) // 2 tc
 
 		if(KIT_LORD_SINGULOTH) //currently disabled, i might return with another anti-engine kit
 			new /obj/item/sbeacondrop(src) // 10 tc
@@ -201,7 +201,7 @@
 			new /obj/item/suppressor(src) // 3 tc
 			new /obj/item/ammo_box/magazine/m9mm(src) // 1 tc
 			new /obj/item/ammo_box/magazine/m9mm(src)
-			new /obj/item/card/id/advanced/chameleon(src) // 2 tc
+			new /obj/item/card/id/advanced/chameleon/elite(src) // 2 tc
 			new /obj/item/clothing/under/chameleon(src) // 1 tc
 			new /obj/item/reagent_containers/hypospray/medipen/stimulants(src) // 5 tc
 			new /obj/item/rag(src)
@@ -218,7 +218,7 @@
 				new /obj/item/throwing_star(src) // 1 tc
 			new /obj/item/storage/belt/chameleon(src) // worth some fraction of a tc
 			new /obj/item/chameleon(src) // 7 tc
-			new /obj/item/card/id/advanced/chameleon(src) // 2 tc
+			new /obj/item/card/id/advanced/chameleon/elite(src) // 2 tc
 			new /obj/item/card/emag/doorjack(src) // 3 tc
 			new /obj/item/book/granter/action/spell/smoke(src) // ninja smoke bomb. 1 tc
 			new /obj/item/clothing/shoes/bhop(src) // mining item, lets you jump at people, at least 2 tc
@@ -227,7 +227,7 @@
 			new /obj/item/dualsaber/red(src) // 16 tc
 			new /obj/item/dnainjector/telemut/darkbundle(src) // ~ 4 tc for tk
 			new /obj/item/clothing/suit/hooded/chaplain_hoodie(src)
-			new /obj/item/card/id/advanced/chameleon(src) // 2 tc
+			new /obj/item/card/id/advanced/chameleon/elite(src) // 2 tc
 			new /obj/item/clothing/shoes/chameleon/noslip(src) //2 tc ,because slipping while being a dark lord sucks
 			new /obj/item/book/granter/action/spell/summonitem(src) // ~2 tc
 			new /obj/item/book/granter/action/spell/lightningbolt(src) // 4 tc
@@ -289,7 +289,7 @@
 				new /obj/item/clothing/neck/collar_bomb(src) // These let you remotely kill people with a signaler, though you have to get them first.
 			new /obj/item/storage/box/syndie_kit/signaler(src)
 			new /obj/item/mod/control/pre_equipped/responsory/inquisitory/syndie(src) // basically a snowflake yet better elite modsuit, so like, 8 + 5 tc.
-			new /obj/item/card/id/advanced/chameleon(src) // 2 tc
+			new /obj/item/card/id/advanced/chameleon/elite(src) // 2 tc
 			new /obj/item/clothing/mask/chameleon(src)
 			new /obj/item/melee/baton/telescopic/contractor_baton(src) // 7 tc
 			new /obj/item/jammer(src) // 5 tc
@@ -736,7 +736,7 @@
 	// The necessary equipment to help secure that disky.
 	new /obj/item/radio/headset/syndicate/alt(src) // 5 TC / Free for nukies
 	new /obj/item/modular_computer/pda/nukeops(src) // ?? TC / Free for nukies
-	new /obj/item/card/id/advanced/chameleon(src) // 2 TC / Free for nukies
+	new /obj/item/card/id/advanced/chameleon/elite(src) // 2 TC / Free for nukies
 	var/obj/item/clothing/suit/space/syndicate/spess_suit = pick(GLOB.syndicate_space_suits_to_helmets)
 	new spess_suit(src) // Above allows me to get the helmet from a variable on the object
 	var/obj/item/clothing/head/helmet/space/syndicate/spess_helmet = GLOB.syndicate_space_suits_to_helmets[spess_suit]
@@ -864,7 +864,7 @@
 	new /obj/item/clothing/suit/space/syndicate/contract(src)
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
-	new /obj/item/card/id/advanced/chameleon(src)
+	new /obj/item/card/id/advanced/chameleon/elite(src)
 	new /obj/item/clothing/glasses/thermal/syndi(src)
 	new /obj/item/storage/toolbox/syndicate(src)
 	new /obj/item/jammer(src)

--- a/code/modules/antagonists/clown_ops/outfits.dm
+++ b/code/modules/antagonists/clown_ops/outfits.dm
@@ -8,7 +8,7 @@
 	ears = /obj/item/radio/headset/syndicate/alt
 	l_pocket = /obj/item/pinpointer/nuke/syndicate
 	r_pocket = /obj/item/bikehorn
-	id = /obj/item/card/id/advanced/chameleon
+	id = /obj/item/card/id/advanced/chameleon/elite
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/toy/riot/clandestine = 1, //The clown op equivalent to the Ansem
 		/obj/item/pen/edagger = 1,

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -8,7 +8,7 @@
 	ears = /obj/item/radio/headset/syndicate/alt
 	l_pocket = /obj/item/modular_computer/pda/nukeops
 	r_pocket = /obj/item/pen/edagger
-	id = /obj/item/card/id/advanced/chameleon
+	id = /obj/item/card/id/advanced/chameleon/elite
 	belt = /obj/item/gun/ballistic/automatic/pistol/clandestine
 
 	skillchips = list(/obj/item/skillchip/disk_verifier)

--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -201,7 +201,7 @@
 		/obj/item/clothing/mask/chameleon,
 		/obj/item/clothing/under/chameleon,
 		/obj/item/storage/belt/chameleon,
-		/obj/item/card/id/advanced/chameleon/crummy,
+		/obj/item/card/id/advanced/chameleon,
 		/obj/item/switchblade,
 		/obj/item/grenade/mirage = 5,
 	)

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -194,7 +194,7 @@
 /datum/outfit/assassin
 	name = "Assassin"
 
-	id = /obj/item/card/id/advanced/chameleon/black
+	id = /obj/item/card/id/advanced/chameleon/elite/black
 	id_trim = /datum/id_trim/reaper_assassin
 	uniform = /obj/item/clothing/under/costume/buttondown/slacks/service
 	neck = /obj/item/clothing/neck/tie/red/hitman/tied

--- a/code/modules/uplink/uplink_items/stealthy_tools.dm
+++ b/code/modules/uplink/uplink_items/stealthy_tools.dm
@@ -13,7 +13,7 @@
 			from other identification cards. In addition, they can be forged to display a new assignment, name and trim. \
 			This can be done an unlimited amount of times. Some Syndicate areas and devices can only be accessed \
 			with these cards."
-	item = /obj/item/card/id/advanced/chameleon
+	item = /obj/item/card/id/advanced/chameleon/elite
 	cost = 2
 
 /datum/uplink_item/stealthy_tools/ai_detector


### PR DESCRIPTION
Original PR: 92097
-----

## About The Pull Request
Agent ID splitting patch is #89709

Previous patch made two tiers of agent IDs, ones that have unlimited slots for access and those with a limited amount (crummy varient). Crummy variant was intended to be the baseline and obtainable from cargo and space ruin etc, with the better version avaliable to uplink antags.

Change 1: Crummy has been removed, it's now the regular ID card. The version with no slot limit is the "elite" variant.

Change 2: Elite cards are more exclusive to the uplink. No outfits spawn elite cards except the nukie outfit and the reaper outfit (i think this is an admin event thing?). This means none of the syndicate corpses in space ruins or ghost roles with chameleon IDs, or spawned from mobs, have unlimited access limits. Effectively they've gone back to pre-buff status.

Change 3: Rewrote the item descriptions to make them clearer to read.
## Why It's Good For The Game
Change 1: Helps clarity when people map and code these into places in future. "Do I want the regular card, or the elite?" vs "Do I want the regular card, or the crappy?". Elite being a subtype tells people in future that these should be exclusive compared to the regular subtype. Also for flavour reasons I think it's better to have traitors/nukies get their hands on *the best* shit that's a step above what the syndicate usually uses, rather than regular agents getting shitty equipment.

Change 2: This was the intent in the previous patch but simply put they flubbed it. They only downgraded the cargo crate's cards, not other sources. Worse, patches that added chameleon cards added the supposedly traitor-only version and not the regular, because of how confusing the subtypes were (hence why change 1

Change 3: Speaks for itself, old description had awkward writing and didnt actually describe the difference between both tiers of card.
## Changelog
:cl:
fix: Agent IDs that have not been spawned by an uplink or on a nuke op no longer have infinite access slots.
spellcheck: Rewrote item description for Agent IDs
/:cl:
