### PR TITLE
[TG Mirror] Constructed SMES auto connects to output cable underneath [MDB IGNORE]

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -70,6 +70,12 @@
 	terminal.master = src
 	update_appearance(UPDATE_OVERLAYS)
 
+/obj/machinery/power/smes/on_construction(mob/user)
+	var/obj/structure/cable/C = locate() in loc
+	if(!QDELETED(C))
+		cable_layer = C.cable_layer
+		connect_to_network()
+
 /obj/machinery/power/smes/disconnect_terminal()
 	if(terminal)
 		terminal.master = null
@@ -145,6 +151,7 @@
 /obj/machinery/power/smes/proc/total_charge()
 	PROTECTED_PROC(TRUE)
 	SHOULD_NOT_OVERRIDE(TRUE)
+	SHOULD_BE_PURE(TRUE)
 
 	for(var/obj/item/stock_parts/power_store/power_cell in component_parts)
 		. += power_cell.charge()
@@ -388,7 +395,7 @@
 // called after all power processes are finished
 // restores charge level to smes if there was excess this ptick
 /obj/machinery/power/smes/proc/restore()
-	if(machine_stat & BROKEN)
+	if(!is_operational)
 		return
 
 	if(!outputting)


### PR DESCRIPTION
Original PR: 92111
-----
## About The Pull Request
Something i didn't notice in #91587.

From the above PR you can now change the cable layer & connect to network with a multitool. But without a multitool the SMES is still by default disconnected from all output after construction.

Now immediately after construction, the SMES will connect to any cable underneath regardless of its layer

## Changelog
:cl:
fix: constructed SMES now auto connects to any output cable underneath it regardless of its layer
/:cl:
