### PR TITLE
[TG Mirror] Removes spacemove crashes/impacts at high speed [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/movement.dm
+++ b/code/__DEFINES/movement.dm
@@ -144,9 +144,5 @@ GLOBAL_VAR_INIT(glide_size_multiplier, 1.0)
 #define INERTIA_FORCE_SPACEMOVE_REDUCTION 0.75 NEWTONS
 /// How much inertia we must have to not be able to instantly stop after having something to grab
 #define INERTIA_FORCE_SPACEMOVE_GRAB 1.5 NEWTONS
-/// How much inertia is required for the impacted object to be thrown at the wall
-#define INERTIA_FORCE_THROW_FLOOR 10 NEWTONS
-/// How much inertia is required past the floor to add 1 strength
-#define INERTIA_FORCE_PER_THROW_FORCE 5 NEWTONS
 // Results in maximum speed of 1 tile per tick, capped at about 2/3rds of maximum force
 #define INERTIA_SPEED_COEF 0.375

--- a/code/datums/drift_handler.dm
+++ b/code/datums/drift_handler.dm
@@ -209,8 +209,6 @@
 
 /datum/drift_handler/proc/attempt_halt(movement_dir, continuous_move, atom/backup)
 	if ((backup.density || !backup.CanPass(parent, get_dir(backup, parent))) && (get_dir(parent, backup) == movement_dir || parent.loc == backup.loc))
-		if (drift_force >= INERTIA_FORCE_THROW_FLOOR)
-			parent.throw_at(backup, 1, floor(1 + (drift_force - INERTIA_FORCE_THROW_FLOOR) / INERTIA_FORCE_PER_THROW_FORCE), spin = FALSE)
 		return FALSE
 
 	if (drift_force < INERTIA_FORCE_SPACEMOVE_GRAB || isnull(drifting_loop))


### PR DESCRIPTION
Original PR: 92284
-----
## About The Pull Request

Something changed in spacemove loop code recently which caused infinite recursions through throw code. This has been a rather bad mechanic already, and I believe that it warrants removal alongside newtonian zero-g physics in general - but for now lets just get rid of the part that crashes the server.

## Why It's Good For The Game

We've pushed the speed limit to the point where you need to be firing a SAW without a jetpack for a full minute to actually crash into something, its a bad mechanic that doesn't bring much to the round as-is.

## Changelog
:cl:
del: Hitting objects at high speed in zero-g no longer makes you crash into them.
/:cl: