### PR TITLE
[TG Mirror] Adds constructible plastitanium reinforced walls [MDB IGNORE]

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_syndielab.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_syndielab.dmm
@@ -103,7 +103,7 @@
 /area/ruin/syndielab)
 "cP" = (
 /obj/effect/mapping_helpers/bombable_wall,
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal{
 	desc = "An ominous looking wall. It has extra insulation to keep the heat in.";
 	name = "plastitanium wall"
 	},
@@ -458,7 +458,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/syndielab)
 "AR" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal{
 	desc = "An ominous looking wall. It has extra insulation to keep the heat in.";
 	name = "plastitanium wall"
 	},

--- a/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
+++ b/_maps/RandomRuins/SpaceRuins/forgottenship.dmm
@@ -14,7 +14,7 @@
 	on = 0;
 	shot_delay = 10
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ad" = (
 /obj/machinery/computer/operating,
@@ -55,7 +55,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "an" = (
 /obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ao" = (
 /turf/open/floor/carpet/royalblack,
@@ -65,7 +65,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "aq" = (
 /obj/structure/sign/poster/contraband/syndicate_recruitment,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ar" = (
 /obj/machinery/camera/xray{
@@ -203,7 +203,7 @@
 /turf/closed/mineral/random,
 /area/ruin/space)
 "bb" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bd" = (
 /obj/structure/closet/crate/secure/gear{
@@ -251,7 +251,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bg" = (
 /obj/structure/sign/poster/contraband/syndicate_pistol,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bh" = (
 /obj/structure/cable,
@@ -458,7 +458,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bR" = (
 /obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bS" = (
 /obj/machinery/button/crematorium{
@@ -473,7 +473,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bX" = (
 /obj/structure/sign/poster/contraband/c20r,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "bY" = (
 /obj/structure/closet/syndicate{
@@ -490,7 +490,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "bZ" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ca" = (
 /obj/machinery/computer/crew/syndie{
@@ -562,7 +562,7 @@
 	on = 0;
 	shot_delay = 10
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "cj" = (
 /obj/machinery/stasis,
@@ -570,7 +570,7 @@
 /area/ruin/space/has_grav/syndicate_forgotten_ship)
 "ck" = (
 /obj/structure/sign/departments/cargo,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/has_grav/syndicate_forgotten_cargopod)
 "cm" = (
 /obj/machinery/door/airlock/grunge{

--- a/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hauntedtradingpost.dmm
@@ -4518,7 +4518,7 @@
 /turf/open/floor/catwalk_floor/iron_smooth,
 /area/ruin/space/has_grav/hauntedtradingpost/public/corridor)
 "MR" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal{
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal{
 	desc = "An ominous looking wall.";
 	name = "reinforced wall"
 	},

--- a/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
+++ b/_maps/RandomRuins/SpaceRuins/old_infiltrator.dmm
@@ -113,7 +113,7 @@
 /turf/open/floor/circuit/red/airless,
 /area/ruin/space/unpowered)
 "ie" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/ruin/space/unpowered)
 "iI" = (
 /obj/effect/turf_decal/syndicateemblem/top/left,
@@ -608,7 +608,7 @@
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/ruin/space/unpowered)
 "Pq" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/ruin/space/unpowered)
 "PC" = (
 /obj/item/stock_parts/capacitor/adv{

--- a/_maps/shuttles/infiltrator_advanced.dmm
+++ b/_maps/shuttles/infiltrator_advanced.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/shuttle/syndicate/bridge)
 "ab" = (
 /obj/machinery/door/poddoor/shutters{
@@ -14,7 +14,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/bridge)
 "ad" = (
 /turf/template_noop,
@@ -23,10 +23,10 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/bridge)
 "af" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/bridge)
 "ah" = (
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate,
@@ -199,7 +199,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/airlock)
 "aC" = (
 /obj/structure/chair/comfy/shuttle{
@@ -212,7 +212,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/airlock)
 "aE" = (
 /obj/structure/chair/comfy/shuttle{
@@ -227,10 +227,10 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)
 "aF" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/hallway)
 "aH" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/eva)
 "aI" = (
 /obj/structure/chair/comfy/shuttle{
@@ -242,7 +242,7 @@
 /area/shuttle/syndicate/airlock)
 "aJ" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/airlock)
 "aK" = (
 /obj/structure/chair/comfy/shuttle{
@@ -259,7 +259,7 @@
 /area/shuttle/syndicate/airlock)
 "aL" = (
 /obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/airlock)
 "aM" = (
 /obj/effect/turf_decal/stripes/line{
@@ -282,7 +282,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/syndicate/airlock)
 "aO" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/airlock)
 "aP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -486,7 +486,7 @@
 /area/shuttle/syndicate/airlock)
 "bn" = (
 /obj/machinery/power/shuttle_engine/heater,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/medical)
 "bo" = (
 /obj/machinery/sleeper/syndie{
@@ -631,10 +631,10 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/syndicate/airlock)
 "bD" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/medical)
 "bE" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/armory)
 "bF" = (
 /obj/machinery/power/shuttle_engine/propulsion,
@@ -827,7 +827,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/airlock)
 "ca" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/shuttle/syndicate/airlock)
 "cb" = (
 /obj/effect/turf_decal/stripes/line{
@@ -921,7 +921,7 @@
 /area/shuttle/syndicate/medical)
 "ck" = (
 /obj/structure/sign/warning/secure_area,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/hallway)
 "cl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -964,7 +964,7 @@
 /area/shuttle/syndicate/medical)
 "cs" = (
 /obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/hallway)
 "ct" = (
 /obj/structure/sign/warning/fire,
@@ -1059,7 +1059,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 6
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/medical)
 "cD" = (
 /obj/machinery/power/shuttle_engine/large,
@@ -1077,7 +1077,7 @@
 /area/shuttle/syndicate/armory)
 "cG" = (
 /obj/machinery/power/shuttle_engine/heater,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/armory)
 "cH" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
@@ -1099,7 +1099,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 10
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/armory)
 "cL" = (
 /obj/machinery/power/shuttle_engine/large,
@@ -1107,7 +1107,7 @@
 /area/shuttle/syndicate/medical)
 "cM" = (
 /obj/machinery/power/shuttle_engine/heater,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/hallway)
 "cN" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
@@ -1162,7 +1162,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 10
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/medical)
 "cW" = (
 /obj/machinery/door/poddoor{
@@ -1196,7 +1196,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 6
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/armory)
 "da" = (
 /obj/item/sbeacondrop/bomb{
@@ -1600,7 +1600,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/syndicate/armory)
 "dR" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/shuttle/syndicate/eva)
 "dS" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1807,7 +1807,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/medical)
 "eo" = (
 /obj/structure/table/reinforced,
@@ -1841,7 +1841,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/armory)
 "er" = (
 /obj/effect/turf_decal/stripes/line{

--- a/_maps/shuttles/infiltrator_basic.dmm
+++ b/_maps/shuttles/infiltrator_basic.dmm
@@ -6,16 +6,16 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/bridge)
 "ac" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/bridge)
 "ad" = (
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 10
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/hallway)
 "ae" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/plastitanium,
@@ -26,7 +26,7 @@
 /turf/open/floor/plating,
 /area/shuttle/syndicate/bridge)
 "af" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/hallway)
 "ag" = (
 /obj/item/clipboard,
@@ -87,13 +87,13 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/eva)
 "ax" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/eva)
 "aB" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/airlock)
 "aD" = (
 /turf/open/floor/iron/dark,
@@ -102,19 +102,19 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/engineering)
 "aG" = (
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 9
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/medical)
 "aJ" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/medical)
 "aK" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/shuttle/syndicate/medical)
 "aN" = (
 /obj/machinery/status_display/evac/directional/south,
@@ -230,7 +230,7 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/shuttle/syndicate/engineering)
 "bj" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/shuttle/syndicate/engineering)
 "bk" = (
 /obj/structure/sign/poster/contraband/random/directional/west,
@@ -243,7 +243,7 @@
 /turf/open/floor/iron/dark/textured,
 /area/shuttle/syndicate/engineering)
 "bn" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/engineering)
 "bq" = (
 /obj/structure/table/reinforced,
@@ -405,7 +405,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/airlock)
 "bQ" = (
 /turf/open/floor/iron/large,
@@ -580,14 +580,14 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 10
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/engineering)
 "dz" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/shuttle/syndicate/medical)
 "fB" = (
 /obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/shuttle/syndicate/airlock)
 "gt" = (
 /obj/item/storage/box/handcuffs{
@@ -699,7 +699,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 5
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/bridge)
 "pQ" = (
 /obj/effect/turf_decal/tile/blue,
@@ -919,7 +919,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 6
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/hallway)
 "Jo" = (
 /turf/open/floor/iron/dark/textured_corner,
@@ -982,7 +982,7 @@
 /obj/machinery/porta_turret/syndicate/shuttle{
 	dir = 6
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/shuttle/syndicate/medical)
 "Nr" = (
 /obj/machinery/computer/records/security/laptop/syndie,
@@ -1096,7 +1096,7 @@
 	},
 /area/shuttle/syndicate/eva)
 "Xy" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/shuttle/syndicate/airlock)
 "YN" = (
 /turf/open/floor/iron/dark/smooth_corner{

--- a/_maps/virtual_domains/syndicate_assault.dmm
+++ b/_maps/virtual_domains/syndicate_assault.dmm
@@ -54,7 +54,7 @@
 /area/virtual_domain)
 "cj" = (
 /obj/structure/transit_tube/crossing,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain/protected_space)
 "ct" = (
 /obj/structure/closet/syndicate{
@@ -123,7 +123,7 @@
 /area/virtual_domain)
 "dd" = (
 /obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain)
 "di" = (
 /obj/machinery/power/terminal{
@@ -208,7 +208,7 @@
 /area/virtual_domain)
 "hA" = (
 /obj/effect/baseturf_helper/virtual_domain,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain)
 "hD" = (
 /obj/structure/table/reinforced,
@@ -224,7 +224,7 @@
 /area/virtual_domain)
 "iL" = (
 /obj/structure/sign/departments/cargo,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain/protected_space)
 "iU" = (
 /obj/structure/closet/crate/secure/gear{
@@ -377,7 +377,7 @@
 /area/virtual_domain)
 "nU" = (
 /obj/structure/sign/poster/contraband/syndicate_pistol,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain)
 "og" = (
 /obj/structure/table/reinforced,
@@ -437,7 +437,7 @@
 /area/space/virtual_domain)
 "qU" = (
 /obj/structure/sign/poster/contraband/c20r,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain/protected_space)
 "qY" = (
 /obj/machinery/light/small/directional/south,
@@ -452,7 +452,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/virtual_domain)
 "ru" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain)
 "rH" = (
 /obj/machinery/airalarm/directional/north,
@@ -603,7 +603,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/virtual_domain)
 "xS" = (
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/virtual_domain)
 "yl" = (
 /obj/machinery/door/airlock/grunge{
@@ -658,7 +658,7 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/virtual_domain)
 "zN" = (
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain/protected_space)
 "Aa" = (
 /obj/structure/chair/comfy/shuttle,
@@ -839,7 +839,7 @@
 	on = 0;
 	shot_delay = 10
 	},
-/turf/closed/wall/r_wall/syndicate/nodiagonal,
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal,
 /area/virtual_domain)
 "Im" = (
 /obj/structure/table/reinforced,
@@ -1111,7 +1111,7 @@
 /area/virtual_domain/protected_space)
 "UQ" = (
 /obj/structure/sign/poster/contraband/syndicate_recruitment,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain)
 "Vg" = (
 /turf/open/space/basic,
@@ -1123,7 +1123,7 @@
 	on = 0;
 	shot_delay = 10
 	},
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain)
 "Vq" = (
 /obj/structure/transit_tube/station/dispenser/reverse{
@@ -1133,7 +1133,7 @@
 /area/virtual_domain/safehouse)
 "Wd" = (
 /obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall/r_wall/syndicate,
+/turf/closed/wall/r_wall/plastitanium/syndicate,
 /area/virtual_domain/protected_space)
 "Wy" = (
 /obj/structure/closet/crate/secure/gear{

--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -131,7 +131,7 @@ DEFINE_BITFIELD(smoothing_junction, list(
 
 #define SMOOTH_GROUP_CLOSED_TURFS S_TURF(53) ///turf/closed
 #define SMOOTH_GROUP_MATERIAL_WALLS S_TURF(54) ///turf/closed/wall/material
-#define SMOOTH_GROUP_SYNDICATE_WALLS S_TURF(55) ///turf/closed/wall/r_wall/syndicate, /turf/closed/indestructible/syndicate
+#define SMOOTH_GROUP_SYNDICATE_WALLS S_TURF(55) ///turf/closed/wall/r_wall/plastitanium/syndicate, /turf/closed/indestructible/syndicate
 #define SMOOTH_GROUP_HOTEL_WALLS S_TURF(56) ///turf/closed/indestructible/hotelwall
 #define SMOOTH_GROUP_MINERAL_WALLS S_TURF(57) ///turf/closed/mineral, /turf/closed/indestructible
 #define SMOOTH_GROUP_BOSS_WALLS S_TURF(58) ///turf/closed/indestructible/riveted/boss

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -220,9 +220,25 @@
 					qdel(src)
 				return
 
+		if(istype(sheets, /obj/item/stack/sheet/mineral/plastitanium))
+			if(state == GIRDER_REINF)
+				if(sheets.get_amount() < 1)
+					return
+				balloon_alert(user, "adding plating...")
+				if(do_after(user, 50*platingmodifier, target = src))
+					if(sheets.get_amount() < 1)
+						return
+					sheets.use(1)
+					var/turf/T = get_turf(src)
+					T.place_on_top(/turf/closed/wall/r_wall/plastitanium)
+					transfer_fingerprints_to(T)
+					qdel(src)
+				return
+			// No return here because generic material construction handles making normal plastitanium walls
+
 		if(!sheets.has_unique_girder && sheets.material_type)
 			if(istype(src, /obj/structure/girder/reinforced))
-				balloon_alert(user, "need plasteel!")
+				balloon_alert(user, "need plasteel or plastitanium!")
 				return
 
 			var/M = sheets.sheettype

--- a/code/game/turfs/closed/wall/reinf_walls.dm
+++ b/code/game/turfs/closed/wall/reinf_walls.dm
@@ -233,13 +233,12 @@
 		return
 	return ..()
 
-/turf/closed/wall/r_wall/syndicate
-	name = "hull"
-	desc = "The armored hull of an ominous looking ship."
+/turf/closed/wall/r_wall/plastitanium
+	name = /turf/closed/wall/mineral/plastitanium::name
+	desc = "An extra durable wall made of an alloy of plasma and titanium, reinforced with plasteel rods."
 	icon = 'icons/turf/walls/plastitanium_wall.dmi'
 	icon_state = "plastitanium_wall-0"
 	base_icon_state = "plastitanium_wall"
-	explosive_resistance = 20
 	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
 	hardness = 25 //plastitanium
 	turf_flags = IS_SOLID
@@ -248,16 +247,32 @@
 	canSmoothWith = SMOOTH_GROUP_SHUTTLE_PARTS + SMOOTH_GROUP_AIRLOCK + SMOOTH_GROUP_PLASTITANIUM_WALLS + SMOOTH_GROUP_SYNDICATE_WALLS
 	rust_resistance = RUST_RESISTANCE_TITANIUM
 
-/turf/closed/wall/r_wall/syndicate/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
-	return FALSE
-
-/turf/closed/wall/r_wall/syndicate/nodiagonal
+/turf/closed/wall/r_wall/plastitanium/nodiagonal
 	icon = 'icons/turf/walls/plastitanium_wall.dmi'
 	icon_state = "map-shuttle_nd"
 	base_icon_state = "plastitanium_wall"
 	smoothing_flags = SMOOTH_BITMASK
 
-/turf/closed/wall/r_wall/syndicate/overspace
+/turf/closed/wall/r_wall/plastitanium/overspace
+	icon_state = "map-overspace"
+	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
+	fixed_underlay = list("space" = TRUE)
+
+/turf/closed/wall/r_wall/plastitanium/syndicate
+	name = "hull"
+	desc = "The armored hull of an ominous looking ship."
+	explosive_resistance = 20
+
+/turf/closed/wall/r_wall/plastitanium/syndicate/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	return FALSE
+
+/turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal
+	icon = 'icons/turf/walls/plastitanium_wall.dmi'
+	icon_state = "map-shuttle_nd"
+	base_icon_state = "plastitanium_wall"
+	smoothing_flags = SMOOTH_BITMASK
+
+/turf/closed/wall/r_wall/plastitanium/syndicate/overspace
 	icon_state = "map-overspace"
 	smoothing_flags = SMOOTH_BITMASK | SMOOTH_DIAGONAL_CORNERS
 	fixed_underlay = list("space" = TRUE)

--- a/code/modules/procedural_mapping/mapGenerators/syndicate.dm
+++ b/code/modules/procedural_mapping/mapGenerators/syndicate.dm
@@ -6,7 +6,7 @@
 
 /datum/map_generator_module/border/syndie_walls
 	spawnableAtoms = list()
-	spawnableTurfs = list(/turf/closed/wall/r_wall/syndicate = 100)
+	spawnableTurfs = list(/turf/closed/wall/r_wall/plastitanium/syndicate = 100)
 
 
 /datum/map_generator_module/syndie_furniture

--- a/tools/UpdatePaths/Scripts/92115_plastitanium_rwall_path_rename.txt
+++ b/tools/UpdatePaths/Scripts/92115_plastitanium_rwall_path_rename.txt
@@ -1,0 +1,5 @@
+#comment This repaths syndicate reinforced walls, as they have been made a subtype of a constructible plastitanium reinforced wall
+
+/turf/closed/wall/r_wall/syndicate : /turf/closed/wall/r_wall/plastitanium/syndicate{@OLD}
+/turf/closed/wall/r_wall/syndicate/nodiagonal : /turf/closed/wall/r_wall/plastitanium/syndicate/nodiagonal{@OLD}
+/turf/closed/wall/r_wall/syndicate/overspace : /turf/closed/wall/r_wall/plastitanium/syndicate/overspace{@OLD}


### PR DESCRIPTION
Original PR: 92115
-----
## About The Pull Request

You can now construct reinforced plastitanium walls by using a single plastitanium sheet on a reinforced girder. These are mostly identical to syndicate walls, but only have 2 explosion resistance like normal reinforced walls, as opposed to the 20 of syndicate walls.

## Why It's Good For The Game

Have you ever wanted a construction project to have that cool syndicate aesthetic, but doing so would compromise its security due to the walls being able to be simply welded down? Now you can make a syndicate shuttle or satellite that will at least require thermite or the aid of an engiborg to rapidly break into.

## Changelog

:cl:
add: You can construct reinforced plastitanium walls by using plastitanium on reinforced girders.
/:cl:
