### PR TITLE
[TG Mirror] Adds some extra material properties to meat and hauntium [MDB IGNORE]

### DIFF
--- a/code/datums/elements/blood_reagent.dm
+++ b/code/datums/elements/blood_reagent.dm
@@ -31,8 +31,12 @@
 		target.description = blood_type.desc
 	target.color = blood_type.get_color()
 
+
 	if (!blood_source)
+		target.material = GET_MATERIAL_REF(/datum/material/meat/blood_meat, target)
 		return
+
+	target.material = GET_MATERIAL_REF(/datum/material/meat/mob_meat, blood_source)
 
 	var/list/blood_data = blood_source.get_blood_data()
 	if(blood_data["viruses"])

--- a/code/datums/materials/hauntium.dm
+++ b/code/datums/materials/hauntium.dm
@@ -27,12 +27,30 @@
 
 /datum/material/hauntium/on_main_applied(atom/source, mat_amount, multiplier)
 	. = ..()
-	if(isobj(source))
-		var/obj/obj = source
-		obj.make_haunted(INNATE_TRAIT, "#f8f8ff")
+	if(!isobj(source))
+		return
+	var/obj/obj = source
+	obj.make_haunted(INNATE_TRAIT, "#f8f8ff")
+	if(isbodypart(source))
+		var/obj/item/bodypart/bodypart = source
+		if(!(bodypart::bodytype & BODYTYPE_GHOST))
+			bodypart.bodytype |= BODYTYPE_GHOST
+	if(isorgan(source))
+		var/obj/item/organ/organ = source
+		if(!(organ::organ_flags & ORGAN_GHOST))
+			organ.organ_flags |= ORGAN_GHOST
 
 /datum/material/hauntium/on_main_removed(atom/source, mat_amount, multiplier)
 	. = ..()
-	if(isobj(source))
-		var/obj/obj = source
-		obj.remove_haunted(INNATE_TRAIT)
+	if(!isobj(source))
+		return
+	var/obj/obj = source
+	obj.remove_haunted(INNATE_TRAIT)
+	if(isbodypart(source))
+		var/obj/item/bodypart/bodypart = source
+		if(!(bodypart::bodytype & BODYTYPE_GHOST))
+			bodypart.bodytype &= ~BODYTYPE_GHOST
+	if(isorgan(source))
+		var/obj/item/organ/organ = source
+		if(!(organ::organ_flags & ORGAN_GHOST))
+			organ.organ_flags &= ~ORGAN_GHOST

--- a/code/datums/materials/meat.dm
+++ b/code/datums/materials/meat.dm
@@ -25,11 +25,20 @@
 	fishing_deceleration_mult = 0.9
 	fishing_bounciness_mult = 0.9
 	fishing_gravity_mult = 0.85
+	var/list/blood_dna
 
 /datum/material/meat/on_main_applied(atom/source, mat_amount, multiplier)
 	. = ..()
 	make_edible(source, mat_amount, multiplier)
 	ADD_TRAIT(source, TRAIT_ROD_REMOVE_FISHING_DUD, REF(src)) //The rod itself is the bait... sorta.
+	if(isbodypart(source))
+		var/obj/item/bodypart/bodypart = source
+		if(!(bodypart::bodytype & BODYTYPE_ORGANIC))
+			bodypart.bodytype |= BODYTYPE_ORGANIC
+	if(isorgan(source))
+		var/obj/item/organ/organ = source
+		if(!(organ::organ_flags & ORGAN_ORGANIC))
+			organ.organ_flags |= ORGAN_ORGANIC
 
 /datum/material/meat/on_applied(atom/source, mat_amount, multiplier)
 	. = ..()
@@ -74,6 +83,7 @@
 	source.AddComponent(
 		/datum/component/bloody_spreader,\
 		blood_left = (protein_count + fat_count) * 0.3 * multiplier,\
+		blood_dna = blood_dna,\
 	)
 
 	// Turfs can't handle the meaty goodness of blood walk.
@@ -85,6 +95,7 @@
 		blood_type = /obj/effect/decal/cleanable/blood,\
 		blood_spawn_chance = 35,\
 		max_blood = (protein_count + fat_count) * 0.3 * multiplier,\
+		blood_dna_info = blood_dna,\
 	)
 
 /datum/material/meat/on_removed(atom/source, mat_amount, multiplier)
@@ -97,6 +108,14 @@
 /datum/material/meat/on_main_removed(atom/source, mat_amount, multiplier)
 	. = ..()
 	REMOVE_TRAIT(source, TRAIT_ROD_REMOVE_FISHING_DUD, REF(src))
+	if(isbodypart(source))
+		var/obj/item/bodypart/bodypart = source
+		if(!(bodypart::bodytype & BODYTYPE_ORGANIC))
+			bodypart.bodytype &= ~BODYTYPE_ORGANIC
+	if(isorgan(source))
+		var/obj/item/organ/organ = source
+		if(!(organ::organ_flags & ORGAN_ORGANIC))
+			organ.organ_flags &= ~ORGAN_ORGANIC
 
 /datum/material/meat/mob_meat
 	init_flags = MATERIAL_INIT_BESPOKE
@@ -114,6 +133,11 @@
 	else if(source.name)
 		subjectname = source.name
 
+	var/datum/blood_type/blood_type = source.get_bloodtype()
+	color = blood_type.get_color()
+
+	blood_dna = source.get_blood_dna_list()
+
 	if(ishuman(source))
 		var/mob/living/carbon/human/human_source = source
 		subjectjob = human_source.job
@@ -128,4 +152,28 @@
 		return FALSE
 
 	name = "[source?.name || "mystery"] [initial(name)]"
+
+	if(source.exotic_bloodtype)
+		var/datum/blood_type/blood_type = get_blood_type(source.exotic_bloodtype)
+		color = blood_type.get_color()
+		blood_dna = list("[blood_type.dna_string]" = blood_type)
+
+	return ..()
+
+/datum/material/meat/blood_meat
+	init_flags = MATERIAL_INIT_BESPOKE
+
+/datum/material/meat/blood_meat/Initialize(_id, datum/reagent/source)
+	if(!istype(source))
+		return FALSE
+
+	var/list/blood_data = source.data
+	name = "[blood_data["real_name"] || "mystery"] [initial(name)]"
+	var/datum/blood_type/blood_type = blood_data["blood_type"]
+	if(blood_type)
+		color = blood_type.get_color()
+		blood_dna = list("[blood_type.dna_string]" = blood_type)
+	else
+		color = source.color
+
 	return ..()

--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -170,9 +170,8 @@
 	new_reagent.purity = added_purity
 	new_reagent.creation_purity = added_purity
 	new_reagent.ph = added_ph
-	if (creation_callback)
-		creation_callback.Invoke(new_reagent)
 	new_reagent.on_new(data)
+	creation_callback?.Invoke(new_reagent)
 
 	if(isliving(my_atom))
 		new_reagent.on_mob_add(my_atom, amount) //Must occur before it could posibly run on_mob_delete


### PR DESCRIPTION
Original PR: 92093
-----
## About The Pull Request

This PR adds some wacky interactions for meat and hauntium, should you choose to transmute items into them using metalgen.
- You can imprint a mob's specific meat onto metalgen using their blood (It doesn't even have to be the blood reagent, it can be any reagent that was drawn from a mob's blood).
- Mob meat now applies the source's blood color to items made out of it.
- Organs and bodyparts made primarily out of meat become organic, if they weren't already.
- Organs and bodyparts made primarily out of hauntium become ghostly, if they weren't already. This makes them suitable for ghost species wall-phasing.

## Why It's Good For The Game

Regarding the cosmetic change to mob meat, I thought it only appropriate that mob meat material should take on the color of the mob it was taken from.

For imprinting mob meat onto metalgen using that mob's blood, I thought it would be funny to take people's blood and transmute objects into being made out of those people's own flesh.

For meaty bodyparts and organs being organic, it can be argued that the thing that makes organic bodyparts and organs organic is being made out of meat, so I think the reverse logic should also apply.

For hauntium bodyparts and organs being ghostly, the ghostly nature of ghostly bodyparts and organs should be what allows them to not fall out of a ghost when they become incorporeal. And how could something made primarily out of a substance extracted from ghosts **NOT** be ghostly in nature?

That said, it's only *theoretically* possible to get hauntium bodyparts and organs as a ghost, what with there being no way to do surgery on ghosts. Good luck figuring out and executing the steps to actually do this.

## Changelog

:cl:
add: Items made out of a specific mob's meat take on the color of that mob's blood.
add: Blood (or anything a mob uses as blood) can be used to imprint that mob's meat onto metalgen.
add: Organs and bodyparts made predominantly out of meat become organic, if they weren't already. Likewise, hauntium makes them ghostly.
/:cl:
