### PR TITLE
[TG Mirror] Fixes M90 underbarrel having its separate inaccessible firing pin [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -359,6 +359,12 @@
 	#define COMPONENT_CANCEL_SAWING_OFF (1<<0)
 #define COMSIG_GUN_SAWN_OFF "gun_sawn_off"
 
+///called in /obj/item/firing_pin/proc/gun_insert(mob/living/user, obj/item/gun/new_gun): (obj/item/firing_pin/pin, mob/living/user)
+#define COMSIG_GUN_PIN_INSERTED "gun_pin_inserted"
+
+///called in /obj/item/firing_pin/proc/gun_remove(mob/living/user): (obj/item/firing_pin/pin, mob/living/user)
+#define COMSIG_GUN_PIN_REMOVED "gun_pin_removed"
+
 // Jetpack things
 // Please kill me
 

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -148,7 +148,6 @@
 	selector_switch_icon = TRUE
 	accepted_magazine_type = /obj/item/ammo_box/magazine/m223
 	can_suppress = FALSE
-	var/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel
 	burst_size = 3
 	burst_delay = 2
 	spread = 5
@@ -156,10 +155,12 @@
 	mag_display = TRUE
 	empty_indicator = TRUE
 	fire_sound = 'sound/items/weapons/gun/smg/shot_alt.ogg'
+	/// Attached underbarrel grenade launcher
+	var/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel/underbarrel
 
 /obj/item/gun/ballistic/automatic/m90/Initialize(mapload)
 	. = ..()
-	underbarrel = new /obj/item/gun/ballistic/revolver/grenadelauncher(src)
+	underbarrel = new(src)
 	update_appearance()
 
 /obj/item/gun/ballistic/automatic/m90/Destroy()

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -1,9 +1,9 @@
 //KEEP IN MIND: These are different from gun/grenadelauncher. These are designed to shoot premade rocket and grenade projectiles, not flashbangs or chemistry casings etc.
 //Put handheld rocket launchers here if someone ever decides to make something so hilarious ~Paprika
 
-/obj/item/gun/ballistic/revolver/grenadelauncher//this is only used for underbarrel grenade launchers at the moment, but admins can still spawn it if they feel like being assholes
-	desc = "A break-operated grenade launcher."
+/obj/item/gun/ballistic/revolver/grenadelauncher
 	name = "grenade launcher"
+	desc = "A break-operated grenade launcher."
 	icon_state = "dshotgun_sawn"
 	inhand_icon_state = "gun"
 	accepted_magazine_type = /obj/item/ammo_box/magazine/internal/grenadelauncher
@@ -19,6 +19,27 @@
 	..()
 	if(istype(A, /obj/item/ammo_box) || isammocasing(A))
 		chamber_round()
+
+/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel
+	name = "underbarrel grenade launcher"
+	pin = null
+
+/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel/Initialize(mapload)
+	. = ..()
+	var/obj/item/gun/gun = loc
+	if (!istype(gun))
+		return INITIALIZE_HINT_QDEL
+	pin = gun.pin
+	RegisterSignal(gun, COMSIG_GUN_PIN_INSERTED, PROC_REF(on_pin_inserted))
+	RegisterSignal(gun, COMSIG_GUN_PIN_REMOVED, PROC_REF(on_pin_removed))
+
+/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel/proc/on_pin_inserted(obj/item/gun/source, obj/item/firing_pin/new_pin, mob/living/user)
+	SIGNAL_HANDLER
+	pin = new_pin
+
+/obj/item/gun/ballistic/revolver/grenadelauncher/underbarrel/proc/on_pin_removed(obj/item/gun/source, obj/item/firing_pin/old_pin, mob/living/user)
+	SIGNAL_HANDLER
+	pin = null
 
 /obj/item/gun/ballistic/revolver/grenadelauncher/cyborg
 	desc = "A 6-shot grenade launcher."

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -20,6 +20,11 @@
 	var/pin_removable = TRUE
 	var/obj/item/gun/gun
 
+/obj/item/firing_pin/Destroy()
+	if(gun)
+		gun_remove()
+	return ..()
+
 /obj/item/firing_pin/interact_with_atom(atom/interacting_with, mob/living/user, list/modifiers)
 	if(!isgun(interacting_with))
 		return NONE
@@ -57,10 +62,12 @@
 	gun = new_gun
 	forceMove(gun)
 	gun.pin = src
+	SEND_SIGNAL(gun, COMSIG_GUN_PIN_INSERTED, src, user)
 	return TRUE
 
 /obj/item/firing_pin/proc/gun_remove(mob/living/user)
 	gun.pin = null
+	SEND_SIGNAL(gun, COMSIG_GUN_PIN_REMOVED, src, user)
 	gun = null
 	return
 
@@ -380,9 +387,3 @@
 		playsound(src, SFX_SCREECH, 75, TRUE)
 		return FALSE
 	return TRUE
-
-/obj/item/firing_pin/Destroy()
-	if(gun)
-		gun.pin = null
-		gun = null
-	return ..()


### PR DESCRIPTION
Original PR: 92305
-----

## About The Pull Request

Underbarrel now depends on the gun's own firing pin, instead of having a separate inaccessible pin.
Closes #92292

## Changelog
:cl:
fix: Fixed M90 underbarrel having its separate inaccessible firing pin
/:cl:
