### PR TITLE
[TG Mirror] Fixes Honey Sweetroll Recipe [MDB IGNORE]

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_lizard.dm
@@ -374,6 +374,7 @@
 	)
 	result = /obj/item/food/honey_roll
 	category = CAT_LIZARD
+	crafting_flags = CRAFT_CLEARS_REAGENTS
 
 /datum/crafting_recipe/food/black_eggs
 	name = "Black scrambled eggs"


### PR DESCRIPTION
Original PR: 92362
-----

## About The Pull Request

Fixes the Honey Sweetroll recipe to stop the water + potassium from exploding everything inside and making it inedible. Adds the CRAFT_CLEARS_REAGENTS flag.

<img width="366" height="182" alt="image" src="https://github.com/user-attachments/assets/a4489c13-7a34-43a5-b2ef-51f4272ea186" />


## Why It's Good For The Game

Fixes a few bug reports regarding this issue.

## Changelog
:cl:
fix: honey sweetrolls can now be eaten
/:cl:
