### PR TITLE
[TG Mirror] fixes the pathing for the nuclear operative syndicate bomb uplink entries [MDB IGNORE]

### DIFF
--- a/code/modules/uplink/uplink_items/nukeops.dm
+++ b/code/modules/uplink/uplink_items/nukeops.dm
@@ -498,18 +498,7 @@
 	item = /obj/item/storage/backpack/duffelbag/syndie/x4
 	cost = 10 // 50% discount!
 
-/datum/uplink_item/explosives/military_grade/emp
-	name = "Syndicate EMP Bomb"
-	desc = "A variation of the syndicate bomb designed to produce a large EMP effect."
-	item = /obj/item/sbeacondrop/emp
-	cost = 6
-
-/datum/uplink_item/explosives/syndicate_bomb/emp/New()
-	..()
-	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
-		cost *= 2
-
-/datum/uplink_item/explosives/syndicate_bomb
+/datum/uplink_item/explosives/military_grade/syndicate_bomb
 	name = "Syndicate Bomb"
 	desc = "The Syndicate bomb is a fearsome device capable of massive destruction. It has an adjustable timer, \
 		with a minimum of %MIN_BOMB_TIMER seconds, and can be bolted to the floor with a wrench to prevent \
@@ -520,9 +509,20 @@
 	item = /obj/item/sbeacondrop/bomb
 	cost = 8
 
-/datum/uplink_item/explosives/syndicate_bomb/New()
+/datum/uplink_item/explosives/military_grade/syndicate_bomb/New()
 	. = ..()
 	desc = replacetext(desc, "%MIN_BOMB_TIMER", SYNDIEBOMB_MIN_TIMER_SECONDS)
+
+/datum/uplink_item/explosives/military_grade/syndicate_bomb/emp
+	name = "Syndicate EMP Bomb"
+	desc = "A variation of the syndicate bomb designed to produce a large EMP effect."
+	item = /obj/item/sbeacondrop/emp
+	cost = 6
+
+/datum/uplink_item/explosives/military_grade/syndicate_bomb/emp/New()
+	. = ..()
+	if(HAS_TRAIT(SSstation, STATION_TRAIT_CYBERNETIC_REVOLUTION))
+		cost *= 2
 
 // Support (Borgs and Reinforcements)
 


### PR DESCRIPTION
Original PR: 92361
-----

## About The Pull Request

fixes https://github.com/tgstation/tgstation/issues/92359

## Why It's Good For The Game

oops

## Changelog
:cl:
fix: Operatives once again can purchase syndicate bombs.
/:cl:
