### PR TITLE
[TG Mirror] Removes acidentally placed slime grinder from nukies base [MDB IGNORE]

### DIFF
--- a/_maps/templates/lazy_templates/nukie_base.dmm
+++ b/_maps/templates/lazy_templates/nukie_base.dmm
@@ -3221,10 +3221,6 @@
 	},
 /turf/open/floor/iron/dark/textured_large,
 /area/centcom/syndicate_mothership/control)
-"IZ" = (
-/obj/machinery/processor/slime/fullupgrade,
-/turf/closed/indestructible/opsglass,
-/area/centcom/syndicate_mothership/control)
 "Jc" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/beer{
@@ -7932,7 +7928,7 @@ uT
 VK
 VK
 DZ
-IZ
+VK
 VK
 VK
 VK


### PR DESCRIPTION
Original PR: 92254
-----
## About The Pull Request

eden why

## Why It's Good For The Game

we love map fixes

## Changelog

:cl:
fix: Removed acidentally placed slime grinder in nuclear operatives outpost
/:cl:
