### PR TITLE
[TG Mirror] Fixes All-in-One tcomms servers not translating radio frequencies [MDB IGNORE]

### DIFF
--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -11,6 +11,49 @@
 	idle_power_usage = 0
 	/// If this mainframe can process all syndicate chatter regardless of z level
 	var/syndicate = FALSE
+	/// List of all frequencies to their name/color
+	var/static/alist/frequency_infos = alist(
+		"[FREQ_SCIENCE]" = list(
+			"name" = RADIO_CHANNEL_SCIENCE,
+			"color" = RADIO_COLOR_SCIENCE
+		),
+		"[FREQ_MEDICAL]" = list(
+			"name" = RADIO_CHANNEL_MEDICAL,
+			"color" = RADIO_COLOR_MEDICAL
+		),
+		"[FREQ_SUPPLY]" = list(
+			"name" = RADIO_CHANNEL_SUPPLY,
+			"color" = RADIO_COLOR_SUPPLY
+		),
+		"[FREQ_SERVICE]" = list(
+			"name" = RADIO_CHANNEL_SERVICE,
+			"color" = RADIO_COLOR_SERVICE
+		),
+		"[FREQ_ENTERTAINMENT]" = list(
+			"name" = RADIO_CHANNEL_ENTERTAINMENT,
+			"color" = RADIO_COLOR_ENTERTAIMENT
+		),
+		"[FREQ_COMMON]" = list(
+			"name" = RADIO_CHANNEL_COMMON,
+			"color" = RADIO_COLOR_COMMON
+		),
+		"[FREQ_AI_PRIVATE]" = list(
+			"name" = RADIO_CHANNEL_AI_PRIVATE,
+			"color" = RADIO_COLOR_AI_PRIVATE
+		),
+		"[FREQ_COMMAND]" = list(
+			"name" = RADIO_CHANNEL_COMMAND,
+			"color" = RADIO_COLOR_COMMAND
+		),
+		"[FREQ_ENGINEERING]" = list(
+			"name" = RADIO_CHANNEL_ENGINEERING,
+			"color" = RADIO_COLOR_ENGINEERING
+		),
+		"[FREQ_SECURITY]" = list(
+			"name" = RADIO_CHANNEL_SECURITY,
+			"color" = RADIO_COLOR_SECURITY
+		)
+	)
 
 /obj/machinery/telecomms/allinone/nuclear
 	name = "advanced telecommunications mainframe"
@@ -34,6 +77,11 @@
 		return
 	if(!syndicate && !(z in signal.levels) && !(RADIO_NO_Z_LEVEL_RESTRICTION in signal.levels))  // has to be syndicate or on the right level
 		return
+
+	var/freq_info = frequency_infos["[signal.frequency]"]
+	if(freq_info)
+		signal.data["frequency_name"] = freq_info["name"]
+		signal.data["frequency_color"] = freq_info["color"]
 
 	// Decompress the signal and mark it done
 	if(syndicate)


### PR DESCRIPTION
Original PR: 92320
-----

## About The Pull Request

This is bad

<img width="283" height="126" alt="image" src="https://github.com/user-attachments/assets/75aa07a9-6e38-40bd-8a3c-cda9431ca961" />

I know this is ugly as sin, but the only alternative is singleton frequencies which will require rewriting our tcomms server UI so this should do it for now, hopefully. (Could also maybe just spawn tcomms server presets and |= their frequencies to ours?)

## Changelog
:cl:
fix: Fixed All-in-One tcomms servers not translating radio frequencies
/:cl:
