### PR TITLE
[TG Mirror] Whitelist Admin Verb [MDB IGNORE]

### DIFF
--- a/code/modules/admin/whitelist.dm
+++ b/code/modules/admin/whitelist.dm
@@ -19,4 +19,23 @@ GLOBAL_LIST(whitelist)
 		return FALSE
 	. = (ckey in GLOB.whitelist)
 
+ADMIN_VERB(whitelist_player, R_BAN, "Whitelist CKey", "Adds a ckey to the Whitelist file.", ADMIN_CATEGORY_MAIN)
+	var/input_ckey = input("CKey to whitelist: (Adds CKey to the whitelist.txt)") as null|text
+	// The ckey proc "santizies" it to be its "true" form
+	var/canon_ckey = ckey(input_ckey)
+	if(!input_ckey || !canon_ckey)
+		return
+	// Dont add them to the whitelist if they are already in it
+	if(canon_ckey in GLOB.whitelist)
+		return
+
+	GLOB.whitelist += canon_ckey
+	rustg_file_append("\n[input_ckey]", WHITELISTFILE)
+
+	message_admins("[input_ckey] has been whitelisted by [key_name(user)]")
+	log_admin("[input_ckey] has been whitelisted by [key_name(user)]")
+
+ADMIN_VERB_CUSTOM_EXIST_CHECK(whitelist_player)
+	return CONFIG_GET(flag/usewhitelist)
+
 #undef WHITELISTFILE


### PR DESCRIPTION
Original PR: 92276
-----
## About The Pull Request
Allows admins to append ckeys to the whitelist file via a verb

- [x] If desired I can lock it behind whitelist being actually enabled but I forget how you show and hide verbs like that.
- [x] Is `R_ADMIN` the correct permission to lock it behind? only other candidate to me is `R_DBRANKS`

"Upstreaming" of https://github.com/ApocryphaXIII/ApocryphaXIII/pull/18 and https://github.com/ApocryphaXIII/ApocryphaXIII/pull/36
Its also been tested on that downstream and is now the primary way we interface with the whitelist txt
## Why It's Good For The Game
I've been told its a pain in the ass to have to update the txt through TGS.
However for TG its frankly useless normally, but could be useful if you need to lock down even harder then panic bunkering for some reason.
More useful for downstreams or tiny servers that might not even have repos.
## Changelog
:cl:
admin: new admin verb for whitelisting players through the txt
/:cl:
