### PR TITLE
[TG Mirror] [NO GBP] Adds unit test checks for materials and processable comp & co. [MDB IGNORE]

### DIFF
--- a/code/datums/components/bakeable.dm
+++ b/code/datums/components/bakeable.dm
@@ -29,6 +29,18 @@
 	if(positive_result)
 		ADD_TRAIT(parent, TRAIT_BAKEABLE, REF(src))
 
+
+	var/obj/item/item_target = parent
+	if(!PERFORM_ALL_TESTS(focus_only/check_materials_when_processed) || !positive_result || !item_target.custom_materials)
+		return
+
+	var/atom/result = new bake_result
+	if(!item_target.compare_materials(result))
+		var/warning = "custom_materials of [result.type] when baked compared to just spawned don't match"
+		var/what_it_should_be = item_target.get_materials_english_list()
+		stack_trace("[warning]. custom_materials should be [what_it_should_be].")
+	qdel(result)
+
 // Inherit the new values passed to the component
 /datum/component/bakeable/InheritComponent(datum/component/bakeable/new_comp, original, bake_result, required_bake_time, positive_result, use_large_steam_sprite)
 	if(!original)

--- a/code/datums/components/grillable.dm
+++ b/code/datums/components/grillable.dm
@@ -34,6 +34,17 @@
 	src.use_large_steam_sprite = use_large_steam_sprite
 	src.added_reagents = added_reagents
 
+	var/obj/item/item_parent = parent
+	if(!PERFORM_ALL_TESTS(focus_only/check_materials_when_processed) || !positive_result || !item_parent.custom_materials || isstack(parent))
+		return
+
+	var/atom/result = new cook_result
+	if(!item_parent.compare_materials(result))
+		var/warning = "custom_materials of [result.type] when grilled compared to just spawned don't match"
+		var/what_it_should_be = item_parent.get_materials_english_list()
+		stack_trace("[warning]. custom_materials should be [what_it_should_be].")
+	qdel(result)
+
 /datum/component/grillable/RegisterWithParent()
 	RegisterSignal(parent, COMSIG_ITEM_GRILL_PLACED, PROC_REF(on_grill_placed))
 	RegisterSignal(parent, COMSIG_ITEM_GRILL_TURNED_ON, PROC_REF(on_grill_turned_on))

--- a/code/datums/elements/dryable.dm
+++ b/code/datums/elements/dryable.dm
@@ -14,6 +14,17 @@
 	RegisterSignal(target, COMSIG_ITEM_DRIED, PROC_REF(finish_drying))
 	ADD_TRAIT(target, TRAIT_DRYABLE, ELEMENT_TRAIT(type))
 
+	var/atom/atom_target = target
+	if(!PERFORM_ALL_TESTS(focus_only/check_materials_when_processed) || !atom_target.custom_materials || !dry_result || isstack(atom_target))
+		return
+
+	var/atom/result = new dry_result
+	if(!atom_target.compare_materials(result))
+		var/warning = "custom_materials of [result.type] when dried compared to just spawned don't match"
+		var/what_it_should_be = atom_target.get_materials_english_list()
+		stack_trace("[warning]. custom_materials should be [what_it_should_be].")
+	qdel(result)
+
 
 /datum/element/dryable/Detach(datum/target)
 	. = ..()

--- a/code/datums/elements/food/microwavable.dm
+++ b/code/datums/elements/food/microwavable.dm
@@ -3,15 +3,15 @@
 	element_flags = ELEMENT_BESPOKE
 	argument_hash_start_idx = 2
 	/// The typepath we default to if we were passed no microwave result
-	var/atom/default_typepath = /obj/item/food/badrecipe
+	var/atom/default_typepath
 	/// Resulting atom typepath on a completed microwave.
 	var/atom/result_typepath
 	/// Reagents that should be added to the result
 	var/list/added_reagents
 
-/datum/element/microwavable/Attach(datum/target, microwave_type, list/reagents)
+/datum/element/microwavable/Attach(obj/item/target, microwave_type, list/reagents, skip_matcheck = FALSE)
 	. = ..()
-	if(!isitem(target))
+	if(!istype(target))
 		return ELEMENT_INCOMPATIBLE
 
 	result_typepath = microwave_type || default_typepath
@@ -22,6 +22,16 @@
 
 	if(!ispath(result_typepath, default_typepath))
 		RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))
+
+	if(!PERFORM_ALL_TESTS(focus_only/check_materials_when_processed) || skip_matcheck || !target.custom_materials || isstack(target))
+		return
+
+	var/atom/result = new result_typepath
+	if(!target.compare_materials(result))
+		var/warning = "custom_materials of [result.type] when microwaved compared to just spawned don't match"
+		var/what_it_should_be = target.get_materials_english_list()
+		stack_trace("[warning]. custom_materials should be [what_it_should_be].")
+	qdel(result)
 
 /datum/element/microwavable/Detach(datum/source)
 	UnregisterSignal(source, list(COMSIG_ITEM_MICROWAVE_ACT, COMSIG_ATOM_EXAMINE))

--- a/code/datums/elements/food/processable.dm
+++ b/code/datums/elements/food/processable.dm
@@ -34,6 +34,22 @@
 	RegisterSignal(target, COMSIG_ATOM_TOOL_ACT(tool_behaviour), PROC_REF(try_process))
 	RegisterSignal(target, COMSIG_ATOM_EXAMINE, PROC_REF(OnExamine))
 
+	if(!PERFORM_ALL_TESTS(focus_only/check_materials_when_processed) || !atom_target.custom_materials)
+		return
+
+	var/atom/movable/prototype = new
+	prototype.set_custom_materials(atom_target.custom_materials, 1 / amount_created)
+	var/atom/movable/result = new result_atom_type
+	if(!prototype.compare_materials(result))
+		var/warning = "custom_materials of [result.type] when processed compared to just spawned don't match"
+		var/what_it_should_be = prototype.get_materials_english_list()
+		//compose a text string containing the syntax and paths to use for editing the custom_materials var
+		if(result.custom_materials)
+			what_it_should_be += " (you can round values a bit)"
+		stack_trace("[warning]. custom_materials should be [what_it_should_be] (you can round values a bit).")
+	qdel(prototype)
+	qdel(result)
+
 /datum/element/processable/Detach(datum/target)
 	. = ..()
 	UnregisterSignal(target, list(COMSIG_ATOM_TOOL_ACT(tool_behaviour), COMSIG_ATOM_EXAMINE, COMSIG_ATOM_REQUESTING_CONTEXT_FROM_ITEM))

--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -652,25 +652,25 @@
 /atom/proc/StartProcessingAtom(mob/living/user, obj/item/process_item, list/chosen_option)
 	var/processing_time = chosen_option[TOOL_PROCESSING_TIME]
 	to_chat(user, span_notice("You start working on [src]."))
-	if(process_item.use_tool(src, user, processing_time, volume=50))
-		var/atom/atom_to_create = chosen_option[TOOL_PROCESSING_RESULT]
-		var/list/atom/created_atoms = list()
-		var/amount_to_create = chosen_option[TOOL_PROCESSING_AMOUNT]
-		for(var/i = 1 to amount_to_create)
-			var/atom/created_atom = new atom_to_create(drop_location())
-			created_atom.OnCreatedFromProcessing(user, process_item, chosen_option, src)
-			if(custom_materials)
-				created_atom.set_custom_materials(custom_materials, 1 / amount_to_create)
-			created_atom.pixel_x = pixel_x
-			created_atom.pixel_y = pixel_y
-			if(i > 1)
-				created_atom.pixel_x += rand(-8,8)
-				created_atom.pixel_y += rand(-8,8)
-			created_atoms.Add(created_atom)
-		to_chat(user, span_notice("You manage to create [amount_to_create] [initial(atom_to_create.gender) == PLURAL ? "[initial(atom_to_create.name)]" : "[initial(atom_to_create.name)][plural_s(initial(atom_to_create.name))]"] from [src]."))
-		SEND_SIGNAL(src, COMSIG_ATOM_PROCESSED, user, process_item, created_atoms)
-		UsedforProcessing(user, process_item, chosen_option, created_atoms)
+	if(!process_item.use_tool(src, user, processing_time, volume=50))
 		return
+	var/atom/atom_to_create = chosen_option[TOOL_PROCESSING_RESULT]
+	var/list/atom/created_atoms = list()
+	var/amount_to_create = chosen_option[TOOL_PROCESSING_AMOUNT]
+	for(var/i = 1 to amount_to_create)
+		var/atom/created_atom = new atom_to_create(drop_location())
+		created_atom.OnCreatedFromProcessing(user, process_item, chosen_option, src)
+		if(custom_materials)
+			created_atom.set_custom_materials(custom_materials, 1 / amount_to_create)
+		created_atom.pixel_x = pixel_x
+		created_atom.pixel_y = pixel_y
+		if(i > 1)
+			created_atom.pixel_x += rand(-8,8)
+			created_atom.pixel_y += rand(-8,8)
+		created_atoms.Add(created_atom)
+	to_chat(user, span_notice("You manage to create [amount_to_create] [initial(atom_to_create.gender) == PLURAL ? "[initial(atom_to_create.name)]" : "[initial(atom_to_create.name)][plural_s(initial(atom_to_create.name))]"] from [src]."))
+	SEND_SIGNAL(src, COMSIG_ATOM_PROCESSED, user, process_item, created_atoms)
+	UsedforProcessing(user, process_item, chosen_option, created_atoms)
 
 /atom/proc/UsedforProcessing(mob/living/user, obj/item/used_item, list/chosen_option, list/created_atoms)
 	qdel(src)

--- a/code/game/objects/items/food/_food.dm
+++ b/code/game/objects/items/food/_food.dm
@@ -152,7 +152,7 @@
 /// This proc handles the microwave component. Overwrite if you want special microwave results.
 /// By default, all food is microwavable. However, they will be microwaved into a bad recipe (burnt mess).
 /obj/item/food/proc/make_microwaveable()
-	AddElement(/datum/element/microwavable)
+	AddElement(/datum/element/microwavable, /obj/item/food/badrecipe, skip_matcheck = TRUE)
 
 ///This proc handles trash components, overwrite this if you want the object to spawn trash
 /obj/item/food/proc/make_leave_trash()

--- a/code/game/objects/items/food/bread.dm
+++ b/code/game/objects/items/food/bread.dm
@@ -118,6 +118,7 @@
 		/datum/reagent/consumable/nutriment/vitamin = 2,
 		/datum/reagent/consumable/nutriment/protein = 2.4,
 	)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 	tastes = list("bread" = 1, "meat" = 1)
 	foodtypes = GRAIN | MEAT | DAIRY
 	crafting_complexity = FOOD_COMPLEXITY_3
@@ -146,6 +147,7 @@
 		/datum/reagent/consumable/nutriment/vitamin = 2,
 		/datum/reagent/consumable/nutriment/protein = 2.4,
 	)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 2.5)
 	tastes = list("bread" = 10, "meat" = 10)
 	foodtypes = GRAIN | MEAT
 	crafting_complexity = FOOD_COMPLEXITY_3
@@ -174,6 +176,7 @@
 		/datum/reagent/consumable/nutriment/vitamin = 2,
 		/datum/reagent/consumable/nutriment/protein = 3,
 	)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 	tastes = list("bread" = 10, "acid" = 10)
 	foodtypes = GRAIN | MEAT | DAIRY
 	crafting_complexity = FOOD_COMPLEXITY_3
@@ -204,6 +207,7 @@
 		/datum/reagent/consumable/nutriment/protein = 4,
 		/datum/reagent/consumable/nutriment/vitamin = 1,
 	)
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 	tastes = list("bread" = 10, "cobwebs" = 5)
 	foodtypes = GRAIN|MEAT|DAIRY|TOXIC
 	crafting_complexity = FOOD_COMPLEXITY_3

--- a/code/game/objects/items/food/cake.dm
+++ b/code/game/objects/items/food/cake.dm
@@ -500,6 +500,7 @@
 	tastes = list("acid" = 3, "metal" = 4, "glass" = 5)
 	foodtypes = GRAIN|DAIRY|SUGAR|GROSS
 	crafting_complexity = FOOD_COMPLEXITY_3
+	custom_materials = list(/datum/material/glass = SHEET_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/cake/vanilla_cake
 	name = "vanilla cake"

--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -16,20 +16,20 @@
 
 	/// What type of donk pocket we're warmed into via baking or microwaving.
 	var/warm_type = /obj/item/food/donkpocket/warm
+	/// Whether baking/microwaving it yields a positive result
+	var/positive_result = TRUE
 	/// The lower end for how long it takes to bake
 	var/baking_time_short = 25 SECONDS
 	/// The upper end for how long it takes to bake
 	var/baking_time_long = 30 SECONDS
-	/// The reagents added when microwaved. Needed since microwaving ignores food_reagents
-	var/static/list/added_reagents = list(/datum/reagent/medicine/omnizine = 6)
-	/// The reagents that most child types add when microwaved. Needed because you can't override static lists.
-	var/static/list/child_added_reagents = list(/datum/reagent/medicine/omnizine = 2)
+	/// The amount of omnizine added when it's cooked.
+	var/omnizine_to_add = 6
 
 /obj/item/food/donkpocket/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, added_reagents)
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), positive_result, TRUE, list(/datum/reagent/medicine/omnizine = omnizine_to_add))
 
 /obj/item/food/donkpocket/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, added_reagents)
+	AddElement(/datum/element/microwavable, warm_type, string_assoc_list(list(/datum/reagent/medicine/omnizine = omnizine_to_add)), !positive_result)
 
 /obj/item/food/donkpocket/warm
 	name = "warm Donk-pocket"
@@ -44,8 +44,10 @@
 
 	// Warmed donk pockets will burn if you leave them in the oven or microwave.
 	warm_type = /obj/item/food/badrecipe
+	positive_result = FALSE
 	baking_time_short = 10 SECONDS
 	baking_time_long = 15 SECONDS
+	omnizine_to_add = 0
 
 /obj/item/food/donkpocket/homemade
 	foodtypes = MEAT|GRAIN
@@ -71,12 +73,7 @@
 	foodtypes = GRAIN|VEGETABLES
 	crafting_complexity = FOOD_COMPLEXITY_2
 	warm_type = /obj/item/food/donkpocket/warm/dank
-
-/obj/item/food/donkpocket/dank/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
-
-/obj/item/food/donkpocket/dank/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
+	omnizine_to_add = 2
 
 /obj/item/food/donkpocket/warm/dank
 	name = "warm Dank-pocket"
@@ -104,12 +101,7 @@
 	tastes = list("umami" = 2, "dough" = 2, "spice" = 1)
 	foodtypes = VEGETABLES|GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/spicy
-
-/obj/item/food/donkpocket/spicy/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
-
-/obj/item/food/donkpocket/spicy/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
+	omnizine_to_add = 2
 
 /obj/item/food/donkpocket/warm/spicy
 	name = "warm Spicy-pocket"
@@ -147,12 +139,7 @@
 	tastes = list("umami" = 2, "dough" = 2, "soy sauce" = 2)
 	foodtypes = GRAIN
 	warm_type = /obj/item/food/donkpocket/warm/teriyaki
-
-/obj/item/food/donkpocket/teriyaki/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
-
-/obj/item/food/donkpocket/teriyaki/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
+	omnizine_to_add = 2
 
 /obj/item/food/donkpocket/warm/teriyaki
 	name = "warm Teriyaki-pocket"
@@ -190,12 +177,7 @@
 	tastes = list("tomato" = 2, "dough" = 2, "cheese"= 2)
 	foodtypes = VEGETABLES|GRAIN|DAIRY
 	warm_type = /obj/item/food/donkpocket/warm/pizza
-
-/obj/item/food/donkpocket/pizza/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
-
-/obj/item/food/donkpocket/pizza/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
+	omnizine_to_add = 2
 
 /obj/item/food/donkpocket/warm/pizza
 	name = "warm Pizza-pocket"
@@ -229,10 +211,10 @@
 	custom_materials = null
 
 /obj/item/food/donkpocket/honk/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, honk_added_reagents)
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), positive_result, TRUE, honk_added_reagents)
 
 /obj/item/food/donkpocket/honk/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, honk_added_reagents)
+	AddElement(/datum/element/microwavable, warm_type, honk_added_reagents, positive_result)
 
 /obj/item/food/donkpocket/warm/honk
 	name = "warm Honk-pocket"
@@ -261,12 +243,7 @@
 	foodtypes = GRAIN|FRUIT|SUGAR
 	warm_type = /obj/item/food/donkpocket/warm/berry
 	custom_materials = null
-
-/obj/item/food/donkpocket/berry/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, child_added_reagents)
-
-/obj/item/food/donkpocket/berry/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, child_added_reagents)
+	omnizine_to_add = 2
 
 /obj/item/food/donkpocket/warm/berry
 	name = "warm Berry-pocket"
@@ -301,10 +278,10 @@
 	)
 
 /obj/item/food/donkpocket/gondola/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, gondola_added_reagents)
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), positive_result, TRUE, gondola_added_reagents)
 
 /obj/item/food/donkpocket/gondola/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, gondola_added_reagents)
+	AddElement(/datum/element/microwavable, warm_type, gondola_added_reagents, positive_result)
 
 /obj/item/food/donkpocket/warm/gondola
 	name = "warm Gondola-pocket"
@@ -341,10 +318,10 @@
 	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 2)
 
 /obj/item/food/donkpocket/deluxe/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, deluxe_added_reagents)
+	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), positive_result, TRUE, deluxe_added_reagents)
 
 /obj/item/food/donkpocket/deluxe/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, deluxe_added_reagents)
+	AddElement(/datum/element/microwavable, warm_type, deluxe_added_reagents, positive_result)
 
 /obj/item/food/donkpocket/warm/deluxe
 	name = "warm Donk-pocket Deluxe"
@@ -375,12 +352,6 @@
 	warm_type = /obj/item/food/donkpocket/warm/deluxe/nocarb
 	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 4)
 
-/obj/item/food/donkpocket/deluxe/meat/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, deluxe_added_reagents)
-
-/obj/item/food/donkpocket/deluxe/meat/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, deluxe_added_reagents)
-
 /obj/item/food/donkpocket/warm/deluxe/nocarb
 	name = "warm Meat-pocket"
 	desc = "The warm food of choice for the carnivorous traitor."
@@ -408,12 +379,6 @@
 	crafting_complexity = FOOD_COMPLEXITY_4
 	warm_type = /obj/item/food/donkpocket/warm/deluxe/vegan
 	custom_materials = null
-
-/obj/item/food/donkpocket/deluxe/vegan/make_bakeable()
-	AddComponent(/datum/component/bakeable, warm_type, rand(baking_time_short, baking_time_long), TRUE, TRUE, deluxe_added_reagents)
-
-/obj/item/food/donkpocket/deluxe/vegan/make_microwaveable()
-	AddElement(/datum/element/microwavable, warm_type, deluxe_added_reagents)
 
 /obj/item/food/donkpocket/warm/deluxe/vegan
 	name = "warm Donk-roll"

--- a/code/game/objects/items/food/lizard.dm
+++ b/code/game/objects/items/food/lizard.dm
@@ -88,6 +88,7 @@
 	foodtypes = MEAT | GORE
 	w_class = WEIGHT_CLASS_TINY
 	crafting_complexity = FOOD_COMPLEXITY_2
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/shredded_lungs
 	name = "crispy shredded lung stirfry"
@@ -266,6 +267,7 @@
 	foodtypes = MEAT | VEGETABLES | NUTS | GORE
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/kebab/picoss_skewers
 	name = "picoss skewer"
@@ -711,7 +713,7 @@
 	food_flags = FOOD_FINGER_FOOD
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_4
-	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT)
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 2.25)
 
 /obj/item/food/honey_roll
 	name = "honey sweetroll"

--- a/code/game/objects/items/food/martian.dm
+++ b/code/game/objects/items/food/martian.dm
@@ -1328,6 +1328,7 @@
 	foodtypes = MEAT
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT)
 
 // Ethereal-suitable cross-culture food
 /*	Ethereals are, as part of the uplifting process, considered as citizens of the Terran Federation.

--- a/code/game/objects/items/food/meatdish.dm
+++ b/code/game/objects/items/food/meatdish.dm
@@ -651,6 +651,7 @@
 	food_flags = FOOD_FINGER_FOOD
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_2
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 6)
 
 /obj/item/food/rawkhinkali
 	name = "raw khinkali"
@@ -688,6 +689,7 @@
 	foodtypes = MEAT|GRAIN|VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_3
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT)
 
 /obj/item/food/meatbun
 	name = "meat bun"
@@ -1036,6 +1038,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	venue_value = FOOD_PRICE_NORMAL
 	crafting_complexity = FOOD_COMPLEXITY_5
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * (4/3))
 
 /obj/item/food/korta_wellington
 	name = "Kotra wellington"
@@ -1070,6 +1073,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	venue_value = FOOD_PRICE_NORMAL
 	crafting_complexity = FOOD_COMPLEXITY_5
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * (4/3))
 
 /obj/item/food/roast_dinner
 	name = "roast dinner"
@@ -1104,6 +1108,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	venue_value = FOOD_PRICE_NORMAL
 	crafting_complexity = FOOD_COMPLEXITY_5
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 2)
 
 /obj/item/food/roast_dinner_lizzy
 	name = "grain-free roast dinner"
@@ -1138,6 +1143,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	venue_value = FOOD_PRICE_NORMAL
 	crafting_complexity = FOOD_COMPLEXITY_5
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT * 2)
 
 /obj/item/food/roast_dinner_tofu
 	name = "tofu roast dinner"
@@ -1240,6 +1246,7 @@
 	foodtypes = MEAT | VEGETABLES
 	w_class = WEIGHT_CLASS_SMALL
 	crafting_complexity = FOOD_COMPLEXITY_4
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 2)
 
 /obj/item/food/sweet_and_sour_meatballs
 	name = "sweet and sour meatballs"

--- a/code/game/objects/items/food/misc.dm
+++ b/code/game/objects/items/food/misc.dm
@@ -705,6 +705,7 @@
 	tastes = list("cooked eggplant" = 5, "potato" = 1, "baked veggies" = 2, "meat" = 4, "bechamel sauce" = 3)
 	foodtypes = MEAT|VEGETABLES|GRAIN|DAIRY
 	crafting_complexity = FOOD_COMPLEXITY_4
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT / 4)
 
 /obj/item/food/candied_pineapple
 	name = "candied pineapple"

--- a/code/game/objects/items/food/pie.dm
+++ b/code/game/objects/items/food/pie.dm
@@ -137,6 +137,7 @@
 	tastes = list("pie" = 1, "meat" = 1)
 	foodtypes = GRAIN|DAIRY|MEAT
 	crafting_complexity = FOOD_COMPLEXITY_3
+	custom_materials = list(/datum/material/meat = MEATSLAB_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/pie/tofupie
 	name = "tofu-pie"
@@ -221,6 +222,7 @@
 	tastes = list("pie" = 1, "acid" = 1, "meat" = 1)
 	foodtypes = GRAIN|DAIRY|MEAT
 	crafting_complexity = FOOD_COMPLEXITY_3
+	custom_materials = list(/datum/material/meat = MEATDISH_MATERIAL_AMOUNT / 5)
 
 /obj/item/food/pie/applepie
 	name = "apple pie"
@@ -481,6 +483,7 @@
 	tastes = list("juicy meat" = 1, "mashed potatoes" = 1, "baked veggies" = 1)
 	foodtypes = MEAT | DAIRY | VEGETABLES
 	crafting_complexity = FOOD_COMPLEXITY_5
+	custom_materials = list(/datum/material/meat = SHEET_MATERIAL_AMOUNT)
 
 /obj/item/food/pie/asdfpie
 	name = "pie-flavored pie"

--- a/code/game/objects/items/food/spaghetti.dm
+++ b/code/game/objects/items/food/spaghetti.dm
@@ -25,7 +25,7 @@
 	tastes = list("pasta" = 1)
 	crafting_complexity = FOOD_COMPLEXITY_1
 
-/obj/item/food/spaghetti/make_bakeable()
+/obj/item/food/spaghetti/raw/make_bakeable()
 	AddComponent(/datum/component/bakeable, /obj/item/food/spaghetti/boiledspaghetti, rand(15 SECONDS, 20 SECONDS), TRUE, TRUE)
 
 /obj/item/food/spaghetti/raw/make_microwaveable()

--- a/code/modules/unit_tests/focus_only_tests.dm
+++ b/code/modules/unit_tests/focus_only_tests.dm
@@ -59,3 +59,6 @@
 
 /// Checks that foodtypes are the same for food whether it's spawned or crafted (with the exact required types)
 /datum/unit_test/focus_only/check_foodtypes
+
+///Checks that items have roughly the same materials whenever spawned via processing/microwaving/baking etc. or any other mean.
+/datum/unit_test/focus_only/check_materials_when_processed


### PR DESCRIPTION
Original PR: 92194
-----
## About The Pull Request
Necessary followup to #89465. The current unit tests don't care for processable and several cooking-related comps and elements, leading to quite a few oversights like "meat spider meat bread slice". Adding more (focus only) unit tests to increase coverage is needed to take care of these post-refactor bugs.

## Why It's Good For The Game
Fixing small issues I've previously introduced. This also uncovered a few other nits with the code.

## Changelog

:cl:
fix: Fixes a few dishes getting a bit too, uh, meaty when cut.
fix: Fixes being able to turn different types of cooked spaghetti into generic cooked spaghetti with an oven.
/:cl:
