### PR TITLE
[TG Mirror] Carp Rifts ignore telekinesis-controlled objects [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/space_dragon/carp_rift.dm
+++ b/code/modules/antagonists/space_dragon/carp_rift.dm
@@ -278,6 +278,21 @@
 		update_light()
 	return TRUE
 
+/obj/structure/carp_rift/attackby(obj/item/attacking_item, mob/user, list/modifiers, list/attack_modifiers)
+	if(HAS_TRAIT(attacking_item, TRAIT_TELEKINESIS_CONTROLLED))
+		if(user)
+			to_chat(user, span_warning("The gravitational field of [src] interferes with the telekenetic control of [user], nullifying the hit!"))
+		return FALSE
+	. = ..()
+
+/obj/structure/carp_rift/hitby(atom/movable/hit_by, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
+	if(HAS_TRAIT(hit_by, TRAIT_TELEKINESIS_CONTROLLED))
+		var/mob/thrower = throwingdatum.thrower.resolve()
+		if(thrower && ismob(thrower))
+			to_chat(thrower, span_warning("The gravitational field of [src] interferes with the telekenetic control of [hit_by], nullifying the hit!"))
+		return
+	. = ..()
+
 #undef CHARGE_ONGOING
 #undef CHARGE_FINALWARNING
 #undef CHARGE_COMPLETED


### PR DESCRIPTION
Original PR: 92180
-----
## About The Pull Request

Dragon rifts no longer take damage from telekinesis objects.
## Why It's Good For The Game

Telekinesis is way too oppressive against dragons. With how most maps are laid out, you'll always have the opportunity to destroy the (surprisingly weak) carp portal from behind a window or airlock. If not, you can just wait until the dragon is distracted with fighting off the entire crew and smash it from a safe distance.

The way I see it, TK users sit amongst the highest priority considerations for a Dragon. This sucks. Other priorities (mechs, renegade ordnance scientists, assistant with an esword and a dream) are more overtly threatening, and make sure there's enough conflict to keep things interesting. Standing at a distance and whittling down a portal while everyone is busy fighting is not interesting for anyone involved, even the guy doing it.

Oh, also, you can bolt down a portal from 15 tiles away if you get it on the alt-click menu. Seen this one get used a few times. I try to avoid swearing in my balance PRs, but I think this one is a bit bullshit.

https://github.com/user-attachments/assets/a4eb6b64-6b63-41ed-ae55-35880d98a5b6
## Changelog
:cl: Rhials
balance: Dragon rifts no longer take damage from telekinesis-ed objects. Get in there and fight like a man!
/:cl:
