### PR TITLE
[TG Mirror] Layers entangled mobs above spacevines [MDB IGNORE]

### DIFF
--- a/code/modules/events/space_vines/vine_mutations.dm
+++ b/code/modules/events/space_vines/vine_mutations.dm
@@ -12,6 +12,20 @@
 	holder.mutations |= src
 	holder.add_atom_colour(hue, FIXED_COLOUR_PRIORITY)
 
+/datum/spacevine_mutation/proc/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
+	SHOULD_CALL_PARENT(TRUE)
+	buckled.layer = SPACEVINE_MOB_LAYER
+	RegisterSignal(buckled, COMSIG_MOB_UNBUCKLED, PROC_REF(on_unbuckle))
+
+/datum/spacevine_mutation/proc/on_unbuckle(datum/source)
+	SHOULD_CALL_PARENT(TRUE)
+	SIGNAL_HANDLER
+	if(!isliving(source))
+		return
+	var/mob/living/buckled = source
+	buckled.layer = initial(buckled.layer)
+	UnregisterSignal(buckled, COMSIG_MOB_UNBUCKLED)
+
 /datum/spacevine_mutation/proc/process_mutation(obj/structure/spacevine/holder)
 	return
 
@@ -37,9 +51,6 @@
 	return
 
 /datum/spacevine_mutation/proc/on_spread(obj/structure/spacevine/holder, turf/target)
-	return
-
-/datum/spacevine_mutation/proc/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
 	return
 
 /datum/spacevine_mutation/proc/on_explosion(severity, target, obj/structure/spacevine/holder)
@@ -168,6 +179,7 @@
 
 /// What happens if an aggr spreading vine buckles a mob.
 /datum/spacevine_mutation/aggressive_spread/on_buckle(obj/structure/spacevine/holder, mob/living/buckled)
+	. = ..()
 	aggrospread_act(holder, buckled)
 
 /// Hurts mobs. To be used when a vine with aggressive spread mutation spreads into the mob's tile or buckles them.


### PR DESCRIPTION
Original PR: 92432
-----
## About The Pull Request
Changes a mobs layer to `SPACEVINE_MOB_LAYER` when they get tangled in spacevines. Reverts it when they unbuckle.

## Why It's Good For The Game
Makes mobs vulnerable to man-eating plants when they foolishly get entangled.
Its pretty annoying to bite buckled mobs at their moment of vulnerability when playing as venus human trap. There aren't many pixels for you to click, and you instantly destroy the spacevine structure if you miss.

## Changelog
:cl:
qol: Mobs entangled within spacevines are layered above the spacevines for as long as they stay buckled
/:cl: