### PR TITLE
[TG Mirror] Removes the Void Torch [MDB IGNORE]

### DIFF
--- a/_maps/minigame/deathmatch/ragnarok.dmm
+++ b/_maps/minigame/deathmatch/ragnarok.dmm
@@ -189,7 +189,7 @@
 /area/deathmatch)
 "hY" = (
 /mob/living/carbon/human/species/monkey,
-/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch/red/on,
 /turf/open/misc/grass/jungle,
 /area/deathmatch)
 "ih" = (
@@ -392,7 +392,7 @@
 "qk" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /obj/effect/turf_decal/weather/dirt,
-/obj/item/flashlight/flare/culttorch,
+/obj/item/flashlight/flare/torch/red/on,
 /turf/open/floor/cult,
 /area/deathmatch)
 "qp" = (
@@ -550,7 +550,7 @@
 /area/deathmatch)
 "xx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/item/flashlight/flare/culttorch,
+/obj/item/flashlight/flare/torch/red/on,
 /turf/open/floor/cult,
 /area/deathmatch)
 "xC" = (
@@ -595,7 +595,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/weather/dirt,
-/obj/item/flashlight/flare/culttorch,
+/obj/item/flashlight/flare/torch/red/on,
 /turf/open/floor/cult,
 /area/deathmatch)
 "An" = (
@@ -712,7 +712,7 @@
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
 	},
-/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch/red/on,
 /turf/open/misc/asteroid/moon,
 /area/deathmatch)
 "DA" = (
@@ -794,7 +794,7 @@
 /area/deathmatch)
 "HN" = (
 /obj/structure/flora/rock/pile/jungle/large/style_random,
-/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch/red/on,
 /turf/open/misc/grass/jungle,
 /area/deathmatch)
 "HS" = (
@@ -1119,7 +1119,7 @@
 /obj/item/clothing/suit/costume/bronze,
 /obj/item/clothing/head/costume/bronze,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/item/flashlight/flare/torch,
+/obj/item/flashlight/flare/torch/red/on,
 /turf/open/floor/bronze/flat,
 /area/deathmatch)
 "VZ" = (

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -702,12 +702,22 @@
 	trash_type = /obj/effect/decal/cleanable/ash
 	can_be_extinguished = TRUE
 
+/obj/item/flashlight/flare/torch/on
+	start_on = TRUE
+
 /obj/item/flashlight/flare/torch/everburning
 	name = "everburning torch"
 	desc = "A torch which burns continuously, even in the vacuum of space"
 	can_be_extinguished = FALSE
 	fuel = INFINITY
 	randomize_fuel = FALSE
+	start_on = TRUE
+
+/obj/item/flashlight/flare/torch/red
+	color = "#ff0000"
+	light_range = 2
+
+/obj/item/flashlight/flare/torch/red/on
 	start_on = TRUE
 
 /obj/item/flashlight/lantern

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -807,65 +807,6 @@ Striking a noncultist, however, will tear their flesh."}
 	playsound(destination, 'sound/effects/phasein.ogg', 25, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 	playsound(destination, SFX_PORTAL_ENTER, 50, TRUE, SHORT_RANGE_SOUND_EXTRARANGE)
 
-/obj/item/flashlight/flare/culttorch
-	name = "void torch"
-	desc = "Used by veteran cultists to instantly transport items to their needful brethren."
-	w_class = WEIGHT_CLASS_SMALL
-	light_range = 1
-	icon_state = "torch"
-	inhand_icon_state = "torch"
-	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
-	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
-	color = "#ff0000"
-	on_damage = 15
-	slot_flags = null
-	var/charges = 5
-	start_on = TRUE
-
-/obj/item/flashlight/flare/culttorch/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
-	var/datum/antagonist/cult/cult = user.mind.has_antag_datum(/datum/antagonist/cult)
-	var/datum/team/cult/cult_team = cult?.get_team()
-	if(isnull(cult_team))
-		to_chat(user, span_warning("That doesn't seem to do anything useful."))
-		return ITEM_INTERACT_BLOCKING
-
-	if(!isitem(interacting_with))
-		to_chat(user, span_warning("[src] can only transport items!"))
-		return ITEM_INTERACT_BLOCKING
-
-	var/list/mob/living/cultists = list()
-	for(var/datum/mind/cult_mind as anything in cult_team.members)
-		if(cult_mind == user.mind)
-			continue
-		if(cult_mind.current?.stat != DEAD)
-			cultists |= cult_mind.current
-
-	var/mob/living/cultist_to_receive = tgui_input_list(user, "Who do you wish to call to [src]?", "Followers of the Geometer", (cultists - user))
-	if(QDELETED(src) || loc != user || user.incapacitated)
-		return ITEM_INTERACT_BLOCKING
-	if(isnull(cultist_to_receive))
-		to_chat(user, span_cult_italic("You require a destination!"))
-		return ITEM_INTERACT_BLOCKING
-	if(cultist_to_receive.stat == DEAD)
-		to_chat(user, span_cult_italic("[cultist_to_receive] has died!"))
-		return ITEM_INTERACT_BLOCKING
-	if(!(cultist_to_receive.mind in cult_team.members))
-		to_chat(user, span_cult_italic("[cultist_to_receive] is not a follower of the Geometer!"))
-		return ITEM_INTERACT_BLOCKING
-	if(!isturf(interacting_with.loc))
-		to_chat(user, span_cult_italic("[interacting_with] must be on a surface in order to teleport it!"))
-		return ITEM_INTERACT_BLOCKING
-
-	to_chat(user, span_cult_italic("You ignite [interacting_with] with [src], turning it to ash, \
-		but through the torch's flames you see that [interacting_with] has reached [cultist_to_receive]!"))
-	user.log_message("teleported [interacting_with] to [cultist_to_receive] with [src].", LOG_GAME)
-	cultist_to_receive.put_in_hands(interacting_with)
-	charges--
-	to_chat(user, span_notice("[src] now has [charges] charge\s."))
-	if(charges <= 0)
-		qdel(src)
-	return ITEM_INTERACT_SUCCESS
-
 /obj/item/melee/cultblade/halberd
 	name = "bloody halberd"
 	desc = "A halberd with a volatile axehead made from crystallized blood. It seems linked to its creator. And, admittedly, more of a poleaxe than a halberd."

--- a/code/modules/antagonists/cult/cult_structure_archives.dm
+++ b/code/modules/antagonists/cult/cult_structure_archives.dm
@@ -1,7 +1,7 @@
 /// Some defines for items the cult archives can create.
 #define CULT_BLINDFOLD "Zealot's Blindfold"
 #define CURSE_ORB "Shuttle Curse"
-#define VEIL_WALKER "Veil Walker Set"
+#define VEIL_WALKER "Veil Walker"
 #define CRIMSON_MEDALLION "Crimson Medallion"
 
 // Cult archives. Gives out utility items.
@@ -31,7 +31,7 @@
 			),
 		VEIL_WALKER = list(
 			PREVIEW_IMAGE = image(icon = 'icons/obj/antags/cult/items.dmi', icon_state = "shifter"),
-			OUTPUT_ITEMS = list(/obj/item/cult_shift, /obj/item/flashlight/flare/culttorch),
+			OUTPUT_ITEMS = list(/obj/item/cult_shift),
 			RADIAL_DESC = "Creates \a [/obj/item/cult_shift::name], a small wand that teleports the user \
 				- and anyone the user is dragging - forward some distance.  Has [/obj/item/cult_shift::uses] uses.",
 			),

--- a/code/modules/deathmatch/deathmatch_loadouts.dm
+++ b/code/modules/deathmatch/deathmatch_loadouts.dm
@@ -941,8 +941,8 @@
 	uniform = /obj/item/clothing/under/color/black
 	id_trim = null
 	belt = /obj/item/melee/cultblade/dagger
-	l_pocket = /obj/item/flashlight/flare/culttorch
-	r_pocket = /obj/item/flashlight/flare/culttorch
+	l_pocket = /obj/item/flashlight/flare/torch/red/on
+	r_pocket = /obj/item/flashlight/flare/torch/red/on
 	gloves = /obj/item/clothing/gloves/color/black
 	shoes = /obj/item/clothing/shoes/cult/alt
 	l_hand = /obj/item/shield/mirror // the dreaded return!!
@@ -969,8 +969,8 @@
 	uniform = /obj/item/clothing/under/color/red
 	id_trim = null
 	belt = /obj/item/melee/cultblade/dagger
-	l_pocket = /obj/item/flashlight/flare/culttorch
-	r_pocket = /obj/item/flashlight/flare/culttorch
+	l_pocket = /obj/item/flashlight/flare/torch/red/on
+	r_pocket = /obj/item/flashlight/flare/torch/red/on
 	gloves = /obj/item/clothing/gloves/color/red
 	shoes = /obj/item/clothing/shoes/cult
 	l_hand = null

--- a/code/modules/mob_spawn/corpses/mining_corpses.dm
+++ b/code/modules/mob_spawn/corpses/mining_corpses.dm
@@ -379,7 +379,6 @@
 	back = /obj/item/storage/backpack/cultpack
 	backpack_contents = list(
 		/obj/item/cult_shift = 1,
-		/obj/item/flashlight/flare/culttorch = 1,
 		/obj/item/reagent_containers/cup/beaker/unholywater = 1,
 		/obj/item/stack/sheet/runed_metal = 15,
 		)
@@ -406,4 +405,3 @@
 			/obj/item/knife/combat/survival = 2,
 		))
 		backpack_contents += backpack_loot
-


### PR DESCRIPTION
Original PR: 92075
-----
## About The Pull Request

Deletes the Void Torch from Cult

Mapped in uses have been replaced with similar red torches

Deathmatch uses were replaced with red torches as well (did they even have a use in dm?)

## Why It's Good For The Game

Void Torch is maybe the # 1 example of bloat that comes to mind when I think of "Cult" 

- Very few people know that it does anything
- Even fewer people know how to use it
- Even FEWER people know how to use it effectively
- It isn't even uniquely produced, it comes with another object for no reason
- In fact, I see people not even *realize* that they get a torch with their veil shifter. In fact in fact, I see more people throw it *away* than use it. 

I don't really see a reason why it should stick around. A fair argument I could see is "muh sandbox, you're pidgeonholeing cult in to just swords and stun". But if that was the case, then why haven't people been using it?

The only sad part to me is torches are cult kino thematically.

## Changelog
:cl: Melbert
del: Removes the Void Torch from Cult
/:cl:
