### PR TITLE
[TG Mirror] Adds a workflow to create Discord notifications for auto-staled PRs [MDB IGNORE]

### DIFF
--- a/.github/workflows/discord_pr_announce.yml
+++ b/.github/workflows/discord_pr_announce.yml
@@ -1,11 +1,12 @@
-name: "New PR Notification"
+name: "Discord PR Notification"
 on:
   pull_request_target:
-    types: [opened, closed]
+    types: [opened, closed, labeled]
 
 jobs:
   notify:
     runs-on: ubuntu-latest
+    if: ${{ github.event.action != "labeled" || github.event.label.name == "Stale" }}
     steps:
       - name: "Check for DISCORD_WEBHOOK"
         id: secrets_set
@@ -19,13 +20,13 @@ jobs:
         uses: tgstation/discord-notify@v3
         if: >
           steps.secrets_set.outputs.SECRETS_ENABLED &&
-          (github.event.pull_request.merged == true || github.event.action == 'opened') &&
+          (github.event.pull_request.merged == true || github.event.action == 'opened' || github.event.action == 'labeled') &&
           github.event.pull_request.author_association != 'FIRST_TIMER' &&
           github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR'
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK }}
           title: ${{ github.event.pull_request.user.login }} - ${{ github.event.pull_request.title }}
-          message: "GET_ACTION"
+          message: ${{ github.event.action != "labeled" && "GET_ACTION" || "**Pull Request ${{ github.event.pull_request.number }} automatically marked as stale.**" }}
           include_image: false
           show_author: false
           avatar_url: https://avatars.githubusercontent.com/u/1363778?s=200&v=4


### PR DESCRIPTION
Original PR: 92148
-----
## About The Pull Request

Exactly what the title says. When the "Stale" label is added to a PR, a notification is sent via the repository's configured webhook.

## Why It's Good For The Game

<img width="586" height="58" alt="image" src="https://github.com/user-attachments/assets/eee0e4a7-f052-4854-9e6e-c4af93663648" />

## Changelog

No player-facing changes.
