### PR TITLE
[TG Mirror] Removes completing re-enforced girders with iron rods [MDB IGNORE]

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -94,11 +94,14 @@
 					transfer_fingerprints_to(FW)
 					qdel(src)
 					return
+			else if(state == GIRDER_REINF)
+				balloon_alert(user, "need plasteel sheet!")
+				return
 			else
 				if(rod.get_amount() < amount)
 					balloon_alert(user, "need [amount] rods!")
 					return
-				balloon_alert(user, "adding plating...")
+				balloon_alert(user, "adding rods...")
 				if(do_after(user, 4 SECONDS, target = src))
 					if(rod.get_amount() < amount)
 						return


### PR DESCRIPTION
Original PR: 92163
-----
## About The Pull Request
- Fixes #92080

There was already a check to stop you from using iron sheets. It should be applied to iron rods as well. Also corrected the feedback

## Changelog
:cl:
fix: You cannot complete re-enforced girders with iron rods
/:cl:

