### PR TITLE
[TG Mirror] Fixed the nukies outpost chemical locker not having beakers inside of the beaker box [MDB IGNORE]

### DIFF
--- a/code/game/objects/items/storage/boxes/medical_boxes.dm
+++ b/code/game/objects/items/storage/boxes/medical_boxes.dm
@@ -51,7 +51,7 @@
 
 /obj/item/storage/box/beakers/big/PopulateContents()
 	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/cup/beaker/large
+		new /obj/item/reagent_containers/cup/beaker/large(src)
 
 /obj/item/storage/box/beakers/bluespace
 	name = "box of bluespace beakers"


### PR DESCRIPTION
Original PR: 92365
-----
## About The Pull Request

title

## Why It's Good For The Game

because you pay tc for chemical room + not intended

## Changelog

:cl:
fix: Fixed the nukies outpost chemical locker not having beakers inside of a beaker box
/:cl:
