### PR TITLE
[TG Mirror] Fixes some storages runtiming when trying to dump their contents into other storages [MDB IGNORE]

### DIFF
--- a/code/datums/storage/storage.dm
+++ b/code/datums/storage/storage.dm
@@ -831,7 +831,7 @@ GLOBAL_LIST_EMPTY(cached_storage_typecaches)
 	if(dest_object.atom_storage)
 		to_chat(user, span_notice("You dump the contents of [parent] into [dest_object]."))
 
-		if(do_rustle)
+		if(do_rustle && rustle_sound)
 			playsound(parent, rustle_sound, 50, TRUE, -5)
 
 		for(var/obj/item/to_dump in real_location)


### PR DESCRIPTION
Original PR: 92247
-----

## About The Pull Request

Storage-to-storage dumping tried to play rustle sounds even if it doesn't have one.

## Changelog
:cl:
fix: Fixed some storages runtiming when trying to dump their contents into other storages
/:cl:
