### PR TITLE
[TG Mirror] Makes seclights attachable to almost every security firearm. [MDB IGNORE]

### DIFF
--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -525,3 +525,10 @@
 /// proc to handle our detonation
 /obj/item/gun/ballistic/automatic/battle_rifle/proc/fucking_explodes_you()
 	explosion(src, devastation_range = 1, heavy_impact_range = 3, light_impact_range = 6, explosion_cause = src)
+//component for seclight attachment
+/obj/item/gun/ballistic/automatic/battle_rifle/add_seclight_point()
+	AddComponent(/datum/component/seclite_attachable, \
+		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \
+		light_overlay = "flight", \
+		overlay_x = 28, \
+		overlay_y = 12)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -50,7 +50,13 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	can_be_sawn_off = TRUE
-
+	//component for seclight attachment
+/obj/item/gun/ballistic/shotgun/riot/add_seclight_point()
+	AddComponent(/datum/component/seclite_attachable, \
+		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \
+		light_overlay = "flight", \
+		overlay_x = 20, \
+		overlay_y = 11)
 // Automatic Shotguns//
 
 /obj/item/gun/ballistic/shotgun/automatic/shoot_live_shot(mob/living/user)
@@ -65,7 +71,13 @@
 	projectile_damage_multiplier = 1.5
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
-
+//component for seclight attachment
+/obj/item/gun/ballistic/shotgun/automatic/combat/add_seclight_point()
+	AddComponent(/datum/component/seclite_attachable, \
+		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \
+		light_overlay = "flight", \
+		overlay_x = 20, \
+		overlay_y = 11)
 /obj/item/gun/ballistic/shotgun/automatic/combat/compact
 	name = "compact combat shotgun"
 	desc = "A compact version of the semi automatic combat shotgun. Lower magazine capacity, but more easily carried."
@@ -73,7 +85,13 @@
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/shot/com/compact
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_MEDIUM
-
+//component for seclight attachment
+/obj/item/gun/ballistic/shotgun/automatic/combat/compact/add_seclight_point()
+	AddComponent(/datum/component/seclite_attachable, \
+		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \
+		light_overlay = "flight", \
+		overlay_x = 16, \
+		overlay_y = 11)
 //Dual Feed Shotgun
 
 /obj/item/gun/ballistic/shotgun/automatic/dual_tube

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -20,6 +20,12 @@
 		/datum/element/slapcrafting,\
 		slapcraft_recipes = slapcraft_recipe_list,\
 	)
+/obj/item/gun/energy/laser/add_seclight_point()
+	AddComponent(/datum/component/seclite_attachable, \
+		light_overlay_icon = 'icons/obj/weapons/guns/flashlights.dmi', \
+		light_overlay = "flight", \
+		overlay_x = 18, \
+		overlay_y = 12)
 
 /obj/item/gun/energy/laser/practice
 	name = "practice laser gun"


### PR DESCRIPTION
Original PR: 91922
-----

## About The Pull Request
THE SECLIGHTENING!!

Hi hello. This PR adds the ability to attach seclights to most security firearms. Nothing like some good seclight QOL.
Below is a picture with them attached, but off.
![image](https://github.com/user-attachments/assets/81fd4bb0-4e27-417b-9971-07d1afdfcf21)
Below is an image with the lights on:
![image](https://github.com/user-attachments/assets/53797ff8-9cff-403d-bbf0-df859e606788)
 (if no one understands why/what the shotguns look like, I tried to make it look like someone taped a flashlight to the side, as god intended.)
 I'm no good at spriting (it was just changing offsets for already existing sprites) but if you have any suggestions for what we can move the offsets to, be my guest.
## Why It's Good For The Game

Well, for starters, we can easily attach seclights to disablers, energy guns, advanced egun, the X01 energy gun, but we cant attach them to other weapons. Why? Balance? I dont see how its unbalanced for a secoff to see in the dark better. I couldnt tell you why you couldnt previously, but I can tell you that it just makes more sense to have them attachable to every weapon.  

## Changelog


:cl:
qol: Makes seclights attachable to almost every security firearm.
/:cl:


