### PR TITLE
[TG Mirror] Render plate code cleanup, moves game effects up to the lit game plate [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -13,8 +13,8 @@
 #define PLANE_SPACE -21
 #define PLANE_SPACE_PARALLAX -20
 
-#define GRAVITY_PULSE_PLANE -12
-#define GRAVITY_PULSE_RENDER_TARGET "*GRAVPULSE_RENDER_TARGET"
+#define DISPLACEMENT_PLANE -12
+#define DISPLACEMENT_RENDER_TARGET "*DISPLACEMENT_RENDER_TARGET"
 
 #define RENDER_PLANE_TRANSPARENT -11 //Transparent plane that shows openspace underneath the floor
 
@@ -38,6 +38,8 @@
 #define GHOST_PLANE 4
 #define POINT_PLANE 5
 
+#define RENDER_PLANE_UNLIT_GAME 9
+
 //---------- LIGHTING -------------
 /// Normal 1 per turf dynamic lighting underlays
 #define LIGHTING_PLANE 10
@@ -47,29 +49,21 @@
 #define O_LIGHTING_VISUAL_RENDER_TARGET "*O_LIGHT_VISUAL_PLANE"
 
 // Render plate used by overlay lighting to mask turf lights
-#define TURF_LIGHTING_PLATE 12
+#define RENDER_PLANE_TURF_LIGHTING 12
 
 #define EMISSIVE_PLANE 13
 /// This plane masks out lighting to create an "emissive" effect, ie for glowing lights in otherwise dark areas.
-#define EMISSIVE_RENDER_PLATE 14
-#define EMISSIVE_RENDER_TARGET "*EMISSIVE_PLANE"
+#define RENDER_PLANE_EMISSIVE 14
+#define EMISSIVE_RENDER_TARGET "*RENDER_PLANE_EMISSIVE"
 // Ensures all the render targets that point at the emissive plate layer correctly
 #define EMISSIVE_Z_BELOW_LAYER 1
 #define EMISSIVE_FLOOR_LAYER 2
 #define EMISSIVE_SPACE_LAYER 3
 #define EMISSIVE_WALL_LAYER 4
 
-#define EMISSIVE_BLOOM_MASK_PLATE 15
-#define EMISSIVE_BLOOM_MASK_TARGET "*EMISSIVE_BLOOM_MASK_PLATE"
-#define EMISSIVE_BLOOM_PLATE 16
-
-//-------------------- Game plane assembly ---------------------
-
-#define RENDER_PLANE_GAME 17
-/// If fov is enabled we'll draw game to this and do shit to it
-#define RENDER_PLANE_GAME_MASKED 18
-/// The bit of the game plane that is let alone is sent here
-#define RENDER_PLANE_GAME_UNMASKED 19
+#define RENDER_PLANE_EMISSIVE_BLOOM_MASK 15
+#define EMISSIVE_BLOOM_MASK_TARGET "*RENDER_PLANE_EMISSIVE_BLOOM_MASK"
+#define RENDER_PLANE_EMISSIVE_BLOOM 16
 
 //-------------------- Lighting ---------------------
 
@@ -77,8 +71,8 @@
 
 /// Masks the lighting plane with turfs, so we never light up the void
 /// Failing that, masks emissives and the overlay lighting plane
-#define LIGHT_MASK_PLANE 21
-#define LIGHT_MASK_RENDER_TARGET "*LIGHT_MASK_PLANE"
+#define RENDER_PLANE_LIGHT_MASK 21
+#define LIGHT_MASK_RENDER_TARGET "*RENDER_PLANE_LIGHT_MASK"
 
 ///Things that should render ignoring lighting
 #define ABOVE_LIGHTING_PLANE 22
@@ -116,7 +110,12 @@
 // The largest plane here must still be less than RENDER_PLANE_GAME
 
 //-------------------- Rendering ---------------------
-#define LIT_GAME_RENDER_PLATE 40
+#define RENDER_PLANE_GAME 40
+/// If fov is enabled we'll draw game to this and do shit to it
+#define RENDER_PLANE_GAME_MASKED 41
+/// The bit of the game plane that is let alone is sent here
+#define RENDER_PLANE_GAME_UNMASKED 42
+
 #define RENDER_PLANE_NON_GAME 45
 
 // Only VERY special planes should be here, as they are above not just the game, but the UI planes as well.

--- a/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_masters/_plane_master.dm
@@ -31,7 +31,7 @@ INITIALIZE_IMMEDIATE(/atom/movable/screen/plane_master)
 
 	//--rendering relay vars--
 	/// list of planes we will relay this plane's render to
-	var/list/render_relay_planes = list(RENDER_PLANE_GAME)
+	var/list/render_relay_planes = list(RENDER_PLANE_UNLIT_GAME)
 	/// blend mode to apply to the render relay in case you dont want to use the plane_masters blend_mode
 	var/blend_mode_override
 	/// list of current relays this plane is utilizing to render

--- a/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
+++ b/code/_onclick/hud/rendering/plane_masters/plane_master_subtypes.dm
@@ -60,12 +60,12 @@
 		<br>If you want something to look as if it has parallax on it, draw it to this plane."
 	plane = PLANE_SPACE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
-	render_relay_planes = list(RENDER_PLANE_GAME, LIGHT_MASK_PLANE)
+	render_relay_planes = list(RENDER_PLANE_UNLIT_GAME, RENDER_PLANE_LIGHT_MASK)
 	critical = PLANE_CRITICAL_FUCKO_PARALLAX // goes funny when touched. no idea why I don't trust byond
 
 /atom/movable/screen/plane_master/parallax_white/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
-	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_layer = EMISSIVE_SPACE_LAYER)
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE, offset), relay_layer = EMISSIVE_SPACE_LAYER)
 
 ///Contains space parallax
 /atom/movable/screen/plane_master/parallax
@@ -106,7 +106,7 @@
 // Hacky shit to ensure parallax works in perf mode
 /atom/movable/screen/plane_master/parallax/outside_bounds(mob/relevant)
 	if(offset == 0)
-		remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME, 0))
+		remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_UNLIT_GAME, 0))
 		is_outside_bounds = TRUE // I'm sorry :(
 		return
 	// If we can't render, and we aren't the bottom layer, don't render us
@@ -121,7 +121,7 @@
 
 /atom/movable/screen/plane_master/parallax/inside_bounds(mob/relevant)
 	if(offset == 0)
-		add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME, 0))
+		add_relay_to(GET_NEW_PLANE(RENDER_PLANE_UNLIT_GAME, 0))
 		is_outside_bounds = FALSE
 		return
 	// Always readd, just in case we lost it
@@ -161,33 +161,33 @@
 /atom/movable/screen/plane_master/parallax/proc/narsie_unsummoned()
 	animate(src, color = null, time = 8 SECONDS)
 
-/atom/movable/screen/plane_master/gravpulse
-	name = "Gravpulse"
-	documentation = "Ok so this one's fun. Basically, we want to be able to distort the game plane when a grav annom is around.\
+/atom/movable/screen/plane_master/displacement
+	name = "Displacement"
+	documentation = "Ok so this one's fun. Basically, we want to be able to distort the game plane when a grav annom or similar is around.\
 		<br>So we draw the pattern we want to use to this plane, and it's then used as a render target by a distortion filter on the game plane.\
 		<br>Note the blend mode and lack of relay targets. This plane exists only to distort, it's never rendered anywhere."
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	plane = GRAVITY_PULSE_PLANE
+	plane = DISPLACEMENT_PLANE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	blend_mode = BLEND_ADD
-	render_target = GRAVITY_PULSE_RENDER_TARGET
+	render_target = DISPLACEMENT_RENDER_TARGET
 	render_relay_planes = list()
 	// We start out hidden as we do not need to render when there's no distortion on our level
 	start_hidden = TRUE
 
-/atom/movable/screen/plane_master/gravpulse/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/displacement/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	RegisterSignal(GLOB, SIGNAL_ADDTRAIT(TRAIT_DISTORTION_IN_USE(offset)), PROC_REF(distortion_enabled))
 	RegisterSignal(GLOB, SIGNAL_REMOVETRAIT(TRAIT_DISTORTION_IN_USE(offset)), PROC_REF(distortion_disabled))
 	if(HAS_TRAIT(GLOB, TRAIT_DISTORTION_IN_USE(offset)))
 		distortion_enabled()
 
-/atom/movable/screen/plane_master/gravpulse/proc/distortion_enabled(datum/source)
+/atom/movable/screen/plane_master/displacement/proc/distortion_enabled(datum/source)
 	SIGNAL_HANDLER
 	var/mob/our_mob = home?.our_hud?.mymob
 	unhide_plane(our_mob)
 
-/atom/movable/screen/plane_master/gravpulse/proc/distortion_disabled(datum/source)
+/atom/movable/screen/plane_master/displacement/proc/distortion_disabled(datum/source)
 	SIGNAL_HANDLER
 	hide_plane()
 
@@ -196,30 +196,30 @@
 	name = "Floor"
 	documentation = "The well, floor. This is mostly used as a sorting mechanism, but it also lets us create a \"border\" around the game world plane, so its drop shadow will actually work."
 	plane = FLOOR_PLANE
-	render_relay_planes = list(RENDER_PLANE_GAME, LIGHT_MASK_PLANE)
+	render_relay_planes = list(RENDER_PLANE_UNLIT_GAME, RENDER_PLANE_LIGHT_MASK)
 
 /atom/movable/screen/plane_master/transparent_floor
 	name = "Transparent Floor"
 	documentation = "Really just openspace, stuff that is a turf but has no color or alpha whatsoever.\
 		<br>We use this to draw to just the light mask plane, cause if it's not there we get holes of blackness over openspace"
 	plane = TRANSPARENT_FLOOR_PLANE
-	render_relay_planes = list(LIGHT_MASK_PLANE)
+	render_relay_planes = list(RENDER_PLANE_LIGHT_MASK)
 	// Needs to be critical or it uh, it'll look white
 	critical = PLANE_CRITICAL_DISPLAY|PLANE_CRITICAL_NO_RELAY
 
 /atom/movable/screen/plane_master/floor/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
-	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_layer = EMISSIVE_FLOOR_LAYER, relay_color = GLOB.em_block_color)
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE, offset), relay_layer = EMISSIVE_FLOOR_LAYER, relay_color = GLOB.em_block_color)
 
 /atom/movable/screen/plane_master/wall
 	name = "Wall"
 	documentation = "Holds all walls. We render this onto the game world. Separate so we can use this + space and floor planes as a guide for where byond blackness is NOT."
 	plane = WALL_PLANE
-	render_relay_planes = list(RENDER_PLANE_GAME_WORLD, LIGHT_MASK_PLANE)
+	render_relay_planes = list(RENDER_PLANE_GAME_WORLD, RENDER_PLANE_LIGHT_MASK)
 
 /atom/movable/screen/plane_master/wall/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
-	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_layer = EMISSIVE_WALL_LAYER, relay_color = GLOB.em_block_color)
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE, offset), relay_layer = EMISSIVE_WALL_LAYER, relay_color = GLOB.em_block_color)
 
 /atom/movable/screen/plane_master/game
 	name = "Game"
@@ -292,7 +292,7 @@
 	documentation = "Contains all lighting drawn to turfs. Not so complex, draws directly onto the lighting plate."
 	plane = LIGHTING_PLANE
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
-	render_relay_planes = list(TURF_LIGHTING_PLATE)
+	render_relay_planes = list(RENDER_PLANE_TURF_LIGHTING)
 	blend_mode_override = BLEND_ADD
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	critical = PLANE_CRITICAL_DISPLAY
@@ -315,7 +315,7 @@
 /atom/movable/screen/plane_master/o_light_visual/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	// I'd love for this to be HSL but filters don't work with blend modes
-	add_relay_to(GET_NEW_PLANE(TURF_LIGHTING_PLATE, offset), BLEND_MULTIPLY, relay_color = list(
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_TURF_LIGHTING, offset), BLEND_MULTIPLY, relay_color = list(
 		-1, -1, -1, 0,
 		-1, -1, -1, 0,
 		-1, -1, -1, 0,
@@ -328,7 +328,7 @@
 	plane = ABOVE_LIGHTING_PLANE
 	documentation = "Anything on the game plane that needs a space to draw on that will be above the lighting plane.\
 		<br>Mostly little alerts and effects, also sometimes contains things that are meant to look as if they glow."
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
+	render_relay_planes = list(RENDER_PLANE_GAME)
 
 /atom/movable/screen/plane_master/weather_glow
 	name = "Weather Glow"
@@ -336,7 +336,7 @@
 	plane = WEATHER_GLOW_PLANE
 	start_hidden = TRUE
 	critical = PLANE_CRITICAL_DISPLAY
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
+	render_relay_planes = list(RENDER_PLANE_GAME)
 
 /atom/movable/screen/plane_master/weather_glow/set_home(datum/plane_master_group/home)
 	. = ..()
@@ -361,11 +361,11 @@
 /atom/movable/screen/plane_master/emissive/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
 	. = ..()
 	/// Okay, so what we're doing here is making all emissives convert to white for actual emissive masking (i.e. adding light so objects glow)
-	add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset), relay_color = list(1,1,1,0, 1,1,1,0, 1,1,1,0, 0,0,0,1, 0,0,0,0))
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE, offset), relay_color = list(1,1,1,0, 1,1,1,0, 1,1,1,0, 0,0,0,1, 0,0,0,0))
 	/// But for the bloom plate we convert only the red color into full white, this way we can have emissives in green channel unaffected by bloom
 	/// which allows us to selectively bloom only a part of our emissives
-	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_PLATE, offset), relay_color = list(255,255,255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0))
-	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_MASK_PLATE, offset), relay_color = list(1,1,1,1, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0))
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE_BLOOM, offset), relay_color = list(255,255,255,0, 0,0,0,0, 0,0,0,0, 0,0,0,1, 0,0,0,0))
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE_BLOOM_MASK, offset), relay_color = list(1,1,1,1, 0,0,0,0, 0,0,0,0, 0,0,0,0, 0,0,0,0))
 
 /atom/movable/screen/plane_master/pipecrawl
 	name = "Pipecrawl"
@@ -373,7 +373,7 @@
 		<br>Has a few effects and a funky color matrix designed to make things a bit more visually readable."
 	plane = PIPECRAWL_IMAGES_PLANE
 	start_hidden = TRUE
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
+	render_relay_planes = list(RENDER_PLANE_GAME)
 
 /atom/movable/screen/plane_master/pipecrawl/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
@@ -389,7 +389,7 @@
 	documentation = "Holds camera static images. Usually only visible to people who can well, see static.\
 		<br>We use images rather then vis contents because they're lighter on maptick, and maptick sucks butt."
 	plane = CAMERA_STATIC_PLANE
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
+	render_relay_planes = list(RENDER_PLANE_GAME)
 
 /atom/movable/screen/plane_master/camera_static/show_to(mob/mymob)
 	. = ..()
@@ -428,7 +428,7 @@
 		<br>Really only exists for its layering potential, we don't use this for any vfx"
 	plane = HIGH_GAME_PLANE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
+	render_relay_planes = list(RENDER_PLANE_GAME)
 
 /atom/movable/screen/plane_master/ghost
 	name = "Ghost"

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -29,161 +29,6 @@
 	name = "Default rendering plate"
 	multiz_scaled = FALSE
 
-///this plate renders the final screen to show to the player
-/atom/movable/screen/plane_master/rendering_plate/master
-	name = "Master rendering plate"
-	documentation = "The endpoint of all plane masters, you can think of this as the final \"view\" we draw.\
-		<br>If offset is not 0 this will be drawn to the transparent plane of the floor above, but otherwise this is drawn to nothing, or shown to the player."
-	plane = RENDER_PLANE_MASTER
-	render_relay_planes = list()
-
-/atom/movable/screen/plane_master/rendering_plate/master/show_to(mob/mymob)
-	. = ..()
-	if(!.)
-		return
-	if(offset == 0)
-		return
-	// Non 0 offset render plates will relay up to the transparent plane above them, assuming they're not on the same z level as their target of course
-	var/datum/hud/hud = home.our_hud
-	// show_to can be called twice successfully with no hide_from call. Ensure no runtimes off the registers from this
-	if(hud)
-		RegisterSignal(hud, COMSIG_HUD_OFFSET_CHANGED, PROC_REF(on_offset_change), override = TRUE)
-	offset_change(hud?.current_plane_offset || 0)
-
-/atom/movable/screen/plane_master/rendering_plate/master/hide_from(mob/oldmob)
-	. = ..()
-	if(offset == 0)
-		return
-	var/datum/hud/hud = home.our_hud
-	if(hud)
-		UnregisterSignal(hud, COMSIG_HUD_OFFSET_CHANGED, PROC_REF(on_offset_change))
-
-/atom/movable/screen/plane_master/rendering_plate/master/proc/on_offset_change(datum/source, old_offset, new_offset)
-	SIGNAL_HANDLER
-	offset_change(new_offset)
-
-/atom/movable/screen/plane_master/rendering_plate/master/proc/offset_change(new_offset)
-	if(new_offset == offset) // If we're on our own z layer, relay to nothing, just draw
-		remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_TRANSPARENT, offset - 1))
-	else // Otherwise, regenerate the relay
-		add_relay_to(GET_NEW_PLANE(RENDER_PLANE_TRANSPARENT, offset - 1))
-
-///renders general in charachter game objects
-/atom/movable/screen/plane_master/rendering_plate/game_plate
-	name = "Game rendering plate"
-	documentation = "Holds all objects that are ahhh, in character? is maybe the best way to describe it.\
-		<br>We apply a displacement effect from the gravity pulse plane too, so we can warp the game world.\
-		<br>If we have fov enabled we'll relay this onto two different rendering plates to apply fov effects to only a portion. If not, we just draw straight to master"
-	plane = RENDER_PLANE_GAME
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
-
-/atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload, datum/hud/hud_owner)
-	. = ..()
-	add_relay_to(GET_NEW_PLANE(EMISSIVE_BLOOM_PLATE, offset), blend_override = BLEND_MULTIPLY)
-	RegisterSignal(GLOB, SIGNAL_ADDTRAIT(TRAIT_DISTORTION_IN_USE(offset)), PROC_REF(distortion_enabled))
-	RegisterSignal(GLOB, SIGNAL_REMOVETRAIT(TRAIT_DISTORTION_IN_USE(offset)), PROC_REF(distortion_disabled))
-	if(HAS_TRAIT(GLOB, TRAIT_DISTORTION_IN_USE(offset)))
-		distortion_enabled()
-
-/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/distortion_enabled(datum/source)
-	SIGNAL_HANDLER
-	add_filter("displacer", 1, displacement_map_filter(render_source = OFFSET_RENDER_TARGET(GRAVITY_PULSE_RENDER_TARGET, offset), size = 10))
-
-/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/distortion_disabled(datum/source)
-	SIGNAL_HANDLER
-	remove_filter("displacer")
-
-/atom/movable/screen/plane_master/rendering_plate/game_plate/show_to(mob/mymob)
-	. = ..()
-	if(!. || !mymob)
-		return .
-	RegisterSignal(mymob, SIGNAL_ADDTRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_enabled), override = TRUE)
-	RegisterSignal(mymob, SIGNAL_REMOVETRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_disabled), override = TRUE)
-	if(HAS_TRAIT(mymob, TRAIT_FOV_APPLIED))
-		fov_enabled(mymob)
-	else
-		fov_disabled(mymob)
-
-/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/fov_enabled(mob/source)
-	SIGNAL_HANDLER
-	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME_UNMASKED, offset))
-	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME_MASKED, offset))
-	remove_relay_from(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset))
-
-/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/fov_disabled(mob/source)
-	SIGNAL_HANDLER
-	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME_UNMASKED, offset))
-	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME_MASKED, offset))
-	add_relay_to(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset))
-
-///renders the parts of the plate unmasked by fov
-/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate
-	name = "Unmasked Game rendering plate"
-	documentation = "Holds the bits of the game plate that aren't impacted by fov.\
-		<br>We use an alpha mask to cut out the bits we plan on dealing with elsewhere"
-	plane = RENDER_PLANE_GAME_UNMASKED
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
-
-/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
-	. = ..()
-	add_filter("fov_handled", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(FIELD_OF_VISION_BLOCKER_RENDER_TARGET, offset), flags = MASK_INVERSE))
-
-/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/show_to(mob/mymob)
-	. = ..()
-	if(!. || !mymob)
-		return .
-	RegisterSignal(mymob, SIGNAL_ADDTRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_enabled), override = TRUE)
-	RegisterSignal(mymob, SIGNAL_REMOVETRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_disabled), override = TRUE)
-	if(HAS_TRAIT(mymob, TRAIT_FOV_APPLIED))
-		fov_enabled(mymob)
-	else
-		fov_disabled(mymob)
-
-/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/proc/fov_enabled(mob/source)
-	SIGNAL_HANDLER
-	if(force_hidden == FALSE)
-		return
-	unhide_plane(source)
-
-/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/proc/fov_disabled(mob/source)
-	SIGNAL_HANDLER
-	hide_plane(source)
-
-///renders the parts of the plate masked by fov
-/atom/movable/screen/plane_master/rendering_plate/masked_game_plate
-	name = "FOV Game rendering plate"
-	documentation = "Contains the bits of the game plate that are hidden by some form of fov\
-		<br>Applies a color matrix to dim and create contrast, alongside a blur. Goal is only half being able to see stuff"
-	plane = RENDER_PLANE_GAME_MASKED
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
-
-/atom/movable/screen/plane_master/rendering_plate/masked_game_plate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
-	. = ..()
-	add_filter("fov_blur", 1, gauss_blur_filter(1.8))
-	add_filter("fov_handled_space", 2, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(FIELD_OF_VISION_BLOCKER_RENDER_TARGET, offset)))
-	add_filter("fov_matrix", 3, color_matrix_filter(list(0.5,-0.15,-0.15,0, -0.15,0.5,-0.15,0, -0.15,-0.15,0.5,0, 0,0,0,1, 0,0,0,0)))
-
-/atom/movable/screen/plane_master/rendering_plate/masked_game_plate/show_to(mob/mymob)
-	. = ..()
-	if(!. || !mymob)
-		return .
-	RegisterSignal(mymob, SIGNAL_ADDTRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_enabled), override = TRUE)
-	RegisterSignal(mymob, SIGNAL_REMOVETRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_disabled), override = TRUE)
-	if(HAS_TRAIT(mymob, TRAIT_FOV_APPLIED))
-		fov_enabled(mymob)
-	else
-		fov_disabled(mymob)
-
-/atom/movable/screen/plane_master/rendering_plate/masked_game_plate/proc/fov_enabled(mob/source)
-	SIGNAL_HANDLER
-	if(force_hidden == FALSE)
-		return
-	unhide_plane(source)
-
-/atom/movable/screen/plane_master/rendering_plate/masked_game_plate/proc/fov_disabled(mob/source)
-	SIGNAL_HANDLER
-	hide_plane(source)
-
 // Blackness renders weird when you view down openspace, because of transforms and borders and such
 // This is a consequence of not using lummy's grouped transparency, but I couldn't get that to work without totally fucking up
 // Sight flags, and shooting vis_contents usage to the moon. So we're doin it different.
@@ -217,6 +62,72 @@
 	if(istype(mymob) && mymob.canon_client?.prefs?.read_preference(/datum/preference/toggle/ambient_occlusion))
 		add_filter("AO", 1, drop_shadow_filter(x = 0, y = -2, size = 4, color = "#04080FAA"))
 
+/atom/movable/screen/plane_master/rendering_plate/unlit_game_plate
+	name = "Unlit Game rendering plate"
+	documentation = "Feeds the bits of the game plate which want to be effected by lighting into RENDER_PLANE_GAME and the emissive bloom pipeline (the reason this exists)."
+	plane = RENDER_PLANE_UNLIT_GAME
+	render_relay_planes = list(RENDER_PLANE_GAME)
+
+/atom/movable/screen/plane_master/rendering_plate/unlit_game_plate/Initialize(mapload, datum/hud/hud_owner)
+	. = ..()
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE_BLOOM, offset), blend_override = BLEND_MULTIPLY)
+
+/atom/movable/screen/plane_master/rendering_plate/turf_lighting
+	name = "Turf lighting post-processing plate"
+	documentation = "Used by overlay lighting, and possibly over plates, to mask out turf lighting."
+	plane = RENDER_PLANE_TURF_LIGHTING
+	render_relay_planes = list(RENDER_PLANE_LIGHTING)
+	blend_mode = BLEND_ADD
+	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/emissive_slate
+	name = "Emissive Plate"
+	documentation = "This system works by exploiting BYONDs color matrix filter to use layers to handle emissive blockers.\
+		<br>Emissive overlays are pasted with an atom color that converts them to be entirely some specific color.\
+		<br>Emissive blockers are pasted with an atom color that converts them to be entirely some different color.\
+		<br>Emissive overlays and emissive blockers are put onto the same plane (This one).\
+		<br>The layers for the emissive overlays and emissive blockers cause them to mask eachother similar to normal BYOND objects.\
+		<br>A color matrix filter is applied to the emissive plane to mask out anything that isn't whatever the emissive color is.\
+		<br>This is then used to alpha mask the lighting plane."
+	plane = RENDER_PLANE_EMISSIVE
+	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	render_target = EMISSIVE_RENDER_TARGET
+	render_relay_planes = list()
+	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/emissive_slate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+	. = ..()
+	add_filter("em_block_masking", 2, color_matrix_filter(GLOB.em_mask_matrix))
+	if(offset != 0)
+		add_relay_to(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE, offset - 1), relay_layer = EMISSIVE_Z_BELOW_LAYER)
+
+/atom/movable/screen/plane_master/rendering_plate/emissive_bloom_mask
+	name = "Emissive bloom mask plate"
+	documentation = "A holder plate used purely as a way to full-white bloom emissives before applying them as a mask onto the emissive bloom plate."
+	plane = RENDER_PLANE_EMISSIVE_BLOOM_MASK
+	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	render_relay_planes = list()
+	render_target = EMISSIVE_BLOOM_MASK_TARGET
+	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/emissive_bloom
+	name = "Emissive bloom plate"
+	documentation = "Plate used to bloom emissives before adding them onto the overlay lighting plane. We do this by multiplying the game plate\
+		onto a fullbright emissive, then alpha masking it by emissive's color to solve the problem of blockers, both alone and covered by emissives."
+	plane = RENDER_PLANE_EMISSIVE_BLOOM
+	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	blend_mode = BLEND_ADD
+	render_relay_planes = list(O_LIGHTING_VISUAL_PLANE)
+	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/emissive_bloom/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+	. = ..()
+	add_filter("emissive_mask", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(EMISSIVE_BLOOM_MASK_TARGET, offset)))
+	add_filter("emissive_bloom", 2, bloom_filter(threshold = COLOR_BLACK, size = 2, offset = 1))
+
 ///Contains all lighting objects
 /atom/movable/screen/plane_master/rendering_plate/lighting
 	name = "Lighting plate"
@@ -231,7 +142,7 @@
 	blend_mode_override = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	critical = PLANE_CRITICAL_DISPLAY
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
+	render_relay_planes = list(RENDER_PLANE_GAME)
 	/// A list of light cutoffs we're actively using, (mass, r, g, b) to avoid filter churn
 	var/list/light_cutoffs
 
@@ -312,28 +223,6 @@
 	add_filter("light_cutdown", 3, color_matrix_filter(list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, -(ratio + red),-(ratio+green),-(ratio+blue),0)))
 	add_filter("light_cutup", 4, color_matrix_filter(list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, ratio+red,ratio+green,ratio+blue,0)))
 
-/atom/movable/screen/plane_master/rendering_plate/emissive_slate
-	name = "Emissive Plate"
-	documentation = "This system works by exploiting BYONDs color matrix filter to use layers to handle emissive blockers.\
-		<br>Emissive overlays are pasted with an atom color that converts them to be entirely some specific color.\
-		<br>Emissive blockers are pasted with an atom color that converts them to be entirely some different color.\
-		<br>Emissive overlays and emissive blockers are put onto the same plane (This one).\
-		<br>The layers for the emissive overlays and emissive blockers cause them to mask eachother similar to normal BYOND objects.\
-		<br>A color matrix filter is applied to the emissive plane to mask out anything that isn't whatever the emissive color is.\
-		<br>This is then used to alpha mask the lighting plane."
-	plane = EMISSIVE_RENDER_PLATE
-	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	render_target = EMISSIVE_RENDER_TARGET
-	render_relay_planes = list()
-	critical = PLANE_CRITICAL_DISPLAY
-
-/atom/movable/screen/plane_master/rendering_plate/emissive_slate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
-	. = ..()
-	add_filter("em_block_masking", 2, color_matrix_filter(GLOB.em_mask_matrix))
-	if(offset != 0)
-		add_relay_to(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset - 1), relay_layer = EMISSIVE_Z_BELOW_LAYER)
-
 /atom/movable/screen/plane_master/rendering_plate/light_mask
 	name = "Light Mask"
 	documentation = "Any part of this plane that is transparent will be black below it on the game rendering plate.\
@@ -341,7 +230,7 @@
 		<br>We relay copies of the space, floor and wall planes to it, so we can use them as masks. Then we just boost any existing alpha to 100% and we're done.\
 		<br>If we ever switch to a sight setup that shows say, mobs but not floors, we instead mask just overlay lighting and emissives.\
 		<br>This avoids dumb seethrough without breaking stuff like thermals."
-	plane = LIGHT_MASK_PLANE
+	plane = RENDER_PLANE_LIGHT_MASK
 	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
 	// Fullwhite where there's anything, no color otherwise
 	color = list(255,255,255,255, 255,255,255,255, 255,255,255,255, 255,255,255,255, 0,0,0,0)
@@ -349,7 +238,7 @@
 	render_target = LIGHT_MASK_RENDER_TARGET
 	// We blend against the game plane, so she's gotta multiply!
 	blend_mode = BLEND_MULTIPLY
-	render_relay_planes = list(LIT_GAME_RENDER_PLATE)
+	render_relay_planes = list(RENDER_PLANE_GAME)
 
 /atom/movable/screen/plane_master/rendering_plate/light_mask/show_to(mob/mymob)
 	. = ..()
@@ -361,24 +250,141 @@
 
 /atom/movable/screen/plane_master/rendering_plate/light_mask/hide_from(mob/oldmob)
 	. = ..()
-	var/atom/movable/screen/plane_master/emissive = home.get_plane(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset))
+	var/atom/movable/screen/plane_master/emissive = home.get_plane(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE, offset))
 	emissive.remove_filter("lighting_mask")
-	remove_relay_from(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset))
+	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME, offset))
 	UnregisterSignal(oldmob, COMSIG_MOB_SIGHT_CHANGE)
 
 /atom/movable/screen/plane_master/rendering_plate/light_mask/proc/handle_sight(datum/source, new_sight, old_sight)
 	// If we can see something that shows "through" blackness, and we can't see turfs, disable our draw to the game plane
 	// And instead mask JUST the overlay lighting plane, since that will look fuckin wrong
-	var/atom/movable/screen/plane_master/emissive = home.get_plane(GET_NEW_PLANE(EMISSIVE_RENDER_PLATE, offset))
+	var/atom/movable/screen/plane_master/emissive = home.get_plane(GET_NEW_PLANE(RENDER_PLANE_EMISSIVE, offset))
 	if(new_sight & SEE_AVOID_TURF_BLACKNESS && !(new_sight & SEE_TURFS))
-		remove_relay_from(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset))
+		remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME, offset))
 		emissive.add_filter("lighting_mask", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(LIGHT_MASK_RENDER_TARGET, offset)))
 	// If we CAN'T see through the black, then draw er down brother!
 	else
 		emissive.remove_filter("lighting_mask")
 		// We max alpha here, so our darkness is actually.. dark
 		// Can't do it before cause it fucks with the filter
-		add_relay_to(GET_NEW_PLANE(LIT_GAME_RENDER_PLATE, offset), relay_color = list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,1))
+		add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME, offset), relay_color = list(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1, 0,0,0,1))
+
+///renders in character game objects
+/atom/movable/screen/plane_master/rendering_plate/game_plate
+	name = "Game rendering plate"
+	documentation = "Holds all objects that are ahhh, in character? is maybe the best way to describe it.\
+		<br>We apply a displacement effect from the gravity pulse plane too, so we can warp the game world.\
+		<br>If we have fov enabled we'll relay this onto two different rendering plates to apply fov effects to only a portion. If not, we just draw straight to master.\
+		<br>It's also the step where we finally build lighting into the visual pipeline"
+	plane = RENDER_PLANE_GAME
+	render_relay_planes = list(RENDER_PLANE_MASTER)
+	critical = PLANE_CRITICAL_DISPLAY
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+	. = ..()
+	RegisterSignal(GLOB, SIGNAL_ADDTRAIT(TRAIT_DISTORTION_IN_USE(offset)), PROC_REF(distortion_enabled))
+	RegisterSignal(GLOB, SIGNAL_REMOVETRAIT(TRAIT_DISTORTION_IN_USE(offset)), PROC_REF(distortion_disabled))
+	if(HAS_TRAIT(GLOB, TRAIT_DISTORTION_IN_USE(offset)))
+		distortion_enabled()
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/distortion_enabled(datum/source)
+	SIGNAL_HANDLER
+	add_filter("displacer", 1, displacement_map_filter(render_source = OFFSET_RENDER_TARGET(DISPLACEMENT_RENDER_TARGET, offset), size = 10))
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/distortion_disabled(datum/source)
+	SIGNAL_HANDLER
+	remove_filter("displacer")
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/show_to(mob/mymob)
+	. = ..()
+	if(!. || !mymob)
+		return .
+	RegisterSignal(mymob, SIGNAL_ADDTRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_enabled), override = TRUE)
+	RegisterSignal(mymob, SIGNAL_REMOVETRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_disabled), override = TRUE)
+	if(HAS_TRAIT(mymob, TRAIT_FOV_APPLIED))
+		fov_enabled(mymob)
+	else
+		fov_disabled(mymob)
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/fov_enabled(mob/source)
+	SIGNAL_HANDLER
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME_UNMASKED, offset))
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_GAME_MASKED, offset))
+	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_MASTER, offset))
+
+/atom/movable/screen/plane_master/rendering_plate/game_plate/proc/fov_disabled(mob/source)
+	SIGNAL_HANDLER
+	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME_UNMASKED, offset))
+	remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_GAME_MASKED, offset))
+	add_relay_to(GET_NEW_PLANE(RENDER_PLANE_MASTER, offset))
+
+///renders the parts of the plate unmasked by fov
+/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate
+	name = "Unmasked Game rendering plate"
+	documentation = "Holds the bits of the game plate that aren't impacted by fov.\
+		<br>We use an alpha mask to cut out the bits we plan on dealing with elsewhere"
+	plane = RENDER_PLANE_GAME_UNMASKED
+	render_relay_planes = list(RENDER_PLANE_MASTER)
+
+/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+	. = ..()
+	add_filter("fov_handled", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(FIELD_OF_VISION_BLOCKER_RENDER_TARGET, offset), flags = MASK_INVERSE))
+
+/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/show_to(mob/mymob)
+	. = ..()
+	if(!. || !mymob)
+		return .
+	RegisterSignal(mymob, SIGNAL_ADDTRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_enabled), override = TRUE)
+	RegisterSignal(mymob, SIGNAL_REMOVETRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_disabled), override = TRUE)
+	if(HAS_TRAIT(mymob, TRAIT_FOV_APPLIED))
+		fov_enabled(mymob)
+	else
+		fov_disabled(mymob)
+
+/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/proc/fov_enabled(mob/source)
+	SIGNAL_HANDLER
+	if(force_hidden == FALSE)
+		return
+	unhide_plane(source)
+
+/atom/movable/screen/plane_master/rendering_plate/unmasked_game_plate/proc/fov_disabled(mob/source)
+	SIGNAL_HANDLER
+	hide_plane(source)
+
+///renders the parts of the plate masked by fov
+/atom/movable/screen/plane_master/rendering_plate/masked_game_plate
+	name = "FOV Game rendering plate"
+	documentation = "Contains the bits of the game plate that are hidden by some form of fov\
+		<br>Applies a color matrix to dim and create contrast, alongside a blur. Goal is only half being able to see stuff"
+	plane = RENDER_PLANE_GAME_MASKED
+	render_relay_planes = list(RENDER_PLANE_MASTER)
+
+/atom/movable/screen/plane_master/rendering_plate/masked_game_plate/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+	. = ..()
+	add_filter("fov_blur", 1, gauss_blur_filter(1.8))
+	add_filter("fov_handled_space", 2, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(FIELD_OF_VISION_BLOCKER_RENDER_TARGET, offset)))
+	add_filter("fov_matrix", 3, color_matrix_filter(list(0.5,-0.15,-0.15,0, -0.15,0.5,-0.15,0, -0.15,-0.15,0.5,0, 0,0,0,1, 0,0,0,0)))
+
+/atom/movable/screen/plane_master/rendering_plate/masked_game_plate/show_to(mob/mymob)
+	. = ..()
+	if(!. || !mymob)
+		return .
+	RegisterSignal(mymob, SIGNAL_ADDTRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_enabled), override = TRUE)
+	RegisterSignal(mymob, SIGNAL_REMOVETRAIT(TRAIT_FOV_APPLIED), PROC_REF(fov_disabled), override = TRUE)
+	if(HAS_TRAIT(mymob, TRAIT_FOV_APPLIED))
+		fov_enabled(mymob)
+	else
+		fov_disabled(mymob)
+
+/atom/movable/screen/plane_master/rendering_plate/masked_game_plate/proc/fov_enabled(mob/source)
+	SIGNAL_HANDLER
+	if(force_hidden == FALSE)
+		return
+	unhide_plane(source)
+
+/atom/movable/screen/plane_master/rendering_plate/masked_game_plate/proc/fov_disabled(mob/source)
+	SIGNAL_HANDLER
+	hide_plane(source)
 
 ///render plate for OOC stuff like ghosts, hud-screen effects, etc
 /atom/movable/screen/plane_master/rendering_plate/non_game
@@ -387,46 +393,44 @@
 	plane = RENDER_PLANE_NON_GAME
 	render_relay_planes = list(RENDER_PLANE_MASTER)
 
-/atom/movable/screen/plane_master/rendering_plate/emissive_bloom_mask
-	name = "Emissive bloom mask plate"
-	documentation = "A holder plate used purely as a way to full-white bloom emissives before applying them as a mask onto the emissive bloom plate."
-	plane = EMISSIVE_BLOOM_MASK_PLATE
-	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+///this plate renders the final screen to show to the player
+/atom/movable/screen/plane_master/rendering_plate/master
+	name = "Master rendering plate"
+	documentation = "The endpoint of all plane masters, you can think of this as the final \"view\" we draw.\
+		<br>If offset is not 0 this will be drawn to the transparent plane of the floor above, but otherwise this is drawn to nothing, or shown to the player."
+	plane = RENDER_PLANE_MASTER
 	render_relay_planes = list()
-	render_target = EMISSIVE_BLOOM_MASK_TARGET
-	critical = PLANE_CRITICAL_DISPLAY
 
-/atom/movable/screen/plane_master/rendering_plate/emissive_bloom
-	name = "Emissive bloom plate"
-	documentation = "Plate used to bloom emissives before adding them onto the overlay lighting plane. We do this by multiplying the game plate\
-		onto a fullbright emissive, then alpha masking it by emissive's color to solve the problem of blockers, both alone and covered by emissives."
-	plane = EMISSIVE_BLOOM_PLATE
-	appearance_flags = PLANE_MASTER|NO_CLIENT_COLOR
-	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
-	blend_mode = BLEND_ADD
-	render_relay_planes = list(O_LIGHTING_VISUAL_PLANE)
-	critical = PLANE_CRITICAL_DISPLAY
-
-/atom/movable/screen/plane_master/rendering_plate/emissive_bloom/Initialize(mapload, datum/hud/hud_owner, datum/plane_master_group/home, offset)
+/atom/movable/screen/plane_master/rendering_plate/master/show_to(mob/mymob)
 	. = ..()
-	add_filter("emissive_mask", 1, alpha_mask_filter(render_source = OFFSET_RENDER_TARGET(EMISSIVE_BLOOM_MASK_TARGET, offset)))
-	add_filter("emissive_bloom", 2, bloom_filter(threshold = COLOR_BLACK, size = 2, offset = 1))
+	if(!.)
+		return
+	if(offset == 0)
+		return
+	// Non 0 offset render plates will relay up to the transparent plane above them, assuming they're not on the same z level as their target of course
+	var/datum/hud/hud = home.our_hud
+	// show_to can be called twice successfully with no hide_from call. Ensure no runtimes off the registers from this
+	if(hud)
+		RegisterSignal(hud, COMSIG_HUD_OFFSET_CHANGED, PROC_REF(on_offset_change), override = TRUE)
+	offset_change(hud?.current_plane_offset || 0)
 
-/atom/movable/screen/plane_master/rendering_plate/turf_lighting
-	name = "Turf lighting post-processing plate"
-	documentation = "Used by overlay lighting, and possibly over plates, to mask out turf lighting."
-	plane = TURF_LIGHTING_PLATE
-	render_relay_planes = list(RENDER_PLANE_LIGHTING)
-	blend_mode = BLEND_ADD
-	critical = PLANE_CRITICAL_DISPLAY
+/atom/movable/screen/plane_master/rendering_plate/master/hide_from(mob/oldmob)
+	. = ..()
+	if(offset == 0)
+		return
+	var/datum/hud/hud = home.our_hud
+	if(hud)
+		UnregisterSignal(hud, COMSIG_HUD_OFFSET_CHANGED, PROC_REF(on_offset_change))
 
-/atom/movable/screen/plane_master/rendering_plate/lit_game
-	name = "Lit game rendering plate"
-	documentation = "Plate which is used to multiply the game rendering plate by lighting visuals and rendering fullbright stuff. Exists so we can fetch fullbright game plate for emissive VFX."
-	plane = LIT_GAME_RENDER_PLATE
-	render_relay_planes = list(RENDER_PLANE_MASTER)
-	critical = PLANE_CRITICAL_DISPLAY
+/atom/movable/screen/plane_master/rendering_plate/master/proc/on_offset_change(datum/source, old_offset, new_offset)
+	SIGNAL_HANDLER
+	offset_change(new_offset)
+
+/atom/movable/screen/plane_master/rendering_plate/master/proc/offset_change(new_offset)
+	if(new_offset == offset) // If we're on our own z layer, relay to nothing, just draw
+		remove_relay_from(GET_NEW_PLANE(RENDER_PLANE_TRANSPARENT, offset - 1))
+	else // Otherwise, regenerate the relay
+		add_relay_to(GET_NEW_PLANE(RENDER_PLANE_TRANSPARENT, offset - 1))
 
 /**
  * Plane master proc called in Initialize() that creates relay objects, and sets them up as needed

--- a/code/game/objects/effects/anomalies/anomalies_gravity.dm
+++ b/code/game/objects/effects/anomalies/anomalies_gravity.dm
@@ -1,6 +1,6 @@
 
 /atom/movable/warp_effect
-	plane = GRAVITY_PULSE_PLANE
+	plane = DISPLACEMENT_PLANE
 	appearance_flags = PIXEL_SCALE|LONG_GLIDE // no tile bound so you can see it around corners and so
 	icon = 'icons/effects/light_overlays/light_352.dmi'
 	icon_state = "light"


### PR DESCRIPTION
Original PR: 92357
-----

## About The Pull Request

Renames GRAVPULSE plane to DISPLACEMENT because that's what we use it for now and it's dumb that it's still named/desc'd like it isn't that.

Renames lit game plate to just game plate, old game plate becomes unlit game plate. Confuses where "output" effects should go.

Moves displacement and fov effects to the game plate, from the old unlit ameplate. These should effect lighting, and it looks strange if they don't/drop the above lighting children.

Sorts render plate definitions by their layer value, because I am the way I am.

Renames all render plate defines to the `RENDER_PLANE_{NAME}` format instead of `{NAME}_PLATE`. I kind of think we should have intermediaries be named `_PLATE` tho I'm not really confident in this change.

In which I forget to incrementally commit

## Why It's Good For The Game

Makes things work a bit better, easier to add to (maybe, this seems to be something only I care about idk)

## Changelog
:cl:
fix: Distortion/fov effects now properly impact the full game world
/:cl:
