### PR TITLE
[TG Mirror] Fixes newspapers being unreadable. [MDB IGNORE]

### DIFF
--- a/tgui/packages/tgui/interfaces/Newspaper.tsx
+++ b/tgui/packages/tgui/interfaces/Newspaper.tsx
@@ -40,7 +40,7 @@ export const Newspaper = (props) => {
 
   return (
     <Window width={300} height={400}>
-      <Window.Content backgroundColor="#858387">
+      <Window.Content backgroundColor="#858387" scrollable>
         {current_page === channels.length + 1 ? (
           <NewspaperEnding />
         ) : current_page ? (


### PR DESCRIPTION
Original PR: 92372
-----

## About The Pull Request

Apparently the scrollbar on newspapers got lost, meaning tabbing to a page too large to render in the box would get you stuck until you resize it so you can see everything that's off-screen. Yes, including the page buttons.
This just adds `scrollable`, fixing that issue.
Adds `scrollable` to newspapers such that they're actually readable again, instead of 

I think it'd be better if the previous/next page buttons were always on screen and the stories would have a scrollbar, but after a while of trying to do that with no progress I'm just posting this fix that returns it to the previous functional state first.
## Why It's Good For The Game

Lets you read newspapers again. woa
## Changelog
:cl:
fix: Newspapers can be scrolled through again.
/:cl:
