### PR TITLE
[TG Mirror] you can now click on the URL in the tgui audio player widget [MDB IGNORE]

### DIFF
--- a/tgui/packages/tgui-panel/audio/NowPlayingWidget.jsx
+++ b/tgui/packages/tgui-panel/audio/NowPlayingWidget.jsx
@@ -46,7 +46,7 @@ export const NowPlayingWidget = (props) => {
               <Section>
                 {URL !== 'Song Link Hidden' && (
                   <Flex.Item grow={1} color="label">
-                    URL: {URL}
+                    URL: <a href={URL}>{URL}</a>
                   </Flex.Item>
                 )}
                 <Flex.Item grow={1} color="label">


### PR DESCRIPTION
Original PR: 92203
-----
## About The Pull Request

port of https://github.com/Monkestation/Monkestation2.0/pull/7220

<img width="729" height="109" alt="image" src="https://github.com/user-attachments/assets/3a1dddac-5dd8-4d60-b360-678d9d796581" />

## Why It's Good For The Game

much less annoying than having to copy-paste it

## Changelog
:cl:
qol: You can now click on the song URL in the music player widget in chat.
/:cl:
