### PR TITLE
[TG Mirror] Fix icon cutter lint not running [MDB IGNORE]

### DIFF
--- a/tools/icon_cutter/check.py
+++ b/tools/icon_cutter/check.py
@@ -93,11 +93,16 @@ for cutter_template in files:
 
     output_hash[output_name] = get_file_hash(output_name)
 
+# Sanity check
+if len(output_hash) == 0:
+    print(f"::error output_hash dict was empty. Something has gone wrong")
+    sys.exit(1)
+
 # Execute cutter
 if platform.system() == "Windows":
     subprocess.run(f"{path_to_us}\..\\build\\build.bat --force-recut --ci icon-cutter")
 else:
-    subprocess.run(f"{path_to_us}/../build/build --force-recut --ci icon-cutter", shell = True)
+    subprocess.run(f"{path_to_us}/../build/build.sh --force-recut --ci icon-cutter", shell = True)
 
 for output_name in output_hash:
     old_hash, old_metadata, old_icon_hash = output_hash[output_name]


### PR DESCRIPTION
Original PR: 92149
-----
## About The Pull Request

`tools/build/build` got renamed to `tools/build/build.sh` but nobody told the icon cutter lint. Also add an error state if the lint failed to hash any dmi/png files

## Why It's Good For The Game

Fixes this
<img width="700" height="125" alt="image" src="https://github.com/user-attachments/assets/7dfc8fea-eaeb-4461-b3e4-0f01b9b39645" />

## Changelog

N/A
