### PR TITLE
[TG Mirror] [NO GBP] Unscrambles normal evac reason broadcasts [MDB IGNORE]

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -698,7 +698,7 @@ SUBSYSTEM_DEF(ticker)
 			// Had an emergency reason supplied to pass along
 			if(emergency_reason)
 				news_message = "[decoded_station_name] has been evacuated after transmitting \
-					the following distress beacon:\n\n[Gibberish(decoded_emergency_reason, FALSE, 8)]"
+					the following distress beacon:\n\n[decoded_emergency_reason]"
 			else
 				news_message = "The crew of [decoded_station_name] has been \
 					evacuated amid unconfirmed reports of enemy activity."
@@ -768,7 +768,7 @@ SUBSYSTEM_DEF(ticker)
 		if(SHUTTLE_HIJACK)
 			news_message = "During routine evacuation procedures, the emergency shuttle of [decoded_station_name] \
 				had its navigation protocols corrupted and went off course, but was recovered shortly after. \
-				The following distress beacon was sent prior to evacuation:\n\n[decoded_emergency_reason]"
+				The following distress beacon was sent prior to evacuation:\n\n[Gibberish(decoded_emergency_reason, FALSE, 8)]"
 		// A supermatter cascade triggered
 		if(SUPERMATTER_CASCADE)
 			news_message = "Officials are advising nearby colonies about a newly declared exclusion zone in \


### PR DESCRIPTION
Original PR: 92173
-----

## About The Pull Request

Normal evac broadcasts are no longer scrambled. Hijacked ones now are.
## Why It's Good For The Game

I put the right code in the wrong place.
## Changelog
:cl: Rhials
fix: Evac broadcast messages are no longer scrambled unless the shuttle was hijacked.
/:cl:
