### PR TITLE
[TG Mirror] Fixes random runtimes from RPD usage [MDB IGNORE]

### DIFF
--- a/code/modules/atmospherics/machinery/components/components_base.dm
+++ b/code/modules/atmospherics/machinery/components/components_base.dm
@@ -71,7 +71,7 @@
 	underlays.Cut()
 
 	color = null
-	var/uncovered_turf = HAS_TRAIT(loc, TRAIT_UNCOVERED_TURF)
+	var/uncovered_turf = loc && HAS_TRAIT(loc, TRAIT_UNCOVERED_TURF)
 	SET_PLANE_IMPLICIT(src, (underfloor_state == UNDERFLOOR_INTERACTABLE && !uncovered_turf) ? GAME_PLANE : FLOOR_PLANE)
 
 	// Layer is handled in update_layer()
@@ -112,7 +112,7 @@
 
 /obj/machinery/atmospherics/components/get_pipe_image(iconfile, iconstate, direction, color, piping_layer, trinary)
 	var/mutable_appearance/pipe_appearance = ..()
-	if (underfloor_state == UNDERFLOOR_VISIBLE || HAS_TRAIT(loc, TRAIT_UNCOVERED_TURF))
+	if (underfloor_state == UNDERFLOOR_VISIBLE || (loc && HAS_TRAIT(loc, TRAIT_UNCOVERED_TURF)))
 		pipe_appearance.layer = BELOW_CATWALK_LAYER + get_pipe_layer_offset()
 		SET_PLANE_EXPLICIT(pipe_appearance, FLOOR_PLANE, src)
 	return pipe_appearance


### PR DESCRIPTION
Original PR: 92246
-----

## About The Pull Request

SSair inits some pipes for its directional cache when RPD is used which runtimes when atmos components  try to update their icon due to assuming they have a loc while being nullspaced.

## Changelog
:cl:
fix: Fixed RPD causing runtimes when placing atmos components for the first time.
/:cl:
