### PR TITLE
[TG Mirror] hand items have no attack cooldown with northstar gloves [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -145,6 +145,8 @@
 #define COMSIG_LIVING_SLAP_MOB "living_slap_mob"
 ///from /obj/item/hand_item/slapper/attack(): (source=mob/living/slapper, mob/living/slapped)
 #define COMSIG_LIVING_SLAPPED "living_slapped"
+///from /obj/item/hand_item/attack(): (source=mob/living/attacker, mob/living/attacked)
+#define COMSIG_LIVING_HAND_ITEM_ATTACK "living_hand_item_attack"
 /// from /mob/living/*/UnarmedAttack(), before sending [COMSIG_LIVING_UNARMED_ATTACK]: (mob/living/source, atom/target, proximity, modifiers)
 /// The only reason this exists is so hulk can fire before Fists of the North Star.
 /// Note that this is called before [/mob/living/proc/can_unarmed_attack] is called, so be wary of that.

--- a/code/datums/components/punchcooldown.dm
+++ b/code/datums/components/punchcooldown.dm
@@ -1,6 +1,6 @@
 ///Your favourite Jojoke. Used for the gloves of the north star.
 /datum/component/wearertargeting/punchcooldown
-	signals = list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_LIVING_SLAP_MOB)
+	signals = list(COMSIG_LIVING_UNARMED_ATTACK, COMSIG_LIVING_HAND_ITEM_ATTACK)
 	mobtype = /mob/living/carbon
 	proctype = PROC_REF(reducecooldown)
 	valid_slots = list(ITEM_SLOT_GLOVES)
@@ -15,7 +15,8 @@
 
 ///Called on COMSIG_LIVING_UNARMED_ATTACK. Yells the warcry and and reduces punch cooldown.
 /datum/component/wearertargeting/punchcooldown/proc/reducecooldown(mob/living/carbon/M, atom/target)
-	if((M.combat_mode && isliving(target)) || istype(M.get_active_held_item(), /obj/item/hand_item/slapper))
+	var/obj/item/used_item = M.get_active_held_item()
+	if((M.combat_mode && isliving(target)) || (used_item & HAND_ITEM))
 		M.changeNext_move(CLICK_CD_RAPID)
 		if(warcry)
 			M.say(warcry, ignore_spam = TRUE, forced = "north star warcry")

--- a/code/game/objects/items/hand_items.dm
+++ b/code/game/objects/items/hand_items.dm
@@ -10,6 +10,10 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NO_STORAGE_INSERT, TRAIT_GENERIC)
 
+/obj/item/hand_item/attack(mob/living/target_mob, mob/living/user)
+	. = ..()
+	SEND_SIGNAL(user, COMSIG_LIVING_HAND_ITEM_ATTACK, target_mob)
+
 /obj/item/hand_item/circlegame
 	name = "circled hand"
 	desc = "If somebody looks at this while it's below your waist, you get to bop them."
@@ -217,6 +221,7 @@
 	AddElement(/datum/element/high_fiver)
 
 /obj/item/hand_item/slapper/attack(mob/living/slapped, mob/living/carbon/human/user)
+	. = ..()
 	SEND_SIGNAL(user, COMSIG_LIVING_SLAP_MOB, slapped)
 	SEND_SIGNAL(slapped, COMSIG_LIVING_SLAPPED, user)
 


### PR DESCRIPTION
Original PR: 91888
-----

## About The Pull Request
closes https://github.com/tgstation/tgstation/issues/84319
## Why It's Good For The Game
consistency
## Changelog
:cl:
fix: all hand items will now have no cooldown when used with northstar gloves, including circle hand
/:cl:
