### PR TITLE
[TG Mirror] Reduces the amount of Public medkits in general, Changes Nanomed wall vendors, into emergency wall vendors [MDB IGNORE]

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -371,12 +371,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"agD" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/openspace,
-/area/station/engineering/atmos/project)
 "agF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -3399,6 +3393,14 @@
 	dir = 1
 	},
 /area/station/science/ordnance/storage)
+"bdi" = (
+/obj/machinery/light/directional/south,
+/obj/structure/rack,
+/obj/effect/spawner/random/armory/riot_shield,
+/obj/structure/cable,
+/obj/machinery/light_switch/directional/south,
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "bdu" = (
 /obj/machinery/vending/boozeomat,
 /obj/structure/extinguisher_cabinet/directional/north,
@@ -3773,6 +3775,26 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/explab)
+"biS" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/filled/mid_joiner{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet{
+	name = "contraband locker";
+	req_access = list("armory")
+	},
+/obj/effect/spawner/random/contraband/armory,
+/obj/effect/spawner/random/maintenance/three,
+/obj/structure/cable,
+/obj/machinery/button/door/directional/south{
+	id = "armory";
+	name = "Armory Shutters"
+	},
+/turf/open/floor/iron/dark/smooth_large,
+/area/station/ai_monitored/security/armory)
 "biZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -4814,13 +4836,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/carpet,
 /area/station/command/bridge)
-"byS" = (
-/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/binary/pump/on/general/visible,
-/turf/open/floor/engine,
-/area/station/engineering/supermatter/room)
 "byU" = (
 /obj/structure/railing{
 	dir = 4
@@ -5092,6 +5107,12 @@
 	},
 /turf/open/floor/wood/large,
 /area/station/service/kitchen)
+"bDj" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/turf/open/floor/catwalk_floor,
+/area/station/engineering/engine_smes)
 "bDm" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/maintenance,
@@ -5929,11 +5950,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/medical/chemistry)
-"bPv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "bPw" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/emergency,
@@ -7174,18 +7190,6 @@
 /obj/machinery/light/dim/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/commons/vacant_room/commissary)
-"cfr" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "cfx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -7354,6 +7358,10 @@
 /obj/machinery/computer/records/medical/laptop,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"cil" = (
+/obj/item/radio/intercom/directional/south,
+/turf/closed/wall/r_wall,
+/area/station/engineering/main)
 "cio" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
@@ -8642,16 +8650,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/commons/storage/art)
-"cBE" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/stairs,
-/turf/open/floor/iron/stairs/medium{
-	dir = 1
-	},
-/area/station/maintenance/port/aft)
 "cBT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing{
@@ -8761,6 +8759,19 @@
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall/r_wall,
 /area/station/engineering/engine_smes)
+"cDg" = (
+/obj/structure/filingcabinet/chestdrawer,
+/mob/living/basic/parrot/poly,
+/obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable,
+/obj/machinery/button/door/directional/west{
+	id = "Engineering";
+	name = "Engineering Lockdown";
+	pixel_x = 23;
+	pixel_y = 11
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/ce)
 "cDq" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -10937,6 +10948,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/maintenance/hallway/abandoned_recreation)
+"dls" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "dlt" = (
 /turf/open/floor/plating/airless,
 /area/station/maintenance/starboard/aft)
@@ -14665,6 +14681,14 @@
 	},
 /turf/open/floor/iron/white/smooth_large,
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"epX" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/glass,
+/obj/item/storage/medkit/regular,
+/obj/structure/cable,
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/security/medical)
 "epY" = (
 /obj/structure/plaque/static_plaque/golden/commission/efficiency{
 	pixel_y = 32
@@ -19725,6 +19749,12 @@
 	dir = 4
 	},
 /area/station/ai_monitored/turret_protected/aisat_interior)
+"fSI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/smooth,
+/area/station/engineering/engine_smes)
 "fSO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/light_construct/directional/east{
@@ -19732,6 +19762,18 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/port/aft)
+"fSP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "fSW" = (
 /obj/machinery/netpod,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -20394,6 +20436,12 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/commons/storage/primary)
+"gbv" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/sign/poster/official/work_for_a_future/directional/south,
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron,
+/area/station/science/research)
 "gby" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21302,6 +21350,16 @@
 /obj/effect/turf_decal/trimline/dark/arrow_ccw,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
+"gnY" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stairs,
+/turf/open/floor/iron/stairs/medium{
+	dir = 1
+	},
+/area/station/maintenance/port/aft)
 "gob" = (
 /obj/item/wheelchair{
 	pixel_y = -3
@@ -21484,6 +21542,10 @@
 	},
 /turf/open/space/openspace,
 /area/space/nearstation)
+"gqI" = (
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/station/security/warden)
 "gqM" = (
 /obj/effect/spawner/random/trash/cigbutt,
 /turf/open/floor/plating,
@@ -23042,11 +23104,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/teleporter)
-"gRh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "gRn" = (
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
@@ -23132,10 +23189,6 @@
 /obj/effect/decal/cleanable/glitter,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/lesser)
-"gRX" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "gRZ" = (
 /obj/effect/turf_decal/bot,
 /obj/item/robot_suit,
@@ -23275,6 +23328,7 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
 "gVi" = (
@@ -25385,6 +25439,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
+"hBj" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 9
+	},
+/obj/machinery/autolathe,
+/obj/structure/sign/poster/official/do_not_question/directional/north,
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "hBu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/visible{
@@ -26014,6 +26077,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/freezer,
 /area/station/commons/dorms)
+"hJM" = (
+/obj/machinery/door/airlock/engineering/glass,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/machinery/door/firedoor,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "hJY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -26087,6 +26158,11 @@
 	},
 /turf/open/openspace,
 /area/station/maintenance/starboard/aft)
+"hLr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "hLu" = (
 /obj/effect/turf_decal/siding{
 	dir = 8
@@ -26271,12 +26347,6 @@
 /obj/machinery/flasher/directional/west,
 /turf/open/floor/carpet/purple,
 /area/station/ai_monitored/turret_protected/ai_upload)
-"hNe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/light/directional/south,
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "hNf" = (
 /obj/structure/cable,
 /turf/open/floor/plating,
@@ -27747,15 +27817,6 @@
 /obj/effect/spawner/random/maintenance/no_decals,
 /turf/open/floor/engine/hull,
 /area/space/nearstation)
-"ilA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "ilB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/filingcabinet,
@@ -31693,13 +31754,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/lesser)
-"jsB" = (
-/obj/effect/mapping_helpers/burnt_floor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "jsD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/table,
@@ -32177,6 +32231,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
+"jyf" = (
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/wood,
+/area/station/hallway/secondary/service)
 "jyl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/railing,
@@ -32362,17 +32420,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/iron/white,
 /area/station/medical/break_room)
-"jAa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/table/glass,
-/obj/item/storage/medkit/regular,
-/obj/item/storage/medkit/regular{
-	pixel_x = 0;
-	pixel_y = 5
-	},
-/obj/structure/cable,
-/turf/open/floor/iron/dark,
-/area/station/security/medical)
 "jAc" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/engine/hull/air,
@@ -33374,6 +33421,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/openspace,
 /area/station/hallway/primary/starboard)
+"jPb" = (
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/iron/dark,
+/area/station/engineering/engine_smes)
 "jPh" = (
 /obj/structure/broken_flooring/pile/directional/south,
 /turf/open/floor/plating,
@@ -33544,6 +33598,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"jSt" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/mapping_helpers/burnt_floor,
+/obj/machinery/light/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "jSz" = (
 /obj/machinery/mass_driver/trash{
 	dir = 4
@@ -34640,6 +34700,11 @@
 /obj/structure/sign/poster/ripped/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"kjl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/construction)
 "kjF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/junction/yjunction{
@@ -41441,6 +41506,18 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/station/commons/fitness/recreation)
+"mmc" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "mmi" = (
 /obj/machinery/camera/directional/north{
 	c_tag = "Holodeck - Fore";
@@ -42953,26 +43030,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating/airless,
 /area/station/maintenance/port/aft)
-"mJN" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/filled/mid_joiner{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet{
-	name = "contraband locker";
-	req_access = list("armory")
-	},
-/obj/effect/spawner/random/contraband/armory,
-/obj/effect/spawner/random/maintenance/three,
-/obj/structure/cable,
-/obj/machinery/button/door/directional/south{
-	id = "armory";
-	name = "Armory Shutters"
-	},
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
 "mJO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43726,6 +43783,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/office)
+"mXC" = (
+/obj/machinery/atmospherics/pipe/bridge_pipe/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump/on/general/visible,
+/turf/open/floor/engine,
+/area/station/engineering/supermatter/room)
 "mXL" = (
 /obj/effect/turf_decal/weather/snow,
 /turf/open/floor/plating,
@@ -44002,6 +44066,10 @@
 /obj/structure/railing,
 /turf/open/openspace,
 /area/station/engineering/atmos/upper)
+"nck" = (
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron/large,
+/area/station/hallway/primary/central)
 "nct" = (
 /obj/item/radio/intercom/directional/south,
 /obj/structure/disposalpipe/segment{
@@ -44324,13 +44392,11 @@
 /area/station/hallway/primary/central)
 "nhD" = (
 /obj/structure/table/glass,
-/obj/item/storage/medkit/regular{
-	pixel_y = 1
-	},
 /obj/machinery/vending/wallmed/directional/west,
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/item/storage/medkit/advanced,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "nhE" = (
@@ -47489,6 +47555,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/service/abandoned_gambling_den)
+"oai" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/engineering/lobby)
 "oaj" = (
 /turf/closed/wall,
 /area/station/security/medical)
@@ -48089,6 +48162,19 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/engine/hull/air,
 /area/station/hallway/secondary/exit/departure_lounge)
+"okr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "oky" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -50891,15 +50977,6 @@
 /obj/machinery/light_switch/directional/east,
 /turf/open/floor/wood,
 /area/station/service/library/printer)
-"pbM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera/autoname/directional/south,
-/obj/structure/extinguisher_cabinet/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "pbN" = (
 /obj/structure/railing{
 	dir = 1
@@ -51076,13 +51153,6 @@
 "pdO" = (
 /turf/closed/wall,
 /area/station/medical/pharmacy)
-"pdQ" = (
-/obj/machinery/firealarm/directional/south,
-/obj/machinery/atmospherics/components/trinary/filter/layer2{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "pec" = (
 /obj/effect/turf_decal/trimline/brown/filled/line{
 	dir = 1
@@ -52982,14 +53052,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/station/command/gateway)
-"pKg" = (
-/obj/machinery/door/airlock/engineering/glass,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/machinery/door/firedoor,
-/turf/open/floor/iron/dark,
-/area/station/engineering/engine_smes)
 "pKk" = (
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/disposal/bin,
@@ -54301,18 +54363,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/maintenance/starboard/central)
-"qcZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "qdd" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -54485,12 +54535,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/construction)
-"qfy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/turf/open/floor/catwalk_floor,
-/area/station/engineering/engine_smes)
 "qfS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -54605,6 +54649,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron,
 /area/station/engineering/main)
+"qhm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "qhq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -58621,11 +58678,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/iron/dark/smooth_large,
 /area/station/science/lab)
-"rrT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/sign/poster/official/work_for_a_future/directional/south,
-/turf/open/floor/iron,
-/area/station/science/research)
 "rrY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/chair{
@@ -60034,6 +60086,12 @@
 /obj/effect/mapping_helpers/broken_machine,
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
+"rNM" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/openspace,
+/area/station/engineering/atmos/project)
 "rNT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -61707,14 +61765,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/openspace,
 /area/station/hallway/primary/central)
-"soz" = (
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 9
-	},
-/obj/machinery/autolathe,
-/obj/structure/sign/poster/official/do_not_question/directional/north,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "soH" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -63786,14 +63836,6 @@
 /obj/effect/spawner/random/contraband/permabrig_weapon,
 /turf/open/floor/iron/dark,
 /area/station/security/evidence)
-"sVU" = (
-/obj/machinery/light/directional/south,
-/obj/structure/rack,
-/obj/effect/spawner/random/armory/riot_shield,
-/obj/structure/cable,
-/obj/machinery/light_switch/directional/south,
-/turf/open/floor/iron/dark/smooth_large,
-/area/station/ai_monitored/security/armory)
 "sWg" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 8
@@ -66683,19 +66725,6 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
-"tRm" = (
-/obj/structure/filingcabinet/chestdrawer,
-/mob/living/basic/parrot/poly,
-/obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable,
-/obj/machinery/button/door/directional/west{
-	id = "Engineering";
-	name = "Engineering Lockdown";
-	pixel_x = 23;
-	pixel_y = 11
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/ce)
 "tRt" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/table/wood,
@@ -66940,6 +66969,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"tVf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera/autoname/directional/south,
+/obj/structure/extinguisher_cabinet/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "tVl" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/maintenance/two,
@@ -69092,10 +69130,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/science/robotics)
-"uyi" = (
-/obj/item/radio/intercom/directional/south,
-/turf/closed/wall/r_wall,
-/area/station/engineering/main)
 "uyn" = (
 /obj/structure/cable,
 /obj/effect/decal/cleanable/dirt,
@@ -69610,6 +69644,10 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/security/prison/mess)
+"uFR" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "uFV" = (
 /obj/structure/table/reinforced,
 /obj/structure/lattice/catwalk,
@@ -72173,6 +72211,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/dark/textured,
 /area/station/maintenance/starboard/lesser)
+"vtK" = (
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/components/trinary/filter/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "vtT" = (
 /turf/open/floor/glass,
 /area/station/science/zoo)
@@ -75069,10 +75114,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/lobby)
-"wmS" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall,
-/area/station/security/warden)
 "wmZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/random/structure/tank_holder,
@@ -75622,6 +75663,13 @@
 /obj/effect/spawner/random/entertainment/dice,
 /turf/open/floor/wood/large,
 /area/station/service/library)
+"wvm" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "wvw" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -75687,19 +75735,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet,
 /area/station/command/bridge)
-"wwg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/ash,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "wwj" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/textured_large,
@@ -78182,12 +78217,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/cytology)
-"xkl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/smooth,
-/area/station/engineering/engine_smes)
 "xkn" = (
 /obj/structure/railing/corner,
 /obj/structure/cable,
@@ -80066,6 +80095,15 @@
 /obj/structure/cable,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage)
+"xOS" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/disposal/incinerator)
 "xOW" = (
 /turf/open/floor/plating,
 /area/station/security/interrogation)
@@ -80757,19 +80795,6 @@
 	luminosity = 2
 	},
 /area/station/ai_monitored/command/nuke_storage)
-"xYz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/disposal/incinerator)
 "xYL" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/effect/mapping_helpers/airlock/access/any/engineering/maintenance,
@@ -106833,7 +106858,7 @@ gPW
 xRU
 xOn
 xAj
-gse
+jyf
 own
 wik
 uxl
@@ -107680,7 +107705,7 @@ jGl
 tce
 fjQ
 qyf
-cBE
+gnY
 lIr
 dcE
 dcE
@@ -113521,7 +113546,7 @@ bOk
 bOk
 wrI
 fjt
-fLr
+nck
 vuO
 ilg
 wmy
@@ -121546,7 +121571,7 @@ hFi
 hFi
 hFi
 hFi
-hFi
+kjl
 gnT
 hFi
 hFi
@@ -122024,7 +122049,7 @@ iYq
 caE
 dUe
 oDH
-oDH
+wvm
 iKT
 oDH
 oDH
@@ -122540,7 +122565,7 @@ qgr
 xiy
 lmt
 qPj
-soz
+hBj
 gNy
 qgI
 lMT
@@ -123008,7 +123033,7 @@ jSf
 jSf
 jSf
 eCn
-uyi
+cil
 jSf
 qWL
 pvp
@@ -125322,7 +125347,7 @@ neI
 bww
 cTQ
 xdR
-byS
+mXC
 cYg
 uJv
 wdS
@@ -125857,7 +125882,7 @@ xSq
 irJ
 grE
 rTW
-dPD
+oai
 dPD
 dPD
 sNK
@@ -127630,8 +127655,8 @@ lOZ
 jrh
 pdD
 smY
-qfy
-xkl
+bDj
+fSI
 qlz
 fUc
 uar
@@ -165198,7 +165223,7 @@ hld
 gKN
 hld
 stm
-sVU
+bdi
 gRG
 qQx
 csh
@@ -165712,7 +165737,7 @@ bkj
 knr
 hYx
 nBw
-mJN
+biS
 gRG
 mXS
 rTo
@@ -167006,7 +167031,7 @@ tlL
 jhO
 muJ
 qFA
-jAa
+epX
 kUq
 uJi
 kUq
@@ -168277,7 +168302,7 @@ dDS
 uKa
 uKa
 bII
-wmS
+gqI
 xeS
 ggt
 ktp
@@ -181929,7 +181954,7 @@ cwP
 xWT
 dTc
 vsK
-rrT
+gbv
 soU
 soU
 soU
@@ -189588,7 +189613,7 @@ laE
 laE
 kke
 rfl
-tRm
+cDg
 dNb
 kgO
 ouV
@@ -191656,7 +191681,7 @@ aMq
 tQs
 lWV
 cPH
-ilA
+xOS
 iOk
 wzR
 wKb
@@ -191913,7 +191938,7 @@ tls
 eLa
 bVd
 uqw
-cfr
+mmc
 iOk
 kgz
 wKb
@@ -192170,9 +192195,9 @@ uaP
 uEE
 ngQ
 xdx
-wwg
+qhm
 iOk
-gRX
+uFR
 wKb
 dlk
 dlk
@@ -192427,9 +192452,9 @@ shx
 nBl
 ngQ
 svD
-qcZ
+fSP
 iOk
-hNe
+jSt
 wKb
 sZh
 dlk
@@ -192684,9 +192709,9 @@ mDo
 xRR
 kBo
 fAb
-xYz
-gRh
-pbM
+okr
+dls
+tVf
 wKb
 sZh
 dlk
@@ -192907,9 +192932,9 @@ ctC
 ctC
 ctC
 dCI
-agD
-pKg
-jsB
+rNM
+hJM
+jPb
 gmz
 bJI
 xqs
@@ -192942,8 +192967,8 @@ hMF
 uRB
 shx
 kuq
-bPv
-pdQ
+hLr
+vtK
 wKb
 sZh
 dlk
@@ -193164,7 +193189,7 @@ ctC
 ctC
 szN
 ctC
-agD
+rNM
 dqJ
 apF
 ucW

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -960,6 +960,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
 "aml" = (
@@ -1277,6 +1278,11 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/security/mechbay)
+"apo" = (
+/obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central/aft)
 "apu" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -3232,7 +3238,6 @@
 /turf/open/floor/iron/dark,
 /area/station/service/library)
 "aNV" = (
-/obj/machinery/vending/wallmed/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/vending/wardrobe/coroner_wardrobe,
 /obj/effect/turf_decal/bot,
@@ -5292,7 +5297,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
-/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay)
 "boD" = (
@@ -6902,6 +6906,10 @@
 /obj/effect/mapping_helpers/airlock/access/any/supply/maintenance,
 /turf/open/floor/iron,
 /area/station/maintenance/fore)
+"bHo" = (
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "bHr" = (
 /obj/structure/table/reinforced,
 /obj/item/stock_parts/power_store/cell/high,
@@ -6943,8 +6951,8 @@
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted{
 	dir = 1
 	},
-/obj/structure/sign/poster/official/random/directional/north,
 /obj/structure/extinguisher_cabinet/directional/west,
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron,
 /area/station/cargo/office)
 "bIa" = (
@@ -10318,10 +10326,10 @@
 /area/station/engineering/storage/tech)
 "cxu" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/item/storage/medkit/advanced,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "cxJ" = (
@@ -13018,6 +13026,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/siding/wood/corner,
+/obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/service)
 "din" = (
@@ -13045,10 +13054,6 @@
 	pixel_x = -8
 	},
 /obj/effect/turf_decal/tile/brown/anticorner/contrasted,
-/obj/item/storage/medkit/regular{
-	pixel_x = 6;
-	pixel_y = 10
-	},
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
 "djd" = (
@@ -15905,6 +15910,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "dTl" = (
@@ -22079,6 +22085,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"fxS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/sign/poster/official/report_crimes/directional/west,
+/turf/open/floor/plating,
+/area/station/security/checkpoint/medical/medsci)
 "fya" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23216,6 +23228,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"fMe" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/report_crimes/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "fMo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -24017,7 +24036,6 @@
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/vending/wallmed/directional/north,
 /obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
@@ -26320,6 +26338,7 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "gvG" = (
@@ -37346,10 +37365,18 @@
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/hos)
 "jjX" = (
-/obj/item/storage/medkit/fire,
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
 /obj/machinery/newscaster/directional/west,
+/obj/item/reagent_containers/spray/hercuri,
+/obj/item/stack/medical/ointment{
+	pixel_x = 2;
+	pixel_y = -3
+	},
+/obj/item/stack/medical/ointment{
+	pixel_x = 6;
+	pixel_y = -3
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
 "jkd" = (
@@ -47642,7 +47669,6 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet/directional/west,
-/obj/machinery/vending/wallmed/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron,
 /area/station/medical/surgery/theatre)
@@ -51554,7 +51580,6 @@
 /area/station/hallway/secondary/entry)
 "mKc" = (
 /obj/structure/table,
-/obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
 	},
@@ -52039,6 +52064,7 @@
 	name = "departures camera"
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mQZ" = (
@@ -52444,7 +52470,6 @@
 /area/station/science/robotics/mechbay)
 "mXg" = (
 /obj/structure/table/glass,
-/obj/item/storage/medkit/regular,
 /obj/machinery/light_switch/directional/west{
 	pixel_x = -24
 	},
@@ -53586,6 +53611,7 @@
 	pixel_x = 11;
 	pixel_y = -2
 	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
 "nnv" = (
@@ -55622,6 +55648,14 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/iron,
 /area/station/hallway/primary/central/aft)
+"nOa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "nOk" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/status_display/ai/directional/west,
@@ -56022,7 +56056,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 1
 	},
-/obj/item/storage/medkit/regular,
+/obj/item/stack/medical/bruise_pack{
+	pixel_x = 1;
+	pixel_y = 4
+	},
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "nTz" = (
@@ -65303,6 +65340,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit)
+"qgG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/exit)
 "qgQ" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/siding/dark_red{
@@ -71474,10 +71516,6 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 1
-	},
-/obj/item/storage/box/bandages{
-	pixel_x = 4;
-	pixel_y = 6
 	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/belt/utility,
@@ -83576,6 +83614,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced/spawner/directional/south,
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "uFH" = (
@@ -86581,6 +86620,7 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vtc" = (
@@ -87702,7 +87742,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/vending/wallmed/directional/east,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -91829,6 +91868,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/north,
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/entry)
 "wGV" = (
@@ -93294,9 +93334,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
-/obj/machinery/vending/wallmed/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/east,
+/obj/structure/sign/poster/official/random/directional/east,
 /turf/open/floor/iron/textured,
 /area/station/medical/medbay)
 "xcR" = (
@@ -94369,6 +94409,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"xqO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "xqR" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -95325,7 +95374,6 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/structure/sign/poster/official/random/directional/east,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/light/small/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -126753,7 +126801,7 @@ laP
 xfq
 kEg
 gxL
-nAb
+xqO
 nAb
 vxZ
 fix
@@ -131914,7 +131962,7 @@ uyB
 qSd
 kqM
 tXO
-tXO
+apo
 khb
 khb
 khb
@@ -133485,7 +133533,7 @@ fMZ
 bXG
 xdN
 sYK
-dyx
+bHo
 qmd
 qbg
 xfU
@@ -135023,7 +135071,7 @@ kdq
 shU
 bbj
 dZc
-lhC
+fMe
 uGE
 qmu
 qfi
@@ -135280,7 +135328,7 @@ xWf
 uZs
 xWf
 dQT
-qfi
+fxS
 qfi
 qfi
 dQT
@@ -141972,7 +142020,7 @@ tIV
 tIV
 tIV
 mhW
-tIV
+qgG
 pYp
 tIV
 tIV
@@ -147317,7 +147365,7 @@ mVO
 nHs
 lkS
 nHs
-nHs
+nOa
 whm
 sQL
 huv

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -13982,7 +13982,6 @@
 "dRc" = (
 /obj/structure/table,
 /obj/machinery/firealarm/directional/west,
-/obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 4
 	},
@@ -20380,6 +20379,10 @@
 /obj/structure/mirror/directional/east,
 /turf/open/floor/iron/freezer,
 /area/station/maintenance/starboard/fore)
+"fLc" = (
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "fLe" = (
 /turf/open/floor/plating,
 /area/station/engineering/lobby)
@@ -23064,7 +23067,7 @@
 /area/station/command/bridge)
 "gya" = (
 /obj/structure/table/wood,
-/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/emergency,
 /turf/open/floor/iron,
 /area/station/commons/dorms)
 "gyd" = (
@@ -24170,6 +24173,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply,
 /turf/open/floor/iron/white,
 /area/station/medical/virology)
+"gPX" = (
+/obj/structure/cable,
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron/white/side{
+	dir = 9
+	},
+/area/station/science/research)
 "gPY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25027,6 +25037,7 @@
 	dir = 8
 	},
 /obj/machinery/duct,
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "hcw" = (
@@ -27623,6 +27634,7 @@
 "hQd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron/white/textured,
 /area/station/security/medical)
 "hQi" = (
@@ -34291,6 +34303,13 @@
 /obj/effect/spawner/random/structure/steam_vent,
 /turf/open/floor/plating,
 /area/station/maintenance/aft/lesser)
+"jOq" = (
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "jOt" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -36304,6 +36323,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron/white/corner,
 /area/station/hallway/secondary/exit/departure_lounge)
 "kqG" = (
@@ -37069,9 +37089,7 @@
 /area/station/science/robotics/mechbay)
 "kBr" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular{
-	pixel_y = 5
-	},
+/obj/item/storage/medkit/advanced,
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "kBL" = (
@@ -46219,9 +46237,8 @@
 /obj/item/emergency_bed{
 	pixel_x = 4
 	},
-/obj/item/storage/medkit/regular{
-	pixel_y = 1
-	},
+/obj/item/storage/box/bandages,
+/obj/item/stack/medical/ointment,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "njJ" = (
@@ -52690,8 +52707,8 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering Lobby"
 	},
-/obj/structure/extinguisher_cabinet/directional/east,
 /obj/structure/window/spawner/directional/north,
+/obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/lobby)
 "oUL" = (
@@ -52919,7 +52936,6 @@
 "oXB" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/item/storage/medkit/regular,
 /obj/item/razor{
 	pixel_y = 5
 	},
@@ -57490,17 +57506,20 @@
 "qlD" = (
 /obj/structure/cable,
 /obj/structure/table,
-/obj/item/storage/medkit/regular,
-/obj/item/storage/medkit/regular{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
+	},
+/obj/item/stack/medical/bandage{
+	pixel_x = 6;
+	pixel_y = -2
+	},
+/obj/item/stack/medical/ointment{
+	pixel_y = 2;
+	pixel_x = -4
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -60605,6 +60624,10 @@
 	},
 /turf/open/misc/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors/nospawn)
+"rdN" = (
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "ree" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -61722,6 +61745,13 @@
 	},
 /turf/open/floor/iron/textured,
 /area/mine/mechbay)
+"rtT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "rud" = (
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/mask/surgical,
@@ -68921,7 +68951,6 @@
 /turf/open/floor/iron,
 /area/station/maintenance/disposal/incinerator)
 "txH" = (
-/obj/machinery/vending/wallmed/directional/south,
 /obj/structure/cable,
 /obj/structure/table/glass,
 /obj/item/stack/sticky_tape/surgical,
@@ -73573,6 +73602,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/captain)
+"uRb" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/tile/blue/half/contrasted,
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/station/command/bridge)
 "uRi" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -77783,7 +77818,6 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/medkit/regular,
 /obj/structure/table/glass,
 /obj/structure/window/reinforced/spawner/directional/south,
 /obj/machinery/firealarm/directional/east,
@@ -80594,10 +80628,6 @@
 /area/station/medical/cryo)
 "wXR" = (
 /obj/structure/table,
-/obj/item/storage/medkit/regular{
-	pixel_x = 6;
-	pixel_y = -5
-	},
 /obj/item/multitool,
 /obj/item/trash/cheesie,
 /obj/effect/decal/cleanable/dirt,
@@ -81563,10 +81593,10 @@
 /area/station/cargo/sorting)
 "xjT" = (
 /obj/structure/table,
-/obj/item/storage/medkit/regular,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/stack/medical/bruise_pack,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "xjZ" = (
@@ -84085,6 +84115,7 @@
 "xUU" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
+/obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
 "xUV" = (
@@ -84743,7 +84774,6 @@
 /area/station/maintenance/department/chapel)
 "ydE" = (
 /obj/structure/table/glass,
-/obj/machinery/vending/wallmed/directional/north,
 /obj/item/book/manual/wiki/surgery{
 	pixel_x = -4;
 	pixel_y = 3
@@ -232800,7 +232830,7 @@ wtr
 oCO
 kxs
 lsi
-gpp
+fLc
 qnj
 qnj
 qnj
@@ -237197,7 +237227,7 @@ iaF
 iaF
 ajw
 ajw
-ajw
+rdN
 pBE
 pBE
 uYc
@@ -244920,7 +244950,7 @@ pvg
 nQW
 vsz
 fdy
-fdy
+jOq
 wHX
 nbi
 qzu
@@ -247199,7 +247229,7 @@ qWZ
 ydk
 tGF
 iUT
-aVH
+uRb
 lpM
 rCD
 uEm
@@ -247992,7 +248022,7 @@ frN
 mhQ
 dnq
 iuv
-vXh
+rtT
 cvS
 ewi
 cvS
@@ -262651,7 +262681,7 @@ fLl
 wMm
 xnM
 wqb
-xnM
+gPX
 xnM
 xnM
 xnM

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -889,10 +889,6 @@
 "aqt" = (
 /obj/structure/table,
 /obj/item/folder/yellow,
-/obj/item/storage/medkit/regular{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -1738,14 +1734,11 @@
 /turf/open/floor/iron,
 /area/station/security/range)
 "aGQ" = (
-/obj/item/storage/medkit/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/item/storage/medkit/advanced,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "aGS" = (
@@ -2177,6 +2170,7 @@
 /obj/structure/table,
 /obj/item/clothing/under/costume/buttondown/slacks/service,
 /obj/effect/turf_decal/tile/neutral,
+/obj/item/clothing/mask/whistle,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "aMW" = (
@@ -3073,14 +3067,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/hallway/primary/central)
-"bcw" = (
-/obj/structure/cable,
-/obj/structure/sign/poster/official/random/directional/west,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/duct,
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "bcx" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap,
@@ -4989,6 +4975,15 @@
 	},
 /turf/open/floor/iron,
 /area/station/cargo/storage)
+"bKd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/light_switch/directional/west,
+/turf/open/floor/wood,
+/area/station/service/theater)
 "bKv" = (
 /obj/item/pen,
 /obj/structure/table/reinforced,
@@ -5562,7 +5557,6 @@
 /area/station/security/prison/mess)
 "bVI" = (
 /obj/item/kirbyplants,
-/obj/machinery/vending/wallmed/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -10045,6 +10039,32 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/fore)
+"dEJ" = (
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/structure/cable,
+/obj/item/pen/blue{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/pen/fountain{
+	pixel_x = 10
+	},
+/obj/item/pen/red{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/stamp/denied{
+	pixel_y = -1
+	},
+/obj/item/stamp{
+	pixel_x = -9;
+	pixel_y = -1
+	},
+/turf/open/floor/catwalk_floor/iron,
+/area/station/cargo/storage)
 "dEV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -13520,12 +13540,6 @@
 /obj/structure/plasticflaps,
 /turf/open/floor/plating,
 /area/station/cargo/sorting)
-"eMG" = (
-/obj/structure/closet/lasertag/blue,
-/obj/effect/landmark/start/hangover/closet,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/commons/fitness/recreation)
 "eMH" = (
 /obj/item/radio/intercom/directional/north,
 /obj/effect/turf_decal/stripes/corner{
@@ -14048,15 +14062,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
-"eWp" = (
-/obj/machinery/suit_storage_unit/cmo,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/obj/machinery/light/small/directional/east,
-/obj/machinery/vending/wallmed/directional/east,
-/turf/open/floor/iron/dark,
-/area/station/command/heads_quarters/cmo)
 "eWq" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -17407,6 +17412,14 @@
 "giA" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/computer)
+"giG" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/duct,
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "giH" = (
 /obj/machinery/vending/engivend,
 /obj/effect/turf_decal/delivery,
@@ -18796,15 +18809,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/hydroponics)
-"gFO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/light_switch/directional/west,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "gFQ" = (
 /turf/closed/wall/r_wall,
 /area/station/science/research)
@@ -22976,15 +22980,6 @@
 /obj/item/food/dough,
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"ied" = (
-/obj/structure/table,
-/obj/item/paper/fluff/holodeck/disclaimer,
-/obj/item/storage/medkit/regular{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/turf/open/floor/iron,
-/area/station/commons/fitness/recreation)
 "iem" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -25120,19 +25115,6 @@
 /obj/structure/window/reinforced/spawner/directional/west,
 /turf/open/floor/iron,
 /area/station/science/xenobiology)
-"iNQ" = (
-/obj/structure/cable,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/duct,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/iron,
-/area/station/hallway/secondary/service)
 "iOc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27440,6 +27422,13 @@
 /obj/structure/cable,
 /turf/open/floor/iron,
 /area/station/construction/storage_wing)
+"jzI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/white,
+/area/station/science/xenobiology)
 "jzN" = (
 /turf/closed/wall/r_wall,
 /area/station/command/corporate_showroom)
@@ -28203,22 +28192,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
-"jMJ" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/cup/bottle/morphine{
-	pixel_y = 6
-	},
-/obj/machinery/camera/directional/north{
-	c_tag = "Prison Sanitarium";
-	network = list("ss13","prison")
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/obj/machinery/light/cold/directional/north,
-/turf/open/floor/iron/white,
-/area/station/security/execution/transfer)
 "jML" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -28258,10 +28231,6 @@
 /area/station/hallway/secondary/entry)
 "jNl" = (
 /obj/structure/table,
-/obj/item/storage/medkit/regular{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/item/storage/medkit/regular,
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/blue/half/contrasted,
@@ -32181,6 +32150,23 @@
 /obj/structure/cable,
 /turf/open/floor/iron/textured,
 /area/station/medical/chem_storage)
+"lfl" = (
+/obj/structure/table/glass,
+/obj/item/storage/medkit/regular,
+/obj/item/reagent_containers/syringe,
+/obj/item/reagent_containers/cup/bottle/morphine{
+	pixel_y = 6
+	},
+/obj/machinery/camera/directional/north{
+	c_tag = "Prison Sanitarium";
+	network = list("ss13","prison")
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/machinery/light/cold/directional/north,
+/turf/open/floor/iron/white,
+/area/station/security/execution/transfer)
 "lfm" = (
 /obj/machinery/light_switch/directional/north,
 /turf/open/floor/iron/freezer,
@@ -32271,7 +32257,7 @@
 /area/station/medical/medbay/central)
 "lhk" = (
 /obj/structure/table,
-/obj/item/storage/medkit/brute,
+/obj/item/stack/medical/bruise_pack,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "lhD" = (
@@ -38016,6 +38002,23 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/iron,
 /area/station/security/office)
+"nle" = (
+/obj/item/cigbutt,
+/obj/structure/table/reinforced,
+/obj/item/paper{
+	pixel_x = -4;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/tile/yellow/half/contrasted{
+	dir = 4
+	},
+/obj/machinery/light/directional/east,
+/obj/item/stack/medical/ointment{
+	pixel_x = 11;
+	pixel_y = 1
+	},
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "nlo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/hidden{
@@ -38295,16 +38298,6 @@
 /obj/structure/window/spawner/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"npX" = (
-/obj/structure/cable,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/effect/turf_decal/trimline/brown/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron,
-/area/station/cargo/storage)
 "npY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -38502,14 +38495,6 @@
 /obj/effect/spawner/random/engineering/tracking_beacon,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/command)
-"nst" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/wood,
-/area/station/service/theater)
 "nsA" = (
 /turf/closed/wall,
 /area/station/science/ordnance/testlab)
@@ -38795,6 +38780,18 @@
 /obj/machinery/firealarm/directional/south,
 /obj/effect/turf_decal/bot{
 	dir = 1
+	},
+/obj/item/storage/box/bandages{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/item/stack/medical/ointment{
+	pixel_x = 11;
+	pixel_y = 5
+	},
+/obj/item/stack/medical/bandage{
+	pixel_x = 13;
+	pixel_y = -3
 	},
 /turf/open/floor/iron,
 /area/station/command/gateway)
@@ -40394,30 +40391,6 @@
 /obj/item/target/alien,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"obl" = (
-/obj/structure/rack,
-/obj/machinery/camera/directional/south{
-	c_tag = "Brig - Infirmary"
-	},
-/obj/item/clothing/under/rank/medical/scrubs/purple,
-/obj/item/storage/medkit/regular,
-/obj/item/healthanalyzer{
-	pixel_y = -2
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/obj/structure/window/spawner/directional/east,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "obw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -42288,6 +42261,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/station/solars/starboard/fore)
+"oII" = (
+/obj/structure/table,
+/obj/item/paper/fluff/holodeck/disclaimer,
+/turf/open/floor/iron,
+/area/station/commons/fitness/recreation)
 "oIM" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -44099,6 +44077,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/security/brig)
+"pro" = (
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/command)
 "prv" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -47987,6 +47976,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"qJT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/primary/starboard)
 "qJU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -49305,6 +49304,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
+"rdD" = (
+/obj/machinery/suit_storage_unit/cmo,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/light/small/directional/east,
+/turf/open/floor/iron/dark,
+/area/station/command/heads_quarters/cmo)
 "rdT" = (
 /obj/structure/toilet{
 	pixel_y = 8
@@ -50505,22 +50512,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/medical/medbay/lobby)
-"ryA" = (
-/obj/item/cigbutt,
-/obj/structure/table/reinforced,
-/obj/item/storage/medkit/fire{
-	pixel_y = -4
-	},
-/obj/item/paper{
-	pixel_x = -4;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/tile/yellow/half/contrasted{
-	dir = 4
-	},
-/obj/machinery/light/directional/east,
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "ryJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
@@ -51741,16 +51732,6 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
-"rTV" = (
-/obj/machinery/firealarm/directional/west,
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/storage/medkit/regular,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/iron,
-/area/station/commons/locker)
 "rUo" = (
 /obj/structure/bed,
 /obj/effect/spawner/random/bedsheet,
@@ -51990,6 +51971,20 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/iron,
 /area/station/hallway/primary/fore)
+"rYq" = (
+/obj/structure/cable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/duct,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "rYs" = (
 /obj/structure/window/reinforced/spawner/directional/east,
 /obj/structure/window/reinforced/spawner/directional/south,
@@ -53022,26 +53017,6 @@
 /obj/item/radio/intercom/prison/directional/north,
 /turf/open/floor/iron,
 /area/station/security/execution/transfer)
-"ssk" = (
-/obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_guide{
-	pixel_x = -2
-	},
-/obj/item/trash/can{
-	pixel_x = -8
-	},
-/obj/machinery/firealarm/directional/south,
-/obj/structure/extinguisher_cabinet/directional/east,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
-/turf/open/floor/iron,
-/area/station/engineering/break_room)
 "ssr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -53552,36 +53527,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/engineering/atmos)
-"sCc" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable,
-/obj/item/storage/medkit/regular{
-	pixel_x = -3;
-	pixel_y = 10
-	},
-/obj/item/pen/blue{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/pen/fountain{
-	pixel_x = 10
-	},
-/obj/item/pen/red{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/stamp/denied{
-	pixel_y = -1
-	},
-/obj/item/stamp{
-	pixel_x = -9;
-	pixel_y = -1
-	},
-/turf/open/floor/catwalk_floor/iron,
-/area/station/cargo/storage)
 "sCh" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -54079,6 +54024,15 @@
 	},
 /turf/open/floor/iron/cafeteria,
 /area/station/service/kitchen)
+"sLz" = (
+/obj/machinery/firealarm/directional/west,
+/obj/structure/table,
+/obj/item/folder,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/iron,
+/area/station/commons/locker)
 "sLE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -54263,6 +54217,29 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port)
+"sNN" = (
+/obj/structure/rack,
+/obj/machinery/camera/directional/south{
+	c_tag = "Brig - Infirmary"
+	},
+/obj/item/clothing/under/rank/medical/scrubs/purple,
+/obj/item/healthanalyzer{
+	pixel_y = -2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/window/spawner/directional/east,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "sNS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -55314,6 +55291,16 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/carpet,
 /area/station/service/library)
+"teZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/port)
 "tfg" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -58191,6 +58178,26 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmospherics_engine)
+"uda" = (
+/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_guide{
+	pixel_x = -2
+	},
+/obj/item/trash/can{
+	pixel_x = -8
+	},
+/obj/machinery/firealarm/directional/south,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow/anticorner/contrasted,
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/station/engineering/break_room)
 "ude" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/white{
@@ -59046,6 +59053,7 @@
 /obj/effect/turf_decal/tile/green/half/contrasted{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "uta" = (
@@ -60141,6 +60149,13 @@
 /obj/structure/window/reinforced/spawner/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/aisat/exterior)
+"uLB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/fore)
 "uLE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60193,6 +60208,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron,
 /area/station/cargo/miningoffice)
+"uMN" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/latex,
+/obj/item/clothing/mask/surgical,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "uMR" = (
 /obj/machinery/holopad,
 /turf/open/floor/iron/white/side{
@@ -60760,13 +60786,6 @@
 /area/station/security/mechbay)
 "uWt" = (
 /obj/structure/rack,
-/obj/item/stack/medical/mesh,
-/obj/item/stack/medical/suture,
-/obj/item/reagent_containers/syringe/multiver,
-/obj/item/reagent_containers/syringe/epinephrine{
-	pixel_x = -1;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
@@ -61643,16 +61662,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/exit/departure_lounge)
-"vkO" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/latex,
-/obj/item/clothing/mask/surgical,
-/obj/item/reagent_containers/spray/cleaner,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "vlh" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/rnd_secure_all,
@@ -61683,6 +61692,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/station/maintenance/port/aft)
+"vlW" = (
+/obj/effect/turf_decal/siding/purple{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "vlY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera/directional/north{
@@ -62350,6 +62366,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden/layer5,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/entry)
+"vwF" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/wood,
+/area/station/service/theater)
 "vwN" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable,
@@ -62680,6 +62704,7 @@
 /obj/effect/spawner/random/entertainment/arcade,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "vCh" = (
@@ -62815,6 +62840,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron,
 /area/station/engineering/atmos/storage/gas)
+"vEu" = (
+/obj/structure/closet/lasertag/blue,
+/obj/effect/landmark/start/hangover/closet,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/sign/poster/official/random/directional/south,
+/turf/open/floor/iron/dark,
+/area/station/commons/fitness/recreation)
 "vEv" = (
 /obj/machinery/computer/mecha{
 	dir = 8
@@ -66176,6 +66208,16 @@
 	dir = 8
 	},
 /area/station/medical/chem_storage)
+"wMi" = (
+/obj/structure/cable,
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/station/cargo/storage)
 "wMx" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/landmark/start/hangover,
@@ -69631,6 +69673,11 @@
 	},
 /turf/open/floor/iron,
 /area/station/command/teleporter)
+"xXB" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/station/hallway/primary/aft)
 "xXC" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/closet/secure_closet/detective,
@@ -86758,7 +86805,7 @@ fcq
 jPE
 auh
 crr
-crr
+teZ
 crr
 qer
 crr
@@ -89315,7 +89362,7 @@ dfk
 rQD
 nsh
 vWD
-sCc
+dEJ
 liU
 nrB
 smB
@@ -90090,7 +90137,7 @@ ksM
 lQf
 wsx
 dsJ
-npX
+wMi
 dtw
 lzD
 hIW
@@ -94172,7 +94219,7 @@ qJi
 mzL
 hAL
 nRZ
-vkO
+uMN
 jDf
 gWT
 vaH
@@ -94928,7 +94975,7 @@ pPR
 jJp
 kNY
 jTZ
-jMJ
+lfl
 qbr
 ouj
 aBL
@@ -94946,7 +94993,7 @@ sch
 acr
 lvu
 iom
-obl
+sNN
 sch
 knB
 guS
@@ -95016,7 +95063,7 @@ oBO
 jNl
 pKP
 xpL
-eWp
+rdD
 hGl
 kha
 dbD
@@ -95247,7 +95294,7 @@ jLQ
 fgS
 jrk
 dhX
-nIR
+pro
 gBD
 twl
 bcx
@@ -97534,7 +97581,7 @@ lKZ
 dNX
 iVA
 mlK
-dNX
+uLB
 dNX
 nyV
 dNX
@@ -98110,7 +98157,7 @@ dXQ
 gmt
 qsx
 gmt
-gmt
+xXB
 uzk
 gmt
 qhx
@@ -102674,7 +102721,7 @@ rUO
 gmk
 qCP
 mPw
-rTV
+sLz
 iPp
 eVz
 pJE
@@ -104020,7 +104067,7 @@ aBX
 iio
 kjG
 gwf
-pOv
+vlW
 mMX
 rhe
 rPA
@@ -105477,7 +105524,7 @@ peF
 liO
 sSs
 gkM
-bcw
+giG
 uKL
 uKL
 mKu
@@ -106253,7 +106300,7 @@ fMm
 xAt
 iYG
 lOU
-eMG
+vEu
 lnc
 lnc
 wdG
@@ -107078,7 +107125,7 @@ tQC
 gsP
 phS
 huG
-iNQ
+rYq
 qFF
 kCZ
 nKI
@@ -107315,7 +107362,7 @@ xww
 xww
 aEr
 sDs
-tUv
+qJT
 obG
 gUe
 yks
@@ -108096,7 +108143,7 @@ kka
 vMw
 iEZ
 uWK
-gFO
+bKd
 rHz
 aFW
 dqX
@@ -108353,7 +108400,7 @@ qiY
 wAt
 utE
 obG
-nst
+vwF
 lih
 sNi
 pmK
@@ -111131,7 +111178,7 @@ kiE
 szp
 eqU
 flB
-ied
+oII
 hMQ
 qXB
 qXB
@@ -112203,8 +112250,8 @@ uTH
 dFH
 ygb
 pEG
-ryA
-ssk
+nle
+uda
 peM
 wUM
 cZw
@@ -114813,7 +114860,7 @@ hbK
 hbK
 rMu
 xiL
-jCO
+jzI
 fdZ
 mMK
 mMK

--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -8470,6 +8470,7 @@
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/brown/filled/line,
 /obj/structure/table,
+/obj/item/storage/medkit/regular,
 /turf/open/floor/iron/dark/smooth_edge{
 	dir = 1
 	},

--- a/_maps/map_files/tramstation/tramstation.dmm
+++ b/_maps/map_files/tramstation/tramstation.dmm
@@ -7922,17 +7922,17 @@
 /area/station/service/library)
 "bLj" = (
 /obj/structure/table/glass,
-/obj/item/book/manual/wiki/surgery{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/medicine,
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light/directional/west,
+/obj/item/storage/medkit/regular,
+/obj/item/storage/medkit/regular{
+	pixel_x = 4;
+	pixel_y = 4
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "bLk" = (
@@ -9044,10 +9044,6 @@
 /area/station/engineering/storage/tech)
 "ccF" = (
 /obj/structure/table,
-/obj/item/storage/medkit/regular{
-	pixel_x = 6;
-	pixel_y = -5
-	},
 /obj/machinery/status_display/supply{
 	pixel_y = 32
 	},
@@ -11220,6 +11216,13 @@
 	},
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
+"cPc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/entry)
 "cPg" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/sign/warning/electric_shock/directional/west,
@@ -13712,6 +13715,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel/monastery)
+"dGY" = (
+/obj/machinery/duct,
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/wallmed/directional/south,
+/turf/open/floor/iron,
+/area/station/hallway/secondary/service)
 "dHc" = (
 /obj/structure/window/reinforced/spawner/directional/west,
 /obj/structure/table,
@@ -18697,6 +18712,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/grass,
 /area/station/science/lower)
+"fyT" = (
+/obj/effect/turf_decal/trimline/brown/filled/line{
+	dir = 6
+	},
+/obj/machinery/vending/wallmed/directional/east,
+/turf/open/floor/iron,
+/area/station/cargo/miningdock)
 "fza" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -21141,6 +21163,7 @@
 	},
 /obj/item/reagent_containers/cup/bottle/multiver,
 /obj/item/reagent_containers/cup/bottle/epinephrine,
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "gtN" = (
@@ -27112,6 +27135,7 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iLn" = (
@@ -27385,11 +27409,6 @@
 "iOS" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/structure/table/glass,
-/obj/item/storage/medkit/regular{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/medkit/regular,
 /obj/machinery/camera/directional/south{
 	network = list("ss13","medbay");
 	c_tag = "Medical - Main North"
@@ -29560,7 +29579,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
-/obj/item/storage/medkit/brute,
+/obj/item/stack/medical/bruise_pack,
 /turf/open/floor/iron,
 /area/station/commons/fitness)
 "jza" = (
@@ -39576,6 +39595,7 @@
 	pixel_y = 3
 	},
 /obj/item/extinguisher,
+/obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/xenobiology)
 "mUd" = (
@@ -46242,7 +46262,7 @@
 /area/station/command/meeting_room)
 "pts" = (
 /obj/machinery/power/smes{
-	charge = 10000;
+	charge = 10000
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -60977,6 +60997,7 @@
 /obj/effect/turf_decal/siding/thinplating/dark,
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/vending/wallmed/directional/south,
 /turf/open/floor/iron/dark,
 /area/station/hallway/secondary/exit/departure_lounge)
 "uuS" = (
@@ -64533,6 +64554,7 @@
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 1
 	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/laundry)
 "vCB" = (
@@ -64904,7 +64926,7 @@
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 5
 	},
-/obj/machinery/newscaster/directional/north,
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron,
 /area/station/engineering/break_room)
 "vIv" = (
@@ -67859,10 +67881,6 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/item/storage/medkit/regular{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "wNq" = (
@@ -69658,15 +69676,14 @@
 /area/station/construction/mining/aux_base)
 "xyn" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular{
-	pixel_x = -5;
-	pixel_y = -3
-	},
 /obj/item/reagent_containers/cup/glass/coffee{
 	pixel_x = 8;
 	pixel_y = 4
 	},
 /obj/item/radio/intercom/directional/west,
+/obj/item/storage/medkit/advanced{
+	pixel_x = -6
+	},
 /turf/open/floor/iron,
 /area/station/command/bridge)
 "xyr" = (
@@ -103233,7 +103250,7 @@ snQ
 iRL
 oXU
 gRY
-nNZ
+dGY
 cWZ
 cWZ
 lbL
@@ -117886,7 +117903,7 @@ uGW
 uGW
 njI
 kjN
-laM
+fyT
 qxm
 iLu
 oys
@@ -148225,7 +148242,7 @@ dFP
 dFP
 dFP
 dFP
-dFP
+cPc
 dFP
 ste
 mtr

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -3956,6 +3956,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron,
 /area/station/engineering/lobby)
 "btJ" = (
@@ -15802,7 +15803,7 @@
 /obj/effect/turf_decal/tile/brown/half/contrasted{
 	dir = 4
 	},
-/obj/structure/sign/poster/random/directional/east,
+/obj/machinery/vending/wallmed/directional/east,
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "fEm" = (
@@ -22354,6 +22355,7 @@
 /obj/effect/turf_decal/tile/neutral/half{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/west,
 /turf/open/floor/iron/edge{
 	dir = 8
 	},
@@ -26718,7 +26720,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/spawner/random/structure/table,
 /obj/machinery/airalarm/directional/south,
-/obj/item/storage/medkit/brute,
+/obj/item/stack/medical/bruise_pack,
 /turf/open/floor/iron,
 /area/station/commons/fitness/recreation)
 "juh" = (
@@ -30839,7 +30841,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/turf_decal/tile/brown/half/contrasted,
 /obj/structure/table,
-/obj/item/storage/medkit/regular,
 /obj/structure/cable,
 /obj/item/healthanalyzer/simple,
 /obj/effect/mapping_helpers/apc/full_charge,
@@ -38018,9 +38019,6 @@
 /obj/item/storage/medkit/regular{
 	pixel_y = 5
 	},
-/obj/item/storage/medkit/regular{
-	pixel_y = 10
-	},
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 4
 	},
@@ -38028,6 +38026,7 @@
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 8
 	},
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "niI" = (
@@ -48731,6 +48730,11 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"qXP" = (
+/obj/structure/cable,
+/obj/machinery/vending/wallmed/directional/north,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "qXY" = (
 /turf/open/misc/asteroid,
 /area/station/cargo/miningoffice)
@@ -49268,13 +49272,9 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/storage/medkit/regular{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/storage/medkit/regular,
 /obj/machinery/airalarm/directional/east,
 /obj/structure/sign/departments/chemistry/pharmacy/directional/north,
+/obj/item/storage/box/bandages,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "rgy" = (
@@ -50825,7 +50825,6 @@
 /obj/item/watertank,
 /obj/item/grenade/chem_grenade/antiweed,
 /obj/structure/table/glass,
-/obj/structure/sign/poster/official/random/directional/south,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -51010,10 +51009,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/item/storage/medkit,
 /obj/structure/table,
 /obj/machinery/light/directional/south,
 /obj/item/radio/intercom/directional/south,
+/obj/item/storage/box/bandages,
 /turf/open/floor/iron,
 /area/station/command/gateway)
 "rIw" = (
@@ -58366,6 +58365,12 @@
 /obj/machinery/exodrone_launcher,
 /turf/open/floor/iron/dark,
 /area/station/cargo/drone_bay)
+"ufl" = (
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron/white/smooth_half{
+	dir = 8
+	},
+/area/station/science/xenobiology)
 "ufr" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -59987,6 +59992,7 @@
 /obj/structure/ladder,
 /obj/item/radio/intercom/directional/west,
 /obj/effect/turf_decal/tile/dark_green/opposingcorners,
+/obj/machinery/vending/wallmed/directional/north,
 /turf/open/floor/iron,
 /area/station/hallway/secondary/service)
 "uIF" = (
@@ -60946,10 +60952,10 @@
 /area/station/medical/virology)
 "vay" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/medkit/regular,
 /obj/effect/turf_decal/tile/dark_blue/half/contrasted{
 	dir = 1
 	},
+/obj/item/storage/medkit/advanced,
 /turf/open/floor/iron/dark,
 /area/station/command/bridge)
 "vaC" = (
@@ -63511,7 +63517,6 @@
 "vWY" = (
 /obj/effect/turf_decal/siding,
 /obj/structure/table,
-/obj/item/storage/medkit/regular,
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/large,
 /area/station/commons/locker)
@@ -65309,6 +65314,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/hallway/secondary/entry)
+"wDs" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "wDu" = (
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
@@ -66347,6 +66359,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/plating,
 /area/station/maintenance/department/medical/central)
+"wXS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/vending/wallmed/directional/west,
+/turf/open/floor/iron,
+/area/station/hallway/primary/central)
 "wXY" = (
 /obj/structure/broken_flooring/side/directional/east,
 /turf/open/floor/plating,
@@ -94392,7 +94413,7 @@ eEa
 kmu
 kmu
 xJe
-kmu
+wDs
 wSi
 kmu
 rqj
@@ -103141,7 +103162,7 @@ nxG
 nxG
 nxG
 hjJ
-nxG
+wXS
 glH
 iAE
 xAm
@@ -107236,7 +107257,7 @@ mDK
 iUJ
 cPt
 ixU
-cpw
+qXP
 dfM
 pBn
 cPo
@@ -188469,7 +188490,7 @@ jEt
 aMf
 rdn
 xSW
-wnA
+ufl
 wnA
 wnA
 wnA

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -36,7 +36,7 @@
 	if (prob(40))
 		new /obj/item/storage/toolbox/emergency(src)
 
-	switch (pick_weight(list("small" = 35, "aid" = 30, "tank" = 20, "both" = 10, "nothing" = 4)))
+	switch (pick_weight(list("small" = 20, "aid" = 20, "tank" = 20, "both" = 30, "nothing" = 10)))
 		if ("small")
 			new /obj/item/tank/internals/emergency_oxygen(src)
 			new /obj/item/tank/internals/emergency_oxygen(src)

--- a/code/modules/uplink/uplink_items/device_tools.dm
+++ b/code/modules/uplink/uplink_items/device_tools.dm
@@ -22,6 +22,14 @@
 	cost = 2
 	surplus = 50
 
+/datum/uplink_item/device_tools/tactical_medkit
+	name = "combat first aid kit"
+	desc = "An medkit meant for combat support, it contains. Two medicated sutures and mesh, Gauze, Advanced health analyzer, And as last atropine medipen"
+	item = /obj/item/storage/medkit/tactical_lite
+	cost = 3
+	surplus = 72
+	purchasable_from = UPLINK_TRAITORS
+
 /datum/uplink_item/device_tools/surgery_syndie
 	name = "Full Syndicate Surgery Medkit"
 	desc = "The Syndicate surgery medkit is a toolkit containing all surgery tools, surgical drapes, \

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -86,9 +86,7 @@
 		/obj/item/reagent_containers/cup/bottle/salglu_solution = 3,
 		/obj/item/reagent_containers/cup/bottle/toxin = 3,
 		/obj/item/reagent_containers/syringe/antiviral = 6,
-		/obj/item/reagent_containers/medigel/libital = 2,
-		/obj/item/reagent_containers/medigel/aiuri = 2,
-		/obj/item/reagent_containers/medigel/sterilizine = 1,
+		/obj/item/reagent_containers/medigel/sterilizine = 3,
 	)
 	contraband = list(
 		/obj/item/reagent_containers/applicator/pill/tox = 3,

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -1,30 +1,28 @@
 /obj/machinery/vending/wallmed
-	name = "\improper NanoMed"
-	desc = "Wall-mounted Medical Equipment dispenser."
+	name = "\improper Emergency NanoMed"
+	desc = "Wall-mounted Medical Equipment dispenser, Meant to be used in medical emergencies."
 	icon_state = "wallmed"
 	icon_deny = "wallmed-deny"
 	panel_type = "wallmed-panel"
 	density = FALSE
 	products = list(
-		/obj/item/reagent_containers/syringe = 3,
-		/obj/item/reagent_containers/applicator/patch/libital = 5,
-		/obj/item/reagent_containers/applicator/patch/aiuri = 5,
-		/obj/item/reagent_containers/applicator/pill/multiver = 2,
-		/obj/item/reagent_containers/medigel/libital = 2,
-		/obj/item/reagent_containers/medigel/aiuri = 2,
-		/obj/item/reagent_containers/medigel/sterilizine = 1,
-		/obj/item/healthanalyzer/simple = 2,
-		/obj/item/stack/medical/bone_gel = 2,
-		/obj/item/storage/box/bandages = 1,
+		/obj/item/stack/medical/bandage = 1,
+		/obj/item/stack/medical/ointment = 1,
+		/obj/item/stack/medical/gauze = 1,
+		/obj/item/reagent_containers/hypospray/medipen/ekit = 1,
+		/obj/item/healthanalyzer/simple = 1,
 	)
 	contraband = list(
-		/obj/item/reagent_containers/applicator/pill/tox = 2,
-		/obj/item/reagent_containers/applicator/pill/morphine = 2,
+		/obj/item/storage/box/bandages = 1,
 		/obj/item/storage/box/gum/happiness = 1,
 	)
+	premium = list(
+		/obj/item/reagent_containers/applicator/patch/libital = 1,
+		/obj/item/reagent_containers/applicator/patch/aiuri = 1,
+	)
 	refill_canister = /obj/item/vending_refill/wallmed
-	default_price = PAYCHECK_COMMAND //Double the medical price due to being meant for public consumption, not player specfic
-	extra_price = PAYCHECK_COMMAND * 1.5
+	default_price = PAYCHECK_CREW * 0.3 // Cheap since crew should be able to affort it in emergency situations
+	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_MED
 	tiltable = FALSE
 	light_mask = "wallmed-light-mask"
@@ -32,5 +30,5 @@
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/vending/wallmed, 32)
 
 /obj/item/vending_refill/wallmed
-	machine_name = "NanoMed"
+	machine_name = "Emergency NanoMed"
 	icon_state = "refill_medical"


### PR DESCRIPTION
Original PR: 92134
-----
## About The Pull Request
I would be very intrested to get this atleast testmerged, but anyhow.

This PR reduces the amount of medkits in general available in maps (Mostly just public ones)
This PR changes the contents of Nanomed Wallvendors to include just emergency stuff.
This PR REMOVES medigels from wall med vendors
This PR increases the sterilizine sprays amount in the drugs vendor from 1 to 3 to compensate the removal out the emergency vendors
This PR adds a tactical lite medkit to traitor uplink for 4 tc this includes medicated suture/mesh health analyzer gauze and a atropine pen

What this PR achieves to AIM is repurposing wallmed vendors into a more of a emergency type of vendor, while emergency lockers surgical kits are free and RNG, this is gauranteed and costs a little bit of money.

Though i will need some help to see whats enough emergency med vendors, so far i have 1 for every department as baseline maybe 1 every hallway section aswell?, Pherhaps free and remove emergency medkits from emergency lockers in general? i would love to hear people's opinion on this

## Why It's Good For The Game

Theres alot of medkits available, so trickling down a little bit to have medbay matter more, but in exchange there will be wall vendors to treat your wounds with so you can bring them to medbay or have a paramedic/doctor come to your location in time without the patient dying.

This also removes one of the only imporant stuff in wall med vendors and thats medigels, medigels are very popular and usually is the most common way to treat damage (and space effecient) 

## Changelog

:cl: Ezel
balance: Removes some public medkits on every map
balance: Changes the contents of wall med vendors to just have emergency stuff
balance: Drugs vendor now includes 3 sterilizine medigels instead of 1
Balance: Tactical lite medkit added to traitor uplink for 4 tc, this includes medicated suture/mesh, atropine pen, gauze, advanced health analyzer
map:Adds more wall med vendors to the map atleast 1 every department.
/:cl:
