### PR TITLE
[TG Mirror] Non-workout sources of athletics experience diminishing returns on experience gain [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/skills.dm
+++ b/code/__DEFINES/skills.dm
@@ -47,6 +47,9 @@
 ///The base modifier a boulder's size grants to the mining skill.
 #define MINING_SKILL_BOULDER_SIZE_XP 10
 
+///The base modifier for how much experience is earned from misc athletics interactions
+#define ATHLETICS_SKILL_MISC_EXP 5
+
 // Skillchip categories
 //Various skillchip categories. Use these when setting which categories a skillchip restricts being paired with
 //while using the SKILLCHIP_RESTRICTED_CATEGORIES flag

--- a/code/datums/elements/climbable.dm
+++ b/code/datums/elements/climbable.dm
@@ -99,7 +99,7 @@
 			if(istype(buckle_target))
 				if(buckle_target.is_buckle_possible(user))
 					buckle_target.buckle_mob(user)
-			user.mind?.adjust_experience(/datum/skill/athletics, 5) //Get a bit fitter with every climb.
+			user.mind?.adjust_experience(/datum/skill/athletics, round(ATHLETICS_SKILL_MISC_EXP/(fitness_level || 1), 1)) //Get a bit fitter with every climb. But it has diminishing returns at a certain point.
 		else
 			to_chat(user, span_warning("You fail to climb onto [climbed_thing]."))
 	LAZYREMOVEASSOC(current_climbers, climbed_thing, user)

--- a/code/game/objects/items/climbingrope.dm
+++ b/code/game/objects/items/climbingrope.dm
@@ -65,7 +65,7 @@
 
 	if(do_after(user, final_climb_time, interacting_with))
 		user.forceMove(interacting_with)
-		user.mind?.adjust_experience(/datum/skill/athletics, 5) //get some experience for our trouble, especially since this costs us a climbing rope use
+		user.mind?.adjust_experience(/datum/skill/athletics, round((ATHLETICS_SKILL_MISC_EXP)/(fitness_level || 1), 1)) //get some experience for our trouble, especially since this costs us a climbing rope use
 
 	QDEL_LIST(effects)
 	return ITEM_INTERACT_SUCCESS

--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -277,7 +277,8 @@
 	user.zMove(target = target, z_move_flags = ZMOVE_CHECK_PULLEDBY|ZMOVE_ALLOW_BUCKLED|ZMOVE_INCLUDE_PULLED)
 
 	if(grant_exp)
-		user.mind?.adjust_experience(/datum/skill/athletics, 10) //get a little experience for our trouble
+		var/fitness_level = user.mind?.get_skill_level(/datum/skill/athletics)
+		user.mind?.adjust_experience(/datum/skill/athletics, round(ATHLETICS_SKILL_MISC_EXP/(fitness_level || 1), 1)) //get a little experience for our trouble
 
 	if(!is_ghost)
 		show_final_fluff_message(user, ladder, going_up)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -902,7 +902,7 @@
 	var/carrydelay = 5 SECONDS //if you have latex you are faster at grabbing
 	var/skills_space
 	var/fitness_level = mind?.get_skill_level(/datum/skill/athletics) - 1
-	var/experience_reward = 5
+	var/experience_reward = ATHLETICS_SKILL_MISC_EXP
 	if(HAS_TRAIT(src, TRAIT_QUICKER_CARRY))
 		carrydelay -= 2 SECONDS
 		experience_reward *= 3
@@ -934,7 +934,7 @@
 		visible_message(span_warning("[src] fails to fireman carry [target]!"))
 		return
 
-	mind?.adjust_experience(/datum/skill/athletics, experience_reward) //Get a bit fitter every time we fireman carry successfully. Deadlift your friends for gains!
+	mind?.adjust_experience(/datum/skill/athletics, round(experience_reward/(fitness_level || 1), 1)) //Get a bit fitter every time we fireman carry successfully. Deadlift your friends for gains!
 
 	return buckle_mob(target, TRUE, TRUE, CARRIER_NEEDS_ARM)
 


### PR DESCRIPTION
Original PR: 92206
-----

## About The Pull Request

For instances of athletics gains that don't involve workout machinery/granting the exercised status effect, those sources of experience suffer from increasing diminishing returns as the person gains athletics levels.

## Why It's Good For The Game

While I still like that this lets more people engage with athletics across a round, it did unfortunately trivialize getting higher levels of athletics by doing some relatively banal activities that took really no preparation to accomplish. The intended method of getting experience should be the workout equipment, and so at a certain point these sources of experience should stop granting free levels.

If someone refuses to interact with the workout mechanics and only chooses to use these alternative methods, then uh....I guess all the more power to them but they'll be there for a while.

## Changelog
:cl:
balance: Athletics experience gain from non-workout sources, such as climbing ladders, hopping tables and rope climbing, experience diminishing returns as you gain athletics levels. To reach legendary fitness, you really should hit the gym.
/:cl:
