### PR TITLE
[TG Mirror] Fixes sighell in marionette component code [MDB IGNORE]

### DIFF
--- a/code/datums/components/marionette.dm
+++ b/code/datums/components/marionette.dm
@@ -29,8 +29,10 @@
 /datum/component/marionette/proc/on_pull(atom/movable/source, atom/movable/puller, force)
 	SIGNAL_HANDLER
 
-	if(!puller)
+	if(!puller || grabber == puller)
 		return
+	if(grabber)
+		UnregisterSignal(grabber, list(COMSIG_MOVABLE_KEYBIND_FACE_DIR, COMSIG_MOB_SAY, COMSIG_QDELETING))
 	grabber = puller
 	RegisterSignal(grabber, COMSIG_MOVABLE_KEYBIND_FACE_DIR, PROC_REF(on_puller_turn))
 	RegisterSignal(grabber, COMSIG_MOB_SAY, PROC_REF(on_puller_speech))


### PR DESCRIPTION
Original PR: 92244
-----

## About The Pull Request

Pull attempts can occur even if said mob is already pulling us, and are called before we're released from another mob's grasp, so signals would override/not unreg properly.

## Changelog
:cl:
fix: Fixed mannequines runtiming when you try to pull them two times in a row
/:cl:
