### PR TITLE
[TG Mirror] Fixes tier 3 heart doesnt prevent bleeding [MDB IGNORE]

### DIFF
--- a/code/modules/surgery/organs/internal/heart/_heart.dm
+++ b/code/modules/surgery/organs/internal/heart/_heart.dm
@@ -291,6 +291,7 @@
 	maxHealth = 2 * STANDARD_ORGAN_THRESHOLD
 	stabilization_available = TRUE
 	toxification_probability = 0
+	bleed_prevention = TRUE
 	emp_vulnerability = 20
 
 /obj/item/organ/heart/cybernetic/surplus


### PR DESCRIPTION
Original PR: 92352
-----
## About The Pull Request

title

## Why It's Good For The Game

fixes #92351

## Changelog

:cl:
fix: Tier 3 cyber heart now prevents bleeding as intended
/:cl:
