### PR TITLE
[TG Mirror] Vars .outfit and .plasmaman_outfit on /datum/job are typed to datum/outfit and datum/outfit/plasmaman respectively [MDB IGNORE]

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -44,10 +44,10 @@
 	/// If you have the use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
 	var/minimal_player_age = 0
 
-	var/outfit = null
+	var/datum/outfit/outfit = null
 
 	/// The job's outfit that will be assigned for plasmamen.
-	var/plasmaman_outfit = null
+	var/datum/outfit/plasmaman/plasmaman_outfit = null
 
 	/// Minutes of experience-time required to play in this job. The type is determined by [exp_required_type] and [exp_required_type_department] depending on configs.
 	var/exp_requirements = 0


### PR DESCRIPTION
Original PR: 92289
-----

## About The Pull Request
I noticed that these two variables defined on the job datum are plain root variables rather than being typed; and so, I modified them to be typed to what they should otherwise always be set to.

## Why It's Good For The Game
Implements something approaching slightly more type safety and inference for these vars.

## Changelog
:cl: Bisar
code: The .outfit and .plasmaman_outfit variables on the job datum are now defined to their expected types.
/:cl:
