### PR TITLE
[TG Mirror] Adds missing ID machinery on CatwalkStation and WawaStation [MDB IGNORE]

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -20754,7 +20754,7 @@
 /turf/open/floor/iron,
 /area/station/cargo/storage)
 "geL" = (
-/obj/item/kirbyplants/random,
+/obj/machinery/pdapainter/medbay,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "geM" = (
@@ -70956,6 +70956,7 @@
 "uUK" = (
 /obj/machinery/light/directional/south,
 /obj/structure/extinguisher_cabinet/directional/south,
+/obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "uUL" = (

--- a/_maps/map_files/wawastation/wawastation.dmm
+++ b/_maps/map_files/wawastation/wawastation.dmm
@@ -66762,10 +66762,20 @@
 /obj/structure/table/wood/fancy/red,
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/recharger{
-	pixel_x = 14
+	pixel_x = 16;
+	pixel_y = 3
 	},
-/obj/item/folder/red,
-/obj/item/stamp/head/hos,
+/obj/item/folder/red{
+	pixel_x = 2;
+	pixel_y = 9
+	},
+/obj/item/stamp/head/hos{
+	pixel_y = 11;
+	pixel_x = 2
+	},
+/obj/machinery/computer/records/security/laptop{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "wZR" = (
@@ -66884,8 +66894,8 @@
 /turf/open/floor/engine,
 /area/station/engineering/supermatter/room)
 "xaY" = (
-/obj/machinery/computer/records/security,
 /obj/item/radio/intercom/directional/north,
+/obj/machinery/modular_computer/preset/id,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/hos)
 "xbi" = (


### PR DESCRIPTION
Original PR: 92255
-----
## About The Pull Request

Added PDA painter in CMO office (catwalk) and replaced security records on id console in HOS office (wawa) ((security records is now laptop on HOS table))

## Why It's Good For The Game

we love fixes here!!

## Changelog

:cl:
fix: Added missing ID machinery on CatwalkStation and WawaStation
/:cl:

