### PR TITLE
[TG Mirror] Fixes hivehead spawning bees on tiles when you're riding disposals [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -642,17 +642,16 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CHANGELING_TRAIT)
 
-/obj/item/clothing/head/helmet/changeling_hivehead/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
-	. = ..()
-	if(!istype(attacking_item, /obj/item/organ/monster_core/regenerative_core/legion) || !holds_reagents)
-		return
-	visible_message(span_boldwarning("As [user] shoves [attacking_item] into [src], [src] begins to mutate."))
+/obj/item/clothing/head/helmet/changeling_hivehead/item_interaction(mob/living/user, obj/item/tool, list/modifiers)
+	if(!istype(tool, /obj/item/organ/monster_core/regenerative_core/legion) || !holds_reagents)
+		return NONE
+	visible_message(span_boldwarning("As [user] shoves [tool] into [src], [src] begins to mutate."))
 	var/mob/living/carbon/wearer = loc
 	playsound(wearer, 'sound/effects/blob/attackblob.ogg', 60, TRUE)
 	wearer.temporarilyRemoveItemFromInventory(wearer.head, TRUE)
 	wearer.equip_to_slot_if_possible(new /obj/item/clothing/head/helmet/changeling_hivehead/legion(wearer), ITEM_SLOT_HEAD, 1, 1, 1)
-	qdel(attacking_item)
-
+	qdel(tool)
+	return ITEM_INTERACT_SUCCESS
 
 /datum/action/cooldown/hivehead_spawn_minions
 	name = "Release Bees"
@@ -670,7 +669,7 @@
 /datum/action/cooldown/hivehead_spawn_minions/PreActivate(atom/target)
 	if(owner.movement_type & VENTCRAWLING)
 		owner.balloon_alert(owner, "unavailable here")
-		return
+		return FALSE
 	return ..()
 
 /datum/action/cooldown/hivehead_spawn_minions/Activate(atom/target)
@@ -680,7 +679,7 @@
 	if(owner.stat >= HARD_CRIT)
 		spawns = 1
 	for(var/i in 1 to spawns)
-		var/mob/living/basic/summoned_minion = new spawn_type(get_turf(owner))
+		var/mob/living/basic/summoned_minion = new spawn_type(owner.drop_location())
 		summoned_minion.faction = list("[REF(owner)]")
 		minion_additional_changes(summoned_minion)
 


### PR DESCRIPTION
Original PR: 92175
-----

## About The Pull Request

Closes #92168
Swapping this to drop_location makes sure that bees get spawned inside of your locker/disposals holder instead of being spewed out on your tile.
Also converted attackby to item_interaction

## Changelog
:cl:
fix: Fixed hiveheads spawning bees on tiles when you're riding disposals
code: Cleaned up and updated hivehead code
/:cl:
