### PR TITLE
[TG Mirror] Fixes portable atmospheric machines trying to add themselves to SSair queue when destroyed [MDB IGNORE]

### DIFF
--- a/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
+++ b/code/modules/atmospherics/machinery/portable/portable_atmospherics.dm
@@ -75,8 +75,10 @@
 	return ..()
 
 /obj/machinery/portable_atmospherics/Destroy()
-	disconnect()
+	disconnect(destroyed = TRUE)
 	air_contents = null
+	if(holding)
+		unregister_holding()
 	SSair.stop_processing_machine(src)
 
 	return ..()
@@ -194,12 +196,15 @@
 /**
  * Allow the portable machine to be disconnected from the connector
  */
-/obj/machinery/portable_atmospherics/proc/disconnect()
+/obj/machinery/portable_atmospherics/proc/disconnect(destroyed = FALSE)
 	if(!connected_port)
 		return FALSE
-	set_anchored(FALSE)
 	connected_port.connected_device = null
 	connected_port = null
+	if (destroyed)
+		return TRUE
+
+	set_anchored(FALSE)
 	pixel_x = 0
 	pixel_y = 0
 


### PR DESCRIPTION
Original PR: 92249
-----

## About The Pull Request

Probably shouldn't try doing that considering SSair gets particularly unhappy about a GCd object being added to its queue

## Changelog
:cl:
fix: Fixed portable atmospheric machines trying to add themselves to SSair queue when destroyed
/:cl:
