### PR TITLE
[TG Mirror] Removes forced tint from NVGs [MDB IGNORE]

### DIFF
--- a/_maps/virtual_domains/meta_central.dmm
+++ b/_maps/virtual_domains/meta_central.dmm
@@ -4408,12 +4408,12 @@
 /area/virtual_domain)
 "Lq" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/glasses/night/colorless{
+/obj/item/clothing/glasses/night{
 	pixel_x = 5;
 	pixel_y = 7
 	},
-/obj/item/clothing/glasses/night/colorless,
-/obj/item/clothing/glasses/night/colorless{
+/obj/item/clothing/glasses/night,
+/obj/item/clothing/glasses/night{
 	pixel_x = -5;
 	pixel_y = -3
 	},

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -300,7 +300,7 @@
 			new /obj/item/clothing/suit/armor/vest/marine/pmc(src) //The armor kit is comparable to the infiltrator, 6 TC
 			new /obj/item/clothing/head/helmet/marine/pmc(src)
 			new /obj/item/clothing/mask/gas/sechailer(src)
-			new /obj/item/clothing/glasses/night/colorless(src) // 3~ TC
+			new /obj/item/clothing/glasses/night(src) // 3~ TC
 			new /obj/item/clothing/gloves/krav_maga/combatglovesplus(src) //5TC
 			new /obj/item/clothing/shoes/jackboots(src)
 			new /obj/item/storage/belt/military/assault/fisher(src) //items in this belt easily costs 18 TC

--- a/code/game/objects/structures/crates_lockers/closets/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/syndicate.dm
@@ -20,7 +20,7 @@
 /obj/structure/closet/syndicate/personal/PopulateContents()
 	..()
 	new /obj/item/trench_tool(src)
-	new /obj/item/clothing/glasses/night/colorless(src)
+	new /obj/item/clothing/glasses/night(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
 	new /obj/item/storage/belt/military(src)
 	new /obj/item/storage/belt/holster/nukie(src)

--- a/code/modules/antagonists/cult/cult_armor.dm
+++ b/code/modules/antagonists/cult/cult_armor.dm
@@ -246,7 +246,6 @@
 	actions_types = null
 	color_cutoffs = list(40, 0, 0) //red
 	glass_colour_type = null
-	forced_glass_color = FALSE
 
 /obj/item/clothing/glasses/hud/health/night/cultblind/equipped(mob/living/user, slot)
 	. = ..()

--- a/code/modules/antagonists/ninja/outfit.dm
+++ b/code/modules/antagonists/ninja/outfit.dm
@@ -1,7 +1,7 @@
 /datum/outfit/ninja
 	name = "Space Ninja"
 	uniform = /obj/item/clothing/under/syndicate/ninja
-	glasses = /obj/item/clothing/glasses/night/colorless
+	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/ninja
 	ears = /obj/item/radio/headset
 	shoes = /obj/item/clothing/shoes/jackboots

--- a/code/modules/antagonists/nukeop/outfits.dm
+++ b/code/modules/antagonists/nukeop/outfits.dm
@@ -66,7 +66,7 @@
 /datum/outfit/syndicate/full
 	name = "Syndicate Operative - Full Kit"
 
-	glasses = /obj/item/clothing/glasses/night/colorless
+	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/syndicate
 	back = /obj/item/mod/control/pre_equipped/nuclear
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -95,7 +95,6 @@
 	color_cutoffs = list(10, 35, 10)
 	glass_colour_type = /datum/client_colour/glass_colour/lightgreen
 	actions_types = list(/datum/action/item_action/toggle_nv)
-	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/meson/night/update_icon_state()
 	. = ..()
@@ -143,7 +142,6 @@
 	color_cutoffs = list(30, 5, 15)
 	glass_colour_type = /datum/client_colour/glass_colour/lightpurple
 	actions_types = list(/datum/action/item_action/toggle_nv)
-	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/science/night/update_icon_state()
 	. = ..()
@@ -160,15 +158,10 @@
 	color_cutoffs = list(10, 25, 10)
 	glass_colour_type = /datum/client_colour/glass_colour/lightgreen
 	actions_types = list(/datum/action/item_action/toggle_nv)
-	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/night/update_icon_state()
 	. = ..()
 	icon_state = length(color_cutoffs) ? initial(icon_state) : "night_off"
-
-/obj/item/clothing/glasses/night/colorless
-	desc = parent_type::desc + " Now with 50% less green!"
-	forced_glass_color = FALSE
 
 /obj/item/clothing/glasses/eyepatch
 	name = "eyepatch"

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -76,7 +76,6 @@
 	color_cutoffs = list(20, 20, 45)
 	glass_colour_type = /datum/client_colour/glass_colour/lightgreen
 	actions_types = list(/datum/action/item_action/toggle_nv)
-	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/hud/health/night/update_icon_state()
 	. = ..()
@@ -92,7 +91,6 @@
 	desc = "A clandestine medical science heads-up display that allows operatives to find \
 		both dying captains and the perfect poison to finish them off, all in complete darkness."
 	clothing_traits = list(TRAIT_REAGENT_SCANNER, TRAIT_MEDICAL_HUD)
-	forced_glass_color = FALSE
 
 /obj/item/clothing/glasses/hud/health/sunglasses
 	name = "medical HUDSunglasses"
@@ -130,7 +128,6 @@
 	color_cutoffs = list(25, 15, 5)
 	glass_colour_type = /datum/client_colour/glass_colour/lightyellow
 	actions_types = list(/datum/action/item_action/toggle_nv)
-	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/hud/diagnostic/night/update_icon_state()
 	. = ..()
@@ -207,7 +204,6 @@
 	color_cutoffs = list(40, 15, 10)
 	glass_colour_type = /datum/client_colour/glass_colour/lightred
 	actions_types = list(/datum/action/item_action/toggle_nv)
-	forced_glass_color = TRUE
 
 /obj/item/clothing/glasses/hud/security/night/update_icon_state()
 	. = ..()

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -248,7 +248,7 @@
 		/obj/item/storage/box/lights/mixed = 1,
 	)
 	belt = /obj/item/storage/belt/janitor/full
-	glasses = /obj/item/clothing/glasses/night/colorless
+	glasses = /obj/item/clothing/glasses/night
 	l_pocket = /obj/item/grenade/chem_grenade/cleaner
 	r_pocket = /obj/item/grenade/chem_grenade/cleaner
 	l_hand = /obj/item/storage/bag/trash/bluespace

--- a/code/modules/mob_spawn/ghost_roles/unused_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/unused_roles.dm
@@ -308,7 +308,7 @@
 
 /datum/outfit/syndicatespace/syndicrew
 	name = "Syndicate Ship Crew Member"
-	glasses = /obj/item/clothing/glasses/night/colorless
+	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/syndicate
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/knife/combat/survival

--- a/tools/UpdatePaths/Scripts/92322_colorless_nvg.txt
+++ b/tools/UpdatePaths/Scripts/92322_colorless_nvg.txt
@@ -1,0 +1,2 @@
+# Colorless NVG was removed alongside the forced tint
+/obj/item/clothing/glasses/night/colorless : /obj/item/clothing/glasses/night{@OLD}


### PR DESCRIPTION
Original PR: 92322
-----

## About The Pull Request

Partially reverts #84594, removing forced tint from night vision goggles (if anyone for some reason wants to experience it again, they can toggle it via alt click like it could be done before the [aforementioned PR](https://github.com/tgstation/tgstation/pull/84594))

Approved by Ghom (the original PR author)

## Why It's Good For The Game

NVG tint is a pretty sizeable accessibility issue, as forced screentint can easily cause eye strain if they're used for prolonged periods of time, being especially bad for blue-tinted NVGs. They're already locked pretty deep down the techweb, and this change just made everyone avoid them. If we need to make tintless variants of them for every single antag and special role (and bitrunners, lol), we maybe shouldn't have added the tint in the first place.

## Changelog
:cl:
del: Removes forced tint from NVGs
/:cl:
