### PR TITLE
[TG Mirror] Fixes the unknown request console on catwalk station [MDB IGNORE]

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -22849,6 +22849,14 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/requests_console/directional/east{
+	name = "Quartermaster's Requests Console";
+	department = "Quartermaster's Desk"
+	},
+/obj/effect/mapping_helpers/requests_console/assistance,
+/obj/effect/mapping_helpers/requests_console/ore_update,
+/obj/effect/mapping_helpers/requests_console/announcement,
+/obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/iron,
 /area/station/command/heads_quarters/qm)
 "gLM" = (
@@ -47117,11 +47125,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/requests_console/directional/east,
-/obj/effect/mapping_helpers/requests_console/ore_update,
-/obj/effect/mapping_helpers/requests_console/assistance,
-/obj/effect/mapping_helpers/requests_console/announcement,
-/obj/effect/mapping_helpers/requests_console/information,
 /turf/open/floor/wood/parquet,
 /area/station/command/heads_quarters/qm)
 "nRE" = (


### PR DESCRIPTION
Original PR: 92257
-----

## About The Pull Request

Adds the proper names to the QM's request console on catwalk. Incidentally moved the request console out into the QM's main office from the bedroom where they're more likely to see it.

Fixes #91866 

## Why It's Good For The Game

New request console who dis?

## Changelog
:cl:
fix: The quartermaster's request console on Catwalk Station will no longer show up as Unknown.
map: The quartermaster's request console on Catwalk Station has been moved from their bedroom to the office.
/:cl:
