### PR TITLE
[TG Mirror] Ensures that components can stop attack_self() proc code from running on energy guns if it would return COMSIG_CANCEL_ATTACK_CHAIN [MDB IGNORE]

### DIFF
--- a/code/datums/components/crank_recharge.dm
+++ b/code/datums/components/crank_recharge.dm
@@ -43,6 +43,7 @@
 	SIGNAL_HANDLER
 
 	INVOKE_ASYNC(src, PROC_REF(crank), source, user) //game doesnt like signal handler and do afters mingling
+	return COMPONENT_CANCEL_ATTACK_CHAIN
 
 /datum/component/crank_recharge/proc/crank(obj/source, mob/user)
 	if(charging_cell.charge >= charging_cell.maxcharge)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -179,9 +179,12 @@
 		update_appearance()
 
 /obj/item/gun/energy/attack_self(mob/living/user as mob)
+	. = ..()
+	if(.)
+		return
+
 	if(ammo_type.len > 1 && can_select)
 		select_fire(user)
-	return ..()
 
 /obj/item/gun/energy/can_shoot()
 	var/obj/item/ammo_casing/energy/shot = ammo_type[select]


### PR DESCRIPTION
Original PR: 92019
-----

## About The Pull Request

What it says on the tin.

## Why It's Good For The Game

Should a component potentially want to override the behaviour of energy guns attack_self() proc, it will not be able to prevent this code from running without this check.

## Changelog

This is not player facing as this does not meaningfully impact anything....yet.
