### PR TITLE
[TG Mirror] Makes mech removal crowbar remove mech sleeper patients [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -238,22 +238,30 @@
 	if(!HAS_TRAIT(src, TRAIT_WIELDED))
 		mech.balloon_alert(user, "not wielded!")
 		return
-	if(!LAZYLEN(mech.occupants) || (LAZYLEN(mech.occupants) == 1 && mech.mecha_flags & SILICON_PILOT)) //if no occupants, or only an ai
+	var/obj/item/mecha_parts/mecha_equipment/sleeper/mech_sleeper = locate() in mech
+	if((!LAZYLEN(mech.occupants) || (LAZYLEN(mech.occupants) == 1 && mech.mecha_flags & SILICON_PILOT)) && (!mech_sleeper || !mech_sleeper.patient)) //if no occupants, or only an ai
 		mech.balloon_alert(user, "it's empty!")
 		return
-	user.log_message("tried to pry open [mech], located at [loc_name(mech)], which is currently occupied by [mech.occupants.Join(", ")].", LOG_ATTACK)
+	var/list/log_list_before = LAZYCOPY(mech.occupants)
+	if(mech_sleeper?.patient)
+		log_list_before += mech_sleeper.patient
+	user.log_message("tried to pry open [mech], located at [loc_name(mech)], which is occupied by [log_list_before.Join(", ")].", LOG_ATTACK)
 	var/mech_dir = mech.dir
 	mech.balloon_alert(user, "prying open...")
 	playsound(mech, 'sound/machines/airlock/airlock_alien_prying.ogg', 100, TRUE)
-	if(!use_tool(mech, user, (mech.mecha_flags & IS_ENCLOSED) ? 5 SECONDS : 3 SECONDS, volume = 0, extra_checks = CALLBACK(src, PROC_REF(extra_checks), mech, mech_dir)))
+	if(!use_tool(mech, user, (mech.mecha_flags & IS_ENCLOSED) ? 5 SECONDS : 3 SECONDS, volume = 0, extra_checks = CALLBACK(src, PROC_REF(extra_checks), mech, mech_dir, mech_sleeper)))
 		mech.balloon_alert(user, "interrupted!")
 		return
-	user.log_message("pried open [mech], located at [loc_name(mech)], which is currently occupied by [mech.occupants.Join(", ")].", LOG_ATTACK)
-	for(var/mob/living/occupant as anything in mech.occupants)
-		if(isAI(occupant))
+	var/list/log_list_after = LAZYCOPY(mech.occupants)
+	if(mech_sleeper?.patient)
+		log_list_after += mech_sleeper.patient
+		mech_sleeper.go_out()
+	user.log_message("pried open [mech], located at [loc_name(mech)], which was occupied by [log_list_after.Join(", ")].", LOG_ATTACK)
+	for(var/mob/living/occupant as anything in SANITIZE_LIST(mech.occupants))
+		if(isAI(occupant) || isbrain(occupant))
 			continue
-		mech.mob_exit(occupant, randomstep = TRUE)
+		mech.mob_exit(occupant)
 	playsound(mech, 'sound/machines/airlock/airlockforced.ogg', 75, TRUE)
 
-/obj/item/crowbar/mechremoval/proc/extra_checks(obj/vehicle/sealed/mecha/mech, mech_dir)
-	return HAS_TRAIT(src, TRAIT_WIELDED) && LAZYLEN(mech.occupants) && mech.dir == mech_dir
+/obj/item/crowbar/mechremoval/proc/extra_checks(obj/vehicle/sealed/mecha/mech, mech_dir, obj/item/mecha_parts/mecha_equipment/sleeper/mech_sleeper)
+	return HAS_TRAIT(src, TRAIT_WIELDED) && (LAZYLEN(mech.occupants) || mech_sleeper?.patient) && (mech.dir == mech_dir)

--- a/code/modules/vehicles/mecha/working/clarke.dm
+++ b/code/modules/vehicles/mecha/working/clarke.dm
@@ -1,6 +1,6 @@
 ///Lavaproof, fireproof, fast mech with low armor and higher energy consumption and has an internal ore box.
 /obj/vehicle/sealed/mecha/clarke
-	desc = "Combining man and machine for a better, stronger miner, Cannot strafe Can even resist lava!"
+	desc = "Combining man and machine for a better, stronger miner. Can even resist lava! Due to its tracks it cannot strafe."
 	name = "\improper Clarke"
 	icon_state = "clarke"
 	base_icon_state = "clarke"


### PR DESCRIPTION
Original PR: 92281
-----

## About The Pull Request
mech removal crowbar removes mech sleeper patients. occupants it removes also no longer get thrown at a random tile
also rewrites the clarke description to follow english language

## Why It's Good For The Game
if the utility of the item is to remove people from mechs it should be able to remove all people from mechs. also it throwing those people you just removed into you is stupid

## Changelog
:cl:
add: mech removal crowbar removes mech sleeper patients
balance: occupants it removes also no longer get thrown at a random tile
spellcheck: clarke mech description was rewritten for grammar
/:cl:
