### PR TITLE
[TG Mirror] Fixes an inverted ternary for determining the effect of gravity on swimmers [MDB IGNORE]

### DIFF
--- a/code/datums/elements/swimming_tile.dm
+++ b/code/datums/elements/swimming_tile.dm
@@ -60,7 +60,7 @@
 		var/effective_stamina_entry_cost = HAS_TRAIT(floater, TRAIT_STRENGTH) ? (stamina_entry_cost + clothing_weight(floater)) : ((stamina_entry_cost + clothing_weight(floater)) / 2)
 
 		//Being in high gravity doubles our effective stamina cost
-		var/gravity_modifier = floater.has_gravity() > STANDARD_GRAVITY ? 1 : 2
+		var/gravity_modifier = floater.has_gravity() > STANDARD_GRAVITY ? 2 : 1
 
 		//If our floater has a specialized spine, include that as a factor.
 		var/obj/item/organ/cyberimp/chest/spine/potential_spine = floater.get_organ_slot(ORGAN_SLOT_SPINE)
@@ -120,7 +120,7 @@
 
 	var/effective_stamina_per_interval = HAS_TRAIT(owner, TRAIT_STRENGTH) ? stamina_per_interval : (stamina_per_interval / 2)
 
-	var/gravity_modifier = owner.has_gravity() > STANDARD_GRAVITY ? 1 : 2
+	var/gravity_modifier = owner.has_gravity() > STANDARD_GRAVITY ? 2 : 1
 
 	var/under_pressure = prob(drowning_process_probability * gravity_modifier)
 


### PR DESCRIPTION
Original PR: 92369
-----

## About The Pull Request

This should be the other way around. Higher gravity means more damage but better rewards. Not less.

## Why It's Good For The Game

Oops

## Changelog
:cl:
fix: Swimming now no longer punishes you with less gains for swimming in heavy gravity, but also weirdly easier to swim in.
/:cl:
