### PR TITLE
[TG Mirror] corrects some loop syntax [MDB IGNORE]

### DIFF
--- a/code/datums/mergers/_merger.dm
+++ b/code/datums/mergers/_merger.dm
@@ -85,7 +85,7 @@
 	if(origin)
 		var/turf/starting = get_turf(origin)
 		check_turf(starting, found_turfs, NONE)
-	for(var/i = 1; i <= length(found_turfs), i++)
+	for(var/i = 1; i <= length(found_turfs); i++)
 		var/turf/focus = found_turfs[i]
 		var/list/focus_packet = found_turfs[focus]
 		var/dirs_checked = focus_packet[MERGE_TURF_PACKET_DIR]

--- a/code/game/objects/effects/wanted_poster.dm
+++ b/code/game/objects/effects/wanted_poster.dm
@@ -84,7 +84,7 @@
 	var/textLen = min(length(text), 7)
 	var/startX = 16 - (2*textLen)
 	var/i
-	for(i=1; i <= textLen, i++)
+	for(i=1; i <= textLen; i++)
 		var/letter = uppertext(text[i])
 		var/icon/letter_icon = icon("icon" = 'icons/testing/Font_Minimal.dmi', "icon_state" = letter)
 		letter_icon.Shift(EAST, startX) //16 - (2*n)

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -376,7 +376,7 @@ no power level overlay is currently in the overlays list.
 	if(connected_gens.len < 2)
 		return
 	var/connected_gen_counter
-	for(connected_gen_counter = 1; connected_gen_counter < connected_gens.len, connected_gen_counter++)
+	for(connected_gen_counter = 1; connected_gen_counter < connected_gens.len; connected_gen_counter++)
 
 		var/list/connected_gen_list = ((connected_gens[connected_gen_counter].connected_gens & connected_gens[connected_gen_counter+1].connected_gens)^src)
 		if(!connected_gen_list.len)


### PR DESCRIPTION
Original PR: 92252
-----

## About The Pull Request
spacemandmm, and byond, did not used to error on using `for init; test, inc`. spacemandmm now does, and i think it's bad syntax to keep around anyway

## Why It's Good For The Game
this syntax was mad

## Changelog
no playerfacing changes
