### PR TITLE
[TG Mirror] [NO GBP] Fixes multiplier applied incorrectly in `trans_to()` [MDB IGNORE]

### DIFF
--- a/code/modules/reagents/chemistry/holder/holder.dm
+++ b/code/modules/reagents/chemistry/holder/holder.dm
@@ -502,6 +502,11 @@
 			continue
 		reagents_to_remove[reagent] = transfer_amount
 		total_transfered_amount += transfered_amount
+<<<<<<< HEAD
+=======
+		reagent.volume -= transfer_amount
+		transfer_log += "[reagent.type] ([transfered_amount]u, [reagent.purity] purity)"
+>>>>>>> 6bc86d2bd45 ([NO GBP] Fixes multiplier applied incorrectly in `trans_to()` (#92404))
 
 		if(!isnull(target_id))
 			break


### PR DESCRIPTION
Original PR: 92404
-----
## About The Pull Request
- Fixes #92401

And many other reagent transfer operations who's multiplier is not 1

## Changelog
:cl:
fix: reagent transfer amounts with multiplier applied(e.g. cryotubes) have been corrected
/:cl: