### PR TITLE
[TG Mirror] Makes monster cores display above lying mobs [MDB IGNORE]

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -228,6 +228,7 @@
 #define BELOW_MOB_LAYER 3.7
 #define LOW_MOB_LAYER 3.75
 #define LYING_MOB_LAYER 3.8
+#define ABOVE_LYING_MOB_LAYER 3.85
 #define VEHICLE_LAYER 3.9
 #define MOB_BELOW_PIGGYBACK_LAYER 3.94
 //#define MOB_LAYER 4 //For easy recordkeeping; this is a byond define

--- a/code/datums/elements/above_mob_drop.dm
+++ b/code/datums/elements/above_mob_drop.dm
@@ -1,0 +1,21 @@
+/// Element that makes mob drops appear above their corpses until moved or picked up
+/datum/element/above_mob_drop
+	element_flags = ELEMENT_BESPOKE
+	argument_hash_start_idx = 2
+	/// Layer to which items are initially changed
+	var/target_layer = ABOVE_LYING_MOB_LAYER
+
+/datum/element/above_mob_drop/Attach(datum/target, target_layer = ABOVE_LYING_MOB_LAYER)
+	. = ..()
+	if (!ismovable(target))
+		return ELEMENT_INCOMPATIBLE
+	src.target_layer = target_layer
+	var/atom/movable/owner = target
+	owner.layer = target_layer
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+
+/datum/element/above_mob_drop/proc/on_moved(atom/movable/source)
+	SIGNAL_HANDLER
+	if (source.layer == target_layer)
+		source.layer = initial(source.layer)
+	Detach(source)

--- a/code/modules/mining/equipment/monster_organs/monster_organ.dm
+++ b/code/modules/mining/equipment/monster_organs/monster_organ.dm
@@ -61,6 +61,7 @@
 /obj/item/organ/monster_core/Initialize(mapload)
 	. = ..()
 	decay_timer = addtimer(CALLBACK(src, PROC_REF(go_inert)), time_to_decay, TIMER_STOPPABLE)
+	AddElement(/datum/element/above_mob_drop)
 
 /obj/item/organ/monster_core/examine(mob/user)
 	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1456,6 +1456,7 @@
 #include "code\datums\dna\blocks\dna_features_block.dm"
 #include "code\datums\dna\blocks\dna_identity_block.dm"
 #include "code\datums\elements\_element.dm"
+#include "code\datums\elements\above_mob_drop.dm"
 #include "code\datums\elements\ai_control_examine.dm"
 #include "code\datums\elements\ai_flee_while_injured.dm"
 #include "code\datums\elements\ai_held_item.dm"


### PR DESCRIPTION
Original PR: 92306
-----

## About The Pull Request

Monster cores now render above lying mobs and corpses, making them easier to grab during fights. They reset to object layer once moved or picked up to avoid visual issues.

## Why It's Good For The Game

During vent defenses when you encounter legions while low on heals you may be tempted to grab a core to buff and regen, but as they're rendered below mobs you either have to pixel hunt through a skeleton's ribs, or use right click to pick it up via the context menu. Both of these options make for a rather unpleasant experience, this should make it less painful to do.
Technically applies to other mobs as well, but I doubt that anyone is butchering monsters mid-fight for lobstrocity or brimdemon cores.

## Changelog
:cl:
qol: Monster cores now display above corpses when dropped
/:cl:
