### PR TITLE
[TG Mirror] Changes 'beach bar' bitdomain ghost-spawners to be virtual_domain subtypes [MDB IGNORE]

### DIFF
--- a/_maps/virtual_domains/beach_bar.dmm
+++ b/_maps/virtual_domains/beach_bar.dmm
@@ -648,7 +648,7 @@
 /area/virtual_domain/fullbright)
 "CA" = (
 /obj/structure/window/reinforced/spawner/directional/east,
-/obj/effect/mob_spawn/ghost_role/human/beach/lifeguard,
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/beach/lifeguard,
 /turf/open/floor/wood,
 /area/virtual_domain/fullbright)
 "CO" = (
@@ -875,7 +875,7 @@
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/virtual_domain/fullbright)
 "OE" = (
-/obj/effect/mob_spawn/ghost_role/human/beach{
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/beach{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -906,7 +906,7 @@
 /area/virtual_domain/fullbright)
 "Pg" = (
 /obj/structure/sign/poster/official/high_class_martini/directional/west,
-/obj/effect/mob_spawn/ghost_role/human/bartender{
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/beach/bartender{
 	dir = 4
 	},
 /turf/open/floor/wood,

--- a/code/modules/bitrunning/spawners.dm
+++ b/code/modules/bitrunning/spawners.dm
@@ -5,6 +5,8 @@
 	you_are_text = "You are NOT supposed to be here. How did you let this happen?"
 	important_text = "Bitrunning is a crime, and your primary threat."
 	temp_body = TRUE
+	///Does this bit-entity get an antag datum with the goal of hunting bitrunners? TRUE by default
+	var/antag = TRUE
 
 
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/special(mob/living/spawned_mob, mob/mob_possessor)
@@ -14,14 +16,42 @@
 
 	..()
 
-	spawned_mob.mind.add_antag_datum(/datum/antagonist/domain_ghost_actor)
-
+	if(antag)
+		spawned_mob.mind.add_antag_datum(/datum/antagonist/domain_ghost_actor)
 
 /// Simulates a ghost role spawn without calling special(), ie a bitrunner spawn instead of a ghost.
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/proc/artificial_spawn(mob/living/runner)
 	SEND_SIGNAL(src, COMSIG_BITRUNNER_SPAWNED, runner)
 
+//Beach Bums (Friendly)
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/beach
+	prompt_name = "a virtual beach bum"
+	name = "virtual beach bum sleeper"
+	you_are_text = "You're, like, totally a virtual simulation of a dudebro, bruh."
+	flavour_text = "Ch'yea. You came here, like, on spring break, hopin' to pick up some bangin' hot e-chicks, y'knaw?"
+	important_text = "You have no qualms with Bitrunning: in fact, you aren't even aware you're in a simulation."
+	outfit = /datum/outfit/beachbum
+	spawner_job_path = /datum/job/beach_bum
+	antag = FALSE
 
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/beach/lifeguard
+	name = "virtual lifeguard sleeper"
+	you_are_text = "You are a spunky virtual lifeguard!"
+	flavour_text = "It's up to you to make sure nobody lags or gets eaten by malware and stuff."
+	outfit = /datum/outfit/beachbum/lifeguard
+
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/beach/lifeguard/special(mob/living/carbon/human/lifeguard, mob/mob_possessor)
+	. = ..()
+	lifeguard.gender = FEMALE
+	lifeguard.update_body()
+
+/obj/effect/mob_spawn/ghost_role/human/virtual_domain/beach/bartender
+	name = "virtual bartender sleeper"
+	you_are_text = "You are a virtual beach bartender!"
+	flavour_text = "Your job is to keep the virtually rendered drinks coming, and help the dudebros engage drunkness simulations."
+	outfit = /datum/outfit/spacebartender
+
+//Skeleton Pirates
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/pirate
 	name = "Virtual Pirate Remains"
 	desc = "Some inanimate bones. They feel like they could spring to life at any moment!"
@@ -42,12 +72,11 @@
 	head = /obj/item/clothing/head/costume/pirate/bandana/armored
 	shoes = /obj/item/clothing/shoes/pirate/armored
 
-
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/pirate/special(mob/living/spawned_mob, mob/mob_possessor)
 	. = ..()
 	spawned_mob.fully_replace_character_name(spawned_mob.real_name, "[pick(strings(PIRATE_NAMES_FILE, "generic_beginnings"))][pick(strings(PIRATE_NAMES_FILE, "generic_endings"))]")
 
-
+//Syndicate
 /obj/effect/mob_spawn/ghost_role/human/virtual_domain/syndie
 	name = "Virtual Syndicate Sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
@@ -58,7 +87,6 @@
 	outfit = /datum/outfit/virtual_syndicate
 	spawner_job_path = /datum/job/space_syndicate
 
-
 /datum/outfit/virtual_syndicate
 	name = "Virtual Syndie"
 	id = /obj/item/card/id/advanced/chameleon
@@ -68,7 +96,6 @@
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
 	shoes = /obj/item/clothing/shoes/combat
 	implants = list(/obj/item/implant/weapons_auth)
-
 
 /datum/outfit/virtual_syndicate/post_equip(mob/living/carbon/human/user, visuals_only)
 	user.faction |= ROLE_SYNDICATE


### PR DESCRIPTION
Original PR: 92177
-----
## About The Pull Request
Simple enough. This domain used just plain ghost spawners from the lavaland ruin previously.
Now, it has `temp_body = TRUE`, allowing ghosts to return to their original body after leaving the domain
_Alongside this it has unique little descriptions to cement it as NPC actors_

This also adds a new `antag` variable to virtual_domain spawners, which decides if they get the hunt-bitrunners antag datum _(default True, in this case False)_

<h5>I did notice a few bugs while testing this, namely that temp_body doesn't always work? I'm not coder enough to hunt down why and fix it though... the two cases I noticed will be made into a bug report.</h5>

## Why It's Good For The Game
It feels weird that there's this temp_body ghost spawner stuff for bitdomains, but it's not used in **all** the bitdomains. They don't last that long, making them permanently kill old bodies feels odd.
This also sets up an easy var for other bit ghostroles to use if they aren't explicitly antags hunting bitrunners, and don't need an antag datum.
<img width="853" height="449" alt="image" src="https://github.com/user-attachments/assets/d5761ac1-25bd-4ee5-b281-14fe4392479e" />

## Changelog
:cl:
qol: made the Beach Bar bitdomain ghostrole spawners keep your old body revivable (as other bitdomain spawners do)
/:cl:
