### PR TITLE
[TG Mirror] Fixes emissive bloom being all white [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -71,7 +71,12 @@
 /// The bit of the game plane that is let alone is sent here
 #define RENDER_PLANE_GAME_UNMASKED 19
 
+
 //-------------------- Lighting ---------------------
+
+/// Main game plane to which everything renders, which then is multiplied by light
+/// Should not be lit directly as it is sourced for emissive bloom
+#define RENDER_PLANE_UNLIT_GAME 19
 
 #define RENDER_PLANE_LIGHTING 20
 


### PR DESCRIPTION
Original PR: 92376
-----

## About The Pull Request

#92357 moved base unlit game below emissives which broke bloom. It should always be directly below RENDER_PLANE_LIGHTING

## Changelog
:cl:
fix: Fixed emissive bloom being all white
/:cl:
