### PR TITLE
[TG Mirror] Allows set_blood_type to take strings [MDB IGNORE]

### DIFF
--- a/code/modules/admin/smites/cluwndice.dm
+++ b/code/modules/admin/smites/cluwndice.dm
@@ -10,5 +10,5 @@
 		return
 
 	var/mob/living/carbon/carbon_target = target
-	carbon_target.set_blood_type(get_blood_type(BLOOD_TYPE_CLOWN))
+	carbon_target.set_blood_type(BLOOD_TYPE_CLOWN)
 	SEND_SOUND(carbon_target, 'sound/items/bikehorn.ogg')

--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -43,7 +43,7 @@
 		spawned.apply_pref_name(/datum/preference/name/clown, player_client)
 		if(check_holidays(APRIL_FOOLS)) // Clown blood is real
 			var/mob/living/carbon/human/human_clown = spawned
-			human_clown.set_blood_type(get_blood_type(BLOOD_TYPE_CLOWN))
+			human_clown.set_blood_type(BLOOD_TYPE_CLOWN)
 
 	return ..()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1323,6 +1323,11 @@
 	if(isnull(dna))
 		return
 
+	if(istext(new_blood_type))
+		new_blood_type = get_blood_type(new_blood_type)
+	if(!istype(new_blood_type))
+		return
+
 	if(get_bloodtype() == new_blood_type) // already has this blood type, we don't need to do anything.
 		return
 

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -388,7 +388,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	if(!human_who_gained_species.get_bloodtype()?.is_species_universal) // Clown blood is forever.
 		//Assigns exotic blood type if the species has one
 		if(exotic_bloodtype && human_who_gained_species.get_bloodtype()?.id != exotic_bloodtype)
-			human_who_gained_species.set_blood_type(get_blood_type(exotic_bloodtype))
+			human_who_gained_species.set_blood_type(exotic_bloodtype)
 		//Otherwise, check if the previous species had an exotic bloodtype and we do not have one and assign a random blood type
 		else if(old_species.exotic_bloodtype && isnull(exotic_bloodtype))
 			human_who_gained_species.set_blood_type(random_human_blood_type())


### PR DESCRIPTION
Original PR: 92242
-----
## About The Pull Request

`set_blood_type` can be passed a string ("O+") and it'll try to associate that with a blood type

## Why It's Good For The Game

I noticed some runtimes because a carbon's blood type was set to a string rather than the blood type datum, which was likely caused by something (probably genetics) passing a blood type id into it instead of the datum

I figured the proc could have support for handling IDs as well as instances, to make it a bit easier to use.

## Changelog

:cl: Melbert
fix: Genetics should be less likely to break your blood type
/:cl:
