### PR TITLE
[TG Mirror] Reduce size of fake rulechat AO from 3 to 2 [MDB IGNORE]

### DIFF
--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -460,7 +460,7 @@
 	if(istype(mymob) && mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/ambient_occlusion))
 		// We use outlines instead of drop shadow due to how extremely expensive it is, and there's no reason to use it for runechat
 		// which already has high drop shadow transparency at just 32 alpha, so outline does the job good enough
-		add_filter("AO", 1, outline_filter(size = 3, color = "#04080F20", flags = OUTLINE_SQUARE))
+		add_filter("AO", 1, outline_filter(size = 2, color = "#04080F20", flags = OUTLINE_SQUARE))
 
 /atom/movable/screen/plane_master/balloon_chat
 	name = "Balloon chat"


### PR DESCRIPTION
Original PR: 92152
-----
## About The Pull Request

Real AO / old / new

<img width="411" height="116" alt="image" src="https://github.com/user-attachments/assets/2544e9c3-1956-4b6a-b299-0ad28e04a808" />

## Why It's Good For The Game

Not perfect, but I found it a little jarring just how large the outline was.

## Changelog

:cl: Melbert
qol: Tweaked size of runechat shadow outline.
/:cl:
