### PR TITLE
[TG Mirror] Fix hoods not hiding anything [MDB IGNORE]

### DIFF
--- a/code/datums/components/toggle_attached_clothing.dm
+++ b/code/datums/components/toggle_attached_clothing.dm
@@ -140,6 +140,7 @@
 		parent_gear.icon_state = "[initial(parent_gear.post_init_icon_state) || initial(parent_gear.icon_state)][parent_icon_state_suffix]"
 		parent_gear.worn_icon_state = parent_gear.icon_state
 	parent_gear.update_slot_icon()
+	wearer.update_obscured_slots(deployable.flags_inv)
 	wearer.update_mob_action_buttons()
 
 /// Undeploy gear if it moves slots somehow


### PR DESCRIPTION
Original PR: 92285
-----
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes the issue with toggleable clothing not properly considering obscured inv_flags slots
this is the issue related to this bug, but this solution is moreso a hack than anything so i'm not closing the issue.
https://github.com/tgstation/tgstation/issues/85028
potential better fix at https://github.com/DaedalusDock/daedalusdock/pull/826
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
ew
<img width="93" height="107" alt="heretic_cosm" src="https://github.com/user-attachments/assets/f560ebab-4e99-45bf-8ec2-ca04fe7f9b1e" />
good
<img width="106" height="103" alt="Screenshot 2025-07-23 224257" src="https://github.com/user-attachments/assets/af61cb06-8578-4349-ab79-436e2cc7ee06" />



<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: clothing with hood now correctly hides slots based on inv_flags
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
