### PR TITLE
[TG Mirror] Fixes manifest hard dels [MDB IGNORE]

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -26,7 +26,7 @@
 	/// The time spent to climb this crate.
 	var/crate_climb_time = 2 SECONDS
 	/// The reference of the manifest paper attached to the cargo crate.
-	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
+	var/datum/weakref/manifest
 	/// Where the Icons for lids are located.
 	var/lid_icon = 'icons/obj/storage/crates.dmi'
 	/// Icon state to use for lid to display when opened. Leave undefined if there isn't one.
@@ -67,7 +67,7 @@
 	AddComponent(/datum/component/soapbox)
 
 /obj/structure/closet/crate/Destroy()
-	QDEL_NULL(manifest)
+	manifest = null
 	return ..()
 
 /obj/structure/closet/crate/CanAllowThrough(atom/movable/mover, border_dir)
@@ -114,8 +114,7 @@
 	. = ..()
 	if(.)
 		return
-	if(manifest)
-		tear_manifest(user)
+	tear_manifest(user)
 
 /obj/structure/closet/crate/after_open(mob/living/user, force)
 	. = ..()
@@ -126,11 +125,8 @@
 			RemoveElement(/datum/element/elevation, pixel_shift = elevation)
 		if(elevation_open)
 			AddElement(/datum/element/elevation, pixel_shift = elevation_open)
-	if(!QDELETED(manifest))
-		playsound(src, 'sound/items/poster/poster_ripped.ogg', 75, TRUE)
-		manifest.forceMove(get_turf(src))
-		manifest = null
-		update_appearance()
+
+	tear_manifest()
 
 /obj/structure/closet/crate/after_close(mob/living/user)
 	. = ..()
@@ -153,12 +149,17 @@
 
 ///Removes the supply manifest from the closet
 /obj/structure/closet/crate/proc/tear_manifest(mob/user)
-	to_chat(user, span_notice("You tear the manifest off of [src]."))
+	var/obj/item/paper/fluff/jobs/cargo/manifest/our_manifest = manifest?.resolve()
+	if(QDELETED(our_manifest))
+		manifest = null
+		return
+	if(user)
+		to_chat(user, span_notice("You tear the manifest off of [src]."))
 	playsound(src, 'sound/items/poster/poster_ripped.ogg', 75, TRUE)
 
-	manifest.forceMove(loc)
+	our_manifest.forceMove(drop_location(src))
 	if(ishuman(user))
-		user.put_in_hands(manifest)
+		user.put_in_hands(our_manifest)
 	manifest = null
 	update_appearance()
 

--- a/code/modules/bitrunning/server/loot.dm
+++ b/code/modules/bitrunning/server/loot.dm
@@ -46,7 +46,7 @@
 	certificate.update_appearance()
 
 	var/obj/structure/closet/crate/secure/bitrunning/decrypted/reward_cache = new(src, generated_domain, bonus)
-	reward_cache.manifest = certificate
+	reward_cache.manifest = WEAKREF(certificate)
 	reward_cache.update_appearance()
 
 	if(can_generate_tech_disk(grade))

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -157,7 +157,6 @@
 				if(!container_contents[missing_item]) // To avoid 0s and negative values on the manifest
 					container_contents -= missing_item
 
-
 	for(var/item in container_contents)
 		manifest_text += "<li> [container_contents[item]] [item][container_contents[item] == 1 ? "" : "s"]</li>"
 	manifest_text += "</ul>"
@@ -173,16 +172,13 @@
 			while(--lost >= 0)
 				qdel(pick(container.contents))
 
-
 	manifest_paper.update_appearance()
 	manifest_paper.forceMove(container)
 
 	if(istype(container, /obj/structure/closet/crate))
-		var/obj/structure/closet/crate/C = container
-		C.manifest = manifest_paper
-		C.update_appearance()
-	else
-		container.contents += manifest_paper
+		var/obj/structure/closet/crate/crate = container
+		crate.manifest = WEAKREF(manifest_paper)
+		crate.update_appearance()
 
 	return manifest_paper
 


### PR DESCRIPTION
Original PR: 92283
-----
## About The Pull Request

<img width="378" height="199" alt="1eSxYbsh0e" src="https://github.com/user-attachments/assets/e8a658ca-c1c4-48fe-bb51-c77c85a7f824" />

Noticed some hard dels here, does some light refactoring/code improvement to ensure that doesn't happen.

Crates shouldn't really be owning a hard ref to the manifest in the first place since they are detachable. Removes some code duplication in favor of calling `tear_manifest()` which has the safety check to prevent `forceMove()`ing a qdeleted manifest out of nullspace.

## Why It's Good For The Game

Less server hiccups.

## Changelog

Nothing players will notice besides less server hiccups.