### PR TITLE
[TG Mirror] Recovered Crew are in spawner menu [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob_living.dm
@@ -337,5 +337,8 @@
 	/// Index in modifiers containing the modifer to surgery speed
 	#define SPEED_MOD_INDEX 2
 
+/// From /datum/spawners_menu/ui_static_data(mob/user) : (list/string_info)
+#define COMSIG_LIVING_GHOSTROLE_INFO "living_ghostrole_info"
+
 ///from mob/living/befriend()
 #define COMSIG_LIVING_MADE_NEW_FRIEND "made_new_friend"

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -182,7 +182,7 @@
 	to_chat(src, span_warning("You cannot speak, your other self is controlling your body!"))
 	return FALSE
 
-/mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE)
+/mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE, forced = FALSE)
 	return FALSE
 
 ///////////////BRAINWASHING////////////////////

--- a/code/datums/elements/orbit_twitcher.dm
+++ b/code/datums/elements/orbit_twitcher.dm
@@ -1,0 +1,50 @@
+/datum/element/orbit_twitcher
+	element_flags = ELEMENT_BESPOKE | ELEMENT_DETACH_ON_HOST_DESTROY
+	argument_hash_start_idx = 2
+	/// Chance we have to twitch per second
+	var/twitch_chance
+	/// Those who are being orbited and should twitch
+	var/list/twitchers = list()
+
+/datum/element/orbit_twitcher/Attach(datum/target, twitch_chance)
+	. = ..()
+	if(!isliving(target))
+		return ELEMENT_INCOMPATIBLE
+
+	src.twitch_chance = twitch_chance
+
+	RegisterSignal(target, COMSIG_ATOM_ORBIT_BEGIN, PROC_REF(orbit_begin))
+	RegisterSignal(target, COMSIG_ATOM_ORBIT_STOP, PROC_REF(orbit_stop))
+
+/datum/element/orbit_twitcher/Detach(datum/source, ...)
+	. = ..()
+
+	twitchers.Remove(source)
+	UnregisterSignal(source, list(COMSIG_ATOM_ORBIT_BEGIN, COMSIG_ATOM_ORBIT_STOP))
+
+/datum/element/orbit_twitcher/process(seconds_per_tick)
+	for(var/mob/living/living as anything in twitchers)
+		if(SPT_PROB(twitch_chance, seconds_per_tick))
+			if(prob(60))
+				living.emote("twitch_s", forced = TRUE)
+			else
+				living.emote("twitch", forced = TRUE)
+
+/datum/element/orbit_twitcher/proc/orbit_begin(atom/source, atom/orbiter)
+	SIGNAL_HANDLER
+
+	twitchers.Add(source)
+	// It checks if we're already processing so it's fine to always call
+	START_PROCESSING(SSdcs, src)
+
+/datum/element/orbit_twitcher/proc/orbit_stop(atom/source, atom/orbiter)
+	SIGNAL_HANDLER
+
+	twitchers.Remove(source)
+
+	if(!twitchers.len)
+		STOP_PROCESSING(SSdcs, src)
+
+/datum/element/orbit_twitcher/OnTargetDelete(datum/source)
+	twitchers.Remove(source)
+	return ..()

--- a/code/datums/spawners_menu.dm
+++ b/code/datums/spawners_menu.dm
@@ -51,7 +51,7 @@
 		this["amount_left"] = 0
 		for(var/mob/joinable_mob as anything in GLOB.joinable_mobs[mob_type])
 			this["amount_left"] += 1
-			if(!this["desc"])
+			if(!SEND_SIGNAL(joinable_mob, COMSIG_LIVING_GHOSTROLE_INFO, this))
 				this["desc"] = initial(joinable_mob.desc)
 		if(this["amount_left"] > 0)
 			data["spawners"] += list(this)

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -12,7 +12,7 @@
 #define BEYBLADE_CONFUSION_LIMIT (40 SECONDS)
 
 //The code execution of the emote datum is located at code/datums/emotes.dm
-/mob/proc/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE)
+/mob/proc/emote(act, m_type = null, message = null, intentional = FALSE, force_silence = FALSE, forced = FALSE)
 	var/param = message
 	var/custom_param = findchar(act, " ")
 	if(custom_param)
@@ -31,7 +31,7 @@
 		if(!emote.check_cooldown(src, intentional))
 			silenced = TRUE
 			continue
-		if(!emote.can_run_emote(src, TRUE, intentional, param))
+		if(!forced && !emote.can_run_emote(src, TRUE, intentional, param))
 			continue
 		if(SEND_SIGNAL(src, COMSIG_MOB_PRE_EMOTED, emote.key, param, m_type, intentional, emote) & COMPONENT_CANT_EMOTE)
 			silenced = TRUE

--- a/code/modules/mob/eye/eye.dm
+++ b/code/modules/mob/eye/eye.dm
@@ -44,7 +44,7 @@
 	z_move_flags |= ZMOVE_IGNORE_OBSTACLES  //cameras do not respect these FLOORS you speak so much of
 	return ..()
 
-/mob/eye/emote(act, m_type=1, message = null, intentional = FALSE, force_silence = FALSE)
+/mob/eye/emote(act, m_type=1, message = null, intentional = FALSE, force_silence = FALSE, forced = FALSE)
 	if(has_emotes)
 		return ..()
 	return FALSE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1581,6 +1581,7 @@
 #include "code\datums\elements\on_hit_effect.dm"
 #include "code\datums\elements\only_pull_living.dm"
 #include "code\datums\elements\openspace_item_click_handler.dm"
+#include "code\datums\elements\orbit_twitcher.dm"
 #include "code\datums\elements\ore_collecting.dm"
 #include "code\datums\elements\organ_set_bonus.dm"
 #include "code\datums\elements\permanent_fire_overlay.dm"


### PR DESCRIPTION
Original PR: 91986
-----

## About The Pull Request
![image](https://github.com/user-attachments/assets/052ad4ae-45e0-4fd5-b59f-4c659adefee3)

Added recovered crew to the ghost role spawner menu. Clicking spawn will make you orbit the recovered crew body.

https://github.com/user-attachments/assets/326856c4-e306-43fd-b7d6-a8d5554a0e81

Orbiting the body will make it twitch a little to indicate to coroners/MD's/roboticists that you're ready to be revived. 

## Why It's Good For The Game

Getting people to actually play the recovered crew is kinda hard on most rounds :( . First on my list is to make the process more convenient for everyone. 

By adding it to the ghostrole spawner menu, ghosts can quickly see if bodies are available if they wish to play as one. Making them twitch when orbited makes it so the people reviving them don't have to revive them every few minutes in the case someone wishes to join as them (they still might, it does get more attention). 

I think the twitching effect is the best natural indicator that someone wishes to join without being too OOC. I can imagine doctors being a little confused at first, but it should click pretty quickly.

I am not too concerned about it being used as a ghost communication medium. The spectroscopic sniffers are a more convenient tool for this, and I don't think I've seen someone do it with them.
## Changelog
:cl:
add: Recovered Crew have been added to the ghostrole spawner menu
add: Orbiting Recovered Crew corpses will make them twitch to indicate a soul is available
/:cl:
Giving them straight up superpowers or more aggressive antag rolls is still something I'm considering. We'll see if/when I decide to do it