### PR TITLE
[TG Mirror] Add shuttle remote design to protolathe [MDB IGNORE]

### DIFF
--- a/code/modules/research/designs/tool_designs.dm
+++ b/code/modules/research/designs/tool_designs.dm
@@ -440,6 +440,7 @@
 	name = "Shuttle Remote Control"
 	desc = "A remote which can send away or try to dock shuttles once linked to a navigation console."
 	id = "shuttle_remote"
+	build_type = PROTOLATHE
 	build_path = /obj/item/shuttle_remote
 	materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT, /datum/material/bluespace = HALF_SHEET_MATERIAL_AMOUNT, /datum/material/iron = SMALL_MATERIAL_AMOUNT * 2, /datum/material/glass = SMALL_MATERIAL_AMOUNT)
 	category = list(


### PR DESCRIPTION
Original PR: 92048
-----

## About The Pull Request

No `build_type` was specified for the shuttle remote design, meaning nobody can actually print it. Adds it to the protolathe

## Why It's Good For The Game

Fixes #92024 

## Changelog
:cl:
fix: fixed shuttle remote design missing from protolathe
/:cl:
