### PR TITLE
[TG Mirror] allows non-prisoners to access sustenance vendor in catwalk bridge [MDB IGNORE]

### DIFF
--- a/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
+++ b/_maps/map_files/CatwalkStation/CatwalkStation_2023.dmm
@@ -64165,7 +64165,9 @@
 /area/station/commons/dorms)
 "sVj" = (
 /obj/structure/cable,
-/obj/machinery/vending/sustenance,
+/obj/machinery/vending/sustenance{
+	req_access = list("command")
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -41,10 +41,18 @@
 	displayed_currency_name = " LP"
 
 /obj/machinery/vending/sustenance/interact(mob/user)
-	if(isliving(user))
-		var/mob/living/living_user = user
-		if(!(machine_stat & NOPOWER) && !istype(living_user.get_idcard(TRUE), /obj/item/card/id/advanced/prisoner))
+	if(!isliving(user))
+		return ..()
+	var/mob/living/living_user = user
+	if(!is_operational)
+		to_chat(user, span_warning("Machine does not respond to your ID swipe"))
+		return
+	if(!istype(living_user.get_idcard(TRUE), /obj/item/card/id/advanced/prisoner))
+		if(!req_access)
 			speak("No valid prisoner account found. Vending is not permitted.")
+			return
+		if(!allowed(user))
+			speak("No valid permissions. Vending is not permitted.")
 			return
 	return ..()
 


### PR DESCRIPTION
Original PR: 92273
-----
## About The Pull Request

Allows non-prisoners to access vendors with access requirements, adds command access requirement to bridge catwalk sustenance vendor

## Why It's Good For The Game

fixes #92185

## Changelog

:cl:

fix: Command can now use their sustenance vendor on Catwalk Station

/:cl:
