### PR TITLE
[TG Mirror] Fix a broken calculation in /obj/item/stock_parts/power_store/suicide_act() [MDB IGNORE]

### DIFF
--- a/code/modules/power/power_store.dm
+++ b/code/modules/power/power_store.dm
@@ -267,13 +267,14 @@
 		return SHAME
 	playsound(user, 'sound/effects/sparks/sparks1.ogg', charge / maxcharge)
 	var/damage = charge / (1 KILO JOULES)
+	var/discharged_energy = charge
 	user.electrocute_act(damage, src, 1, SHOCK_IGNORE_IMMUNITY|SHOCK_DELAY_STUN|SHOCK_NOGLOVES)
 	charge = 0
 	update_appearance()
 	if(user.stat != DEAD)
 		to_chat(user, span_suicide("There's not enough charge in [src] to kill you!"))
 		return SHAME
-	addtimer(CALLBACK(src, PROC_REF(gib_user), user, charge), 3 SECONDS)
+	addtimer(CALLBACK(src, PROC_REF(gib_user), user, discharged_energy), 3 SECONDS)
 	return MANUAL_SUICIDE
 
 /obj/item/stock_parts/power_store/proc/gib_user(mob/living/user, discharged_energy)


### PR DESCRIPTION
Original PR: 92336
-----

## About The Pull Request
This fixes the subsequent call to gib the user to actually account for the discharged energy, rather than accidentally always setting itself to 0.

## Why It's Good For The Game
Fixes a broken calculation that was preventing code from performing its intended side effects.

## Changelog
:cl: Bisar
fix: The calculation for discharged energy when committing suicide with a power storage part should now be correctly evaluated.
/:cl:
