### PR TITLE
[TG Mirror] Refactor custom vending machine brand selection [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machines/machine_circuitboards.dm
@@ -649,78 +649,37 @@
 	build_path = /obj/machinery/vending/custom
 	req_components = list(/obj/item/vending_refill/custom = 1)
 
-	var/static/list/vending_names_paths = list(
-		/obj/machinery/vending/assist = "Part-Mart",
-		/obj/machinery/vending/autodrobe = "AutoDrobe",
-		/obj/machinery/vending/boozeomat = "Booze-O-Mat",
-		/obj/machinery/vending/cart = "PTech",
-		/obj/machinery/vending/cigarette = "ShadyCigs Deluxe",
-		/obj/machinery/vending/clothing = "ClothesMate",
-		/obj/machinery/vending/coffee = "Solar's Best Hot Drinks",
-		/obj/machinery/vending/cola = "Robust Softdrinks",
-		/obj/machinery/vending/custom = "Custom Vendor",
-		/obj/machinery/vending/cytopro = "CytoPro",
-		/obj/machinery/vending/dinnerware = "Plasteel Chef's Dinnerware Vendor",
-		/obj/machinery/vending/drugs = "NanoDrug Plus",
-		/obj/machinery/vending/engineering = "Robco Tool Maker",
-		/obj/machinery/vending/engivend = "Engi-Vend",
-		/obj/machinery/vending/games = "\improper Good Clean Fun",
-		/obj/machinery/vending/hydronutrients = "NutriMax",
-		/obj/machinery/vending/hydroseeds = "MegaSeed Servitor",
-		/obj/machinery/vending/medical = "NanoMed Plus",
-		/obj/machinery/vending/modularpc = "Deluxe Silicate Selections",
-		/obj/machinery/vending/robotics = "Robotech Deluxe",
-		/obj/machinery/vending/security = "SecTech",
-		/obj/machinery/vending/snack = "Getmore Chocolate Corp",
-		/obj/machinery/vending/sovietsoda = "BODA",
-		/obj/machinery/vending/sustenance = "Sustenance Vendor",
-		/obj/machinery/vending/tool = "YouTool",
-		/obj/machinery/vending/wallmed = "NanoMed",
-		/obj/machinery/vending/wardrobe/atmos_wardrobe = "AtmosDrobe",
-		/obj/machinery/vending/wardrobe/bar_wardrobe = "BarDrobe",
-		/obj/machinery/vending/wardrobe/cargo_wardrobe = "CargoDrobe",
-		/obj/machinery/vending/wardrobe/chap_wardrobe = "ChapDrobe",
-		/obj/machinery/vending/wardrobe/chef_wardrobe = "ChefDrobe",
-		/obj/machinery/vending/wardrobe/chem_wardrobe = "ChemDrobe",
-		/obj/machinery/vending/wardrobe/coroner_wardrobe = "MortiDrobe",
-		/obj/machinery/vending/wardrobe/curator_wardrobe = "CuraDrobe",
-		/obj/machinery/vending/wardrobe/det_wardrobe = "DetDrobe",
-		/obj/machinery/vending/wardrobe/engi_wardrobe = "EngiDrobe",
-		/obj/machinery/vending/wardrobe/gene_wardrobe = "GeneDrobe",
-		/obj/machinery/vending/wardrobe/hydro_wardrobe = "HyDrobe",
-		/obj/machinery/vending/wardrobe/jani_wardrobe = "JaniDrobe",
-		/obj/machinery/vending/wardrobe/law_wardrobe = "LawDrobe",
-		/obj/machinery/vending/wardrobe/medi_wardrobe = "MediDrobe",
-		/obj/machinery/vending/wardrobe/robo_wardrobe = "RoboDrobe",
-		/obj/machinery/vending/wardrobe/science_wardrobe = "SciDrobe",
-		/obj/machinery/vending/wardrobe/sec_wardrobe = "SecDrobe",
-		/obj/machinery/vending/wardrobe/viro_wardrobe = "ViroDrobe",
-	)
+	///Assoc list (machine name = machine typepath) of all vendors that can be chosen when the circuit is screwdrivered
+	var/static/list/valid_vendor_names_paths
+
+/obj/item/circuitboard/machine/vendor/Initialize(mapload)
+	. = ..()
+	if(!valid_vendor_names_paths)
+		valid_vendor_names_paths = list()
+		for(var/obj/machinery/vending/vendor_type as anything in subtypesof(/obj/machinery/vending))
+			if(vendor_type::allow_custom)
+				valid_vendor_names_paths[vendor_type::name] = vendor_type
 
 /obj/item/circuitboard/machine/vendor/screwdriver_act(mob/living/user, obj/item/tool)
-	var/static/list/display_vending_names_paths
-	if(!display_vending_names_paths)
-		display_vending_names_paths = list()
-		for(var/path in vending_names_paths)
-			display_vending_names_paths[vending_names_paths[path]] = path
-	var/choice = tgui_input_list(user, "Choose a new brand", "Select an Item", sort_list(display_vending_names_paths))
+	var/choice = tgui_input_list(user, "Choose a new brand", "Select an Item", sort_list(valid_vendor_names_paths))
 	if(isnull(choice))
 		return
-	if(isnull(display_vending_names_paths[choice]))
+	if(isnull(valid_vendor_names_paths[choice]))
 		return
-	set_type(display_vending_names_paths[choice])
+	set_type(valid_vendor_names_paths[choice])
 	return TRUE
 
 /obj/item/circuitboard/machine/vendor/proc/set_type(obj/machinery/vending/typepath)
 	build_path = typepath
-	name = "[vending_names_paths[build_path]] Vendor"
+	name = "[typepath::name] Vendor"
 	req_components = list(initial(typepath.refill_canister) = 1)
 	flatpack_components = list(initial(typepath.refill_canister))
 
 /obj/item/circuitboard/machine/vendor/apply_default_parts(obj/machinery/machine)
-	for(var/typepath in vending_names_paths)
-		if(istype(machine, typepath))
-			set_type(typepath)
+	for(var/key in valid_vendor_names_paths)
+		// == instead of istype so subtypes don't pass check for their supertypes
+		if(machine.type == valid_vendor_names_paths[key])
+			set_type(valid_vendor_names_paths[key])
 			break
 	return ..()
 

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -218,6 +218,9 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	//the path of the fish_source datum to use for the fishing_spot component
 	var/fish_source_path = /datum/fish_source/vending
 
+	///Whether this vendor can be selected when building a custom vending machine
+	var/allow_custom = FALSE
+
 /datum/armor/machinery_vending
 	melee = 20
 	fire = 50
@@ -1717,6 +1720,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	/// Base64 cache of custom icons.
 	var/list/base64_cache = list()
 	panel_type = "panel20"
+	allow_custom = TRUE
 
 /obj/machinery/vending/custom/compartmentLoadAccessCheck(mob/user)
 	. = FALSE
@@ -1879,6 +1883,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 /obj/machinery/vending/custom/unbreakable
 	name = "Indestructible Vendor"
 	resistance_flags = INDESTRUCTIBLE
+	allow_custom = FALSE
 
 /obj/item/vending_refill/custom
 	machine_name = "Custom Vendor"
@@ -1893,6 +1898,7 @@ GLOBAL_LIST_EMPTY(vending_machines_to_restock)
 	max_loaded_items = 40
 	light_mask = "greed-light-mask"
 	custom_materials = list(/datum/material/gold = SHEET_MATERIAL_AMOUNT * 5)
+	allow_custom = FALSE
 
 /obj/machinery/vending/custom/greed/Initialize(mapload)
 	. = ..()

--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -34,6 +34,7 @@
 		/obj/item/universal_scanner = 3,
 		/obj/item/vending_refill/custom = 3,
 	)
+	allow_custom = TRUE
 
 	refill_canister = /obj/item/vending_refill/assist
 	product_ads = "Only the finest!;Have some tools.;The most robust equipment.;The finest gear in space!"

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -234,6 +234,7 @@ GLOBAL_VAR_INIT(all_autodrobe_items, (autodrobe_costumes_items +\
 	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SRV
 	light_mask = "theater-light-mask"
+	allow_custom = TRUE
 
 /obj/machinery/vending/autodrobe/Initialize(mapload)
 	product_categories = list(

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -90,10 +90,12 @@
 	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SRV
 	light_mask = "boozeomat-light-mask"
+	allow_custom = TRUE
 
 /obj/machinery/vending/boozeomat/syndicate
 	age_restrictions = FALSE
 	initial_language_holder = /datum/language_holder/syndicate
+	allow_custom = FALSE
 
 /obj/item/vending_refill/boozeomat
 	machine_name = "Booze-O-Mat"

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -20,6 +20,7 @@
 	extra_price = PAYCHECK_COMMAND * 2.5
 	payment_department = ACCOUNT_SRV
 	light_mask = "cart-light-mask"
+	allow_custom = TRUE
 
 /obj/item/vending_refill/cart
 	machine_name = "PTech"

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -35,6 +35,7 @@
 	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SRV
 	light_mask = "cigs-light-mask"
+	allow_custom = TRUE
 
 /obj/machinery/vending/cigarette/syndicate
 	products = list(
@@ -50,6 +51,7 @@
 		/obj/item/storage/fancy/rollingpapers = 5,
 	)
 	initial_language_holder = /datum/language_holder/syndicate
+	allow_custom = FALSE
 
 /obj/machinery/vending/cigarette/beach //Used in the lavaland_biodome_beach.dmm ruin
 	name = "\improper ShadyCigs Ultra"
@@ -73,6 +75,7 @@
 		/obj/item/lighter = 3,
 	)
 	initial_language_holder = /datum/language_holder/beachbum
+	allow_custom = FALSE
 
 /obj/item/vending_refill/cigarette
 	machine_name = "ShadyCigs Deluxe"

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -232,6 +232,7 @@
 	payment_department = NO_FREEBIES
 	light_mask = "wardrobe-light-mask"
 	light_color = LIGHT_COLOR_ELECTRIC_GREEN
+	allow_custom = TRUE
 
 /obj/item/vending_refill/clothing
 	machine_name = "ClothesMate"

--- a/code/modules/vending/coffee.dm
+++ b/code/modules/vending/coffee.dm
@@ -19,6 +19,7 @@
 	payment_department = ACCOUNT_SRV
 	light_mask = "coffee-light-mask"
 	light_color = COLOR_DARK_MODERATE_ORANGE
+	allow_custom = TRUE
 
 /obj/item/vending_refill/coffee
 	machine_name = "Solar's Best Hot Drinks"

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -35,6 +35,7 @@
 	default_price = PAYCHECK_CREW * 0.7
 	extra_price = PAYCHECK_CREW
 	payment_department = ACCOUNT_SRV
+	allow_custom = TRUE
 
 	var/static/list/spiking_booze = list(
 		// Your "common" spiking booze
@@ -81,10 +82,12 @@
 	icon_state = "Cola_Machine"
 	light_mask = "cola-light-mask"
 	light_color = COLOR_MODERATE_BLUE
+	allow_custom = FALSE
 
 /obj/machinery/vending/cola/black
 	icon_state = "cola_black"
 	light_mask = "cola-light-mask"
+	allow_custom = FALSE
 
 /obj/machinery/vending/cola/red
 	icon_state = "red_cola"
@@ -93,6 +96,7 @@
 	product_slogans = "Cola in space!"
 	light_mask = "red_cola-light-mask"
 	light_color = COLOR_DARK_RED
+	allow_custom = FALSE
 
 /obj/machinery/vending/cola/space_up
 	icon_state = "space_up"
@@ -101,6 +105,7 @@
 	product_slogans = "Space-up! Like a hull breach in your mouth."
 	light_mask = "space_up-light-mask"
 	light_color = COLOR_DARK_MODERATE_LIME_GREEN
+	allow_custom = FALSE
 
 /obj/machinery/vending/cola/starkist
 	icon_state = "starkist"
@@ -110,12 +115,14 @@
 	panel_type = "panel7"
 	light_mask = "starkist-light-mask"
 	light_color = COLOR_LIGHT_ORANGE
+	allow_custom = FALSE
 
 /obj/machinery/vending/cola/sodie
 	icon_state = "soda"
 	panel_type = "panel7"
 	light_mask = "soda-light-mask"
 	light_color = COLOR_WHITE
+	allow_custom = FALSE
 
 /obj/machinery/vending/cola/pwr_game
 	icon_state = "pwr_game"
@@ -124,6 +131,7 @@
 	product_slogans = "The POWER that gamers crave! PWR GAME!"
 	light_mask = "pwr_game-light-mask"
 	light_color = COLOR_STRONG_VIOLET
+	allow_custom = FALSE
 
 /obj/machinery/vending/cola/shamblers
 	name = "\improper Shambler's Vendor"
@@ -145,6 +153,7 @@
 	product_ads = "Refreshing!;Thirsty for DNA? Satiate your craving!;Over 1 trillion souls drank!;Made with real DNA!;The hivemind demands your thirst!;Drink up!;Absorb your thirst."
 	light_mask = "shamblers-light-mask"
 	light_color = COLOR_MOSTLY_PURE_PINK
+	allow_custom = FALSE
 
 /obj/machinery/vending/cola/shamblers/Initialize(mapload)
 	. = ..()

--- a/code/modules/vending/cytopro.dm
+++ b/code/modules/vending/cytopro.dm
@@ -29,6 +29,7 @@
 	default_price = PAYCHECK_CREW * 1
 	extra_price = PAYCHECK_COMMAND * 0.5
 	payment_department = ACCOUNT_SCI
+	allow_custom = TRUE
 
 /obj/item/vending_refill/cytopro
 	machine_name = "CytoPro"

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -69,6 +69,7 @@
 	extra_price = PAYCHECK_CREW * 2.4
 	payment_department = ACCOUNT_SRV
 	light_mask = "dinnerware-light-mask"
+	allow_custom = TRUE
 
 /obj/item/vending_refill/dinnerware
 	machine_name = "Plasteel Chef's Dinnerware Vendor"

--- a/code/modules/vending/engineering.dm
+++ b/code/modules/vending/engineering.dm
@@ -35,6 +35,7 @@
 	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_ENG
 	light_mask = "engi-light-mask"
+	allow_custom = TRUE
 
 /obj/item/vending_refill/engineering
 	machine_name = "Robco Tool Maker"

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -32,6 +32,7 @@
 	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_ENG
 	light_mask = "engivend-light-mask"
+	allow_custom = TRUE
 
 /obj/item/vending_refill/engivend
 	machine_name = "Engi-Vend"

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -115,6 +115,7 @@
 	extra_price = PAYCHECK_COMMAND * 1.25
 	payment_department = ACCOUNT_SRV
 	light_mask = "games-light-mask"
+	allow_custom = TRUE
 
 /obj/item/vending_refill/games
 	machine_name = "\improper Good Clean Fun"

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -39,6 +39,7 @@
 	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_MED
 	light_mask = "med-light-mask"
+	allow_custom = TRUE
 
 /obj/item/vending_refill/medical
 	machine_name = "NanoMed Plus"
@@ -47,6 +48,7 @@
 /obj/machinery/vending/medical/syndicate
 	name = "\improper SyndiMed Plus"
 	initial_language_holder = /datum/language_holder/syndicate
+	allow_custom = FALSE
 
 /obj/machinery/vending/medical/infested_frigate
 	products = list(
@@ -64,6 +66,8 @@
 		/obj/item/cane/white = 2,
 		/obj/item/clothing/glasses/eyepatch/medical = 2,
 	)
+	allow_custom = FALSE
+
 //Created out of a necessity to get these dumb chems out of the medical tools vendor.
 /obj/machinery/vending/drugs
 	name = "\improper NanoDrug Plus"
@@ -102,6 +106,7 @@
 	extra_price = 100
 	payment_department = ACCOUNT_MED
 	refill_canister = /obj/item/vending_refill/drugs
+	allow_custom = TRUE
 
 /obj/item/vending_refill/drugs
 	machine_name = "NanoDrug Plus"

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -26,6 +26,10 @@
 	payment_department = ACCOUNT_MED
 	tiltable = FALSE
 	light_mask = "wallmed-light-mask"
+	allow_custom = TRUE
+
+/obj/machinery/vending/wallmed/directional
+	allow_custom = FALSE
 
 MAPPING_DIRECTIONAL_HELPERS(/obj/machinery/vending/wallmed, 32)
 

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -105,6 +105,7 @@
 	default_price = PAYCHECK_LOWER
 	extra_price = PAYCHECK_CREW
 	payment_department = ACCOUNT_SRV
+	allow_custom = TRUE
 
 /obj/item/vending_refill/hydroseeds
 	machine_name = "MegaSeed Servitor"

--- a/code/modules/vending/modularpc.dm
+++ b/code/modules/vending/modularpc.dm
@@ -19,6 +19,7 @@
 	default_price = PAYCHECK_CREW
 	extra_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SCI
+	allow_custom = TRUE
 
 /obj/item/vending_refill/modularpc
 	machine_name = "Deluxe Silicate Selections"

--- a/code/modules/vending/nutrimax.dm
+++ b/code/modules/vending/nutrimax.dm
@@ -28,6 +28,7 @@
 	default_price = PAYCHECK_CREW * 0.8
 	extra_price = PAYCHECK_COMMAND * 0.8
 	payment_department = ACCOUNT_SRV
+	allow_custom = TRUE
 
 /obj/item/vending_refill/hydronutrients
 	machine_name = "NutriMax"

--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -26,6 +26,7 @@
 	refill_canister = /obj/item/vending_refill/robotics
 	default_price = PAYCHECK_COMMAND
 	payment_department = ACCOUNT_SCI
+	allow_custom = TRUE
 
 /obj/item/vending_refill/robotics
 	machine_name = "Robotech Deluxe"

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -37,6 +37,7 @@
 	default_price = PAYCHECK_CREW
 	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_SEC
+	allow_custom = TRUE
 
 /obj/machinery/vending/security/pre_throw(obj/item/thrown_item)
 	if(isgrenade(thrown_item))

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -45,18 +45,23 @@
 	default_price = PAYCHECK_CREW * 0.6
 	extra_price = PAYCHECK_CREW
 	payment_department = ACCOUNT_SRV
+	allow_custom = TRUE
 
 /obj/item/vending_refill/snack
 	machine_name = "Getmore Chocolate Corp"
 
 /obj/machinery/vending/snack/blue
 	icon_state = "snackblue"
+	allow_custom = FALSE
 
 /obj/machinery/vending/snack/orange
 	icon_state = "snackorange"
+	allow_custom = FALSE
 
 /obj/machinery/vending/snack/green
 	icon_state = "snackgreen"
+	allow_custom = FALSE
 
 /obj/machinery/vending/snack/teal
 	icon_state = "snackteal"
+	allow_custom = FALSE

--- a/code/modules/vending/sovietsoda.dm
+++ b/code/modules/vending/sovietsoda.dm
@@ -18,6 +18,7 @@
 	payment_department = NO_FREEBIES
 	light_color = COLOR_PALE_ORANGE
 	initial_language_holder = /datum/language_holder/spinwarder
+	allow_custom = TRUE
 
 /obj/item/vending_refill/sovietsoda
 	machine_name = "BODA"

--- a/code/modules/vending/sustenance.dm
+++ b/code/modules/vending/sustenance.dm
@@ -25,6 +25,7 @@
 	default_price = PAYCHECK_LOWER
 	extra_price = PAYCHECK_LOWER * 0.6
 	payment_department = NO_FREEBIES
+	allow_custom = TRUE
 
 /obj/item/vending_refill/sustenance
 	machine_name = "Sustenance Vendor"
@@ -39,6 +40,7 @@
 	all_products_free = FALSE
 	displayed_currency_icon = "digging"
 	displayed_currency_name = " LP"
+	allow_custom = FALSE
 
 /obj/machinery/vending/sustenance/interact(mob/user)
 	if(isliving(user))

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -71,6 +71,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	refill_canister = /obj/item/vending_refill/wardrobe/sec_wardrobe
 	payment_department = ACCOUNT_SEC
 	light_color = COLOR_MOSTLY_PURE_RED
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/sec_wardrobe
 	machine_name = "SecDrobe"
@@ -117,6 +118,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/medi_wardrobe
 	payment_department = ACCOUNT_MED
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/medi_wardrobe
 	machine_name = "MediDrobe"
@@ -147,6 +149,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	refill_canister = /obj/item/vending_refill/wardrobe/engi_wardrobe
 	payment_department = ACCOUNT_ENG
 	light_color = COLOR_VIVID_YELLOW
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/engi_wardrobe
 	machine_name = "EngiDrobe"
@@ -172,6 +175,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	refill_canister = /obj/item/vending_refill/wardrobe/atmos_wardrobe
 	payment_department = ACCOUNT_ENG
 	light_color = COLOR_VIVID_YELLOW
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/atmos_wardrobe
 	machine_name = "AtmosDrobe"
@@ -215,6 +219,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/cargo_wardrobe
 	payment_department = ACCOUNT_CAR
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/cargo_wardrobe
 	machine_name = "CargoDrobe"
@@ -249,6 +254,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	refill_canister = /obj/item/vending_refill/wardrobe/robo_wardrobe
 	extra_price = PAYCHECK_COMMAND * 1.2
 	payment_department = ACCOUNT_SCI
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/robo_wardrobe
 	machine_name = "RoboDrobe"
@@ -278,6 +284,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/science_wardrobe
 	payment_department = ACCOUNT_SCI
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/science_wardrobe
 	machine_name = "SciDrobe"
@@ -306,6 +313,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	refill_canister = /obj/item/vending_refill/wardrobe/hydro_wardrobe
 	payment_department = ACCOUNT_SRV
 	light_color = LIGHT_COLOR_ELECTRIC_GREEN
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/hydro_wardrobe
 	machine_name = "HyDrobe"
@@ -339,6 +347,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/curator_wardrobe
 	payment_department = ACCOUNT_SRV
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/curator_wardrobe
 	machine_name = "CuraDrobe"
@@ -388,6 +397,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/coroner_wardrobe
 	payment_department = ACCOUNT_MED
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/coroner_wardrobe
 	machine_name = "MortiDrobe"
@@ -425,6 +435,8 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	refill_canister = /obj/item/vending_refill/wardrobe/bar_wardrobe
 	payment_department = ACCOUNT_MED
 	extra_price = PAYCHECK_COMMAND
+	allow_custom = TRUE
+
 /obj/item/vending_refill/wardrobe/bar_wardrobe
 	machine_name = "BarDrobe"
 
@@ -454,6 +466,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/chef_wardrobe
 	payment_department = ACCOUNT_SRV
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/chef_wardrobe
 	machine_name = "ChefDrobe"
@@ -493,6 +506,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	extra_price = PAYCHECK_COMMAND * 0.8
 	payment_department = ACCOUNT_SRV
 	light_color = COLOR_STRONG_MAGENTA
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/jani_wardrobe
 	machine_name = "JaniDrobe"
@@ -535,6 +549,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/law_wardrobe
 	payment_department = ACCOUNT_SRV
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/law_wardrobe
 	machine_name = "LawDrobe"
@@ -581,6 +596,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/chap_wardrobe
 	payment_department = ACCOUNT_SRV
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/chap_wardrobe
 	machine_name = "DeusVend"
@@ -612,6 +628,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/chem_wardrobe
 	payment_department = ACCOUNT_MED
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/chem_wardrobe
 	machine_name = "ChemDrobe"
@@ -637,6 +654,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/gene_wardrobe
 	payment_department = ACCOUNT_SCI
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/gene_wardrobe
 	machine_name = "GeneDrobe"
@@ -664,6 +682,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	)
 	refill_canister = /obj/item/vending_refill/wardrobe/viro_wardrobe
 	payment_department = ACCOUNT_MED
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/viro_wardrobe
 	machine_name = "ViroDrobe"
@@ -710,6 +729,7 @@ GLOBAL_VAR_INIT(roaches_deployed, FALSE)
 	refill_canister = /obj/item/vending_refill/wardrobe/det_wardrobe
 	extra_price = PAYCHECK_COMMAND * 1.75
 	payment_department = ACCOUNT_SEC
+	allow_custom = TRUE
 
 /obj/item/vending_refill/wardrobe/det_wardrobe
 	machine_name = "DetDrobe"

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -33,6 +33,7 @@
 	default_price = PAYCHECK_CREW
 	extra_price = PAYCHECK_COMMAND * 1.5
 	payment_department = ACCOUNT_ENG
+	allow_custom = TRUE
 
 /obj/item/vending_refill/youtool
 	machine_name = "YouTool"


### PR DESCRIPTION
Original PR: 92205
-----
## About The Pull Request

The list of options you could choose from when screwdrivering a custom vending machine circuit board was hard-coded and also contained copy pastes of every vending machine name (some of which were outdated). It was yucky
- Add a new var on `/obj/machinery/vending` called `allow_custom`, defaults to FALSE and determines whether that type shows up as an option when screwdrivering a custom vending machine board, I've went through and made assignments for it mirror what was in the old static list i.e. this won't introduce any new options
- Change the hard-coded static list to be built on Initialize, populating with every subtype that has `allow_custom` set to TRUE
- Eliminate a second static list that was just the inverse of the first one (first one was typepath = name and this one was just name = typepath)
- Changed an `istype` check to `==` because old behavior meant subtypes of a given vending machine would have their type set to the supertype if that was also a valid custom vending machine option

## Why It's Good For The Game

Cleaner code, no needing to maintain two separate entries for the name of a vending machine, eligibility for a machine to be used in custom vending machines is now a var on the type instead of in a random file pertaining to circuit boards

## Changelog
:cl:
refactor: refactored custom vending machine brand code, a new var on /obj/machinery/vending called allow_custom now determines whether the machine can be chosen when screwdrivering the circuit board
/:cl:
