### PR TITLE
[TG Mirror] makes the hermit spawner on icebox an icebox hermit [MDB IGNORE]

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_underground_hermit.dmm
@@ -25,7 +25,7 @@
 /turf/open/floor/grass/fairy,
 /area/ruin/powered/hermit)
 "ha" = (
-/obj/effect/mob_spawn/ghost_role/human/hermit,
+/obj/effect/mob_spawn/ghost_role/human/hermit/icemoon,
 /turf/open/floor/wood,
 /area/ruin/powered/hermit)
 "hN" = (


### PR DESCRIPTION
Original PR: 92261
-----

## About The Pull Request

makes the icebox hermit native to icebox rather than lavaland

## Why It's Good For The Game

fixes #89835

## Changelog
:cl:
fix: makes the icebox hermit native to icebox
/:cl:
