### PR TITLE
[TG Mirror] Fixes EMP Flashlight not working on Cyborgs [MDB IGNORE]

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -172,7 +172,7 @@ GLOBAL_LIST_INIT(blacklisted_borg_hats, typecacheof(list( //Hats that don't real
 		balloon_alert(user, "toner filled")
 		return ITEM_INTERACT_SUCCESS
 
-	if(istype(tool, /obj/item/flashlight))
+	if(istype(tool, /obj/item/flashlight) && !istype(tool, /obj/item/flashlight/emp)) //subtypes my behated. OOP was a dumb idea
 		if(user.combat_mode)
 			return NONE
 		if(!opened)


### PR DESCRIPTION
Original PR: 92339
-----
## About The Pull Request
Shitcode that fixes a bug. Before, it would try to run through the normal flashlight procedure, which potentially involves deleting your traitor item and fixing the borg's flightlight (or more likely you'd just get the message about the cover being closed and that's the end of it.)

Technically it did work if you were on combat but that's very intuitive.
## Why It's Good For The Game
Fix
## Changelog
:cl:
fix: EMP Flashlights work on cyborgs for non-combat mode as well as combat mode
/:cl:
