### PR TITLE
[TG Mirror] Fixed echolocation/psyker [MDB IGNORE]

### DIFF
--- a/code/datums/components/echolocation.dm
+++ b/code/datums/components/echolocation.dm
@@ -127,7 +127,7 @@
 
 /datum/component/echolocation/proc/show_image(image/input_appearance, atom/input, current_time)
 	var/image/final_image = image(input_appearance)
-	//final_image.layer += FOV_EFFECT_LAYER
+	final_image.layer += EFFECTS_LAYER
 	final_image.plane = FULLSCREEN_PLANE
 	final_image.loc = images_are_static ? get_turf(input) : input
 	final_image.dir = input.dir


### PR DESCRIPTION
Original PR: 92434
-----

## About The Pull Request
Fixes bitrunning psykers. I dont really know why that one line was commented, but it seems to work fine and as intended with it. Regular psykers not blind anymore, while bitrunning ones cant see nothing but outlines.
[#91490 Makes psyker playable](https://github.com/tgstation/tgstation/pull/91490)
[#91713 psychic bitrunning domains do not show you anything](https://github.com/tgstation/tgstation/issues/91713)
## Why It's Good For The Game
Bugfix
## Changelog
:cl:
fix: Fixed bitrunning psyker
/:cl:
