### PR TITLE
[TG Mirror] Fixes the issue of usr pointing to admins by making Trigger pass down clicker [MDB IGNORE]

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -666,7 +666,7 @@ GLOBAL_LIST_INIT(achievements_unlocked, list())
 	button_icon_state = "round_end"
 	show_to_observers = FALSE
 
-/datum/action/report/Trigger(trigger_flags)
+/datum/action/report/Trigger(mob/clicker, trigger_flags)
 	if(owner && GLOB.common_report && SSticker.current_state == GAME_STATE_FINISHED)
 		SSticker.show_roundend_report(owner.client)
 

--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -68,7 +68,7 @@
 	var/trigger_flags
 	if(LAZYACCESS(modifiers, RIGHT_CLICK))
 		trigger_flags |= TRIGGER_SECONDARY_ACTION
-	linked_action.Trigger(trigger_flags = trigger_flags)
+	linked_action.Trigger(usr, trigger_flags = trigger_flags)
 	return TRUE
 
 // Entered and Exited won't fire while you're dragging something, because you're still "holding" it

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -461,7 +461,7 @@ SUBSYSTEM_DEF(vote)
 /datum/action/vote/IsAvailable(feedback = FALSE)
 	return TRUE // Democracy is always available to the free people
 
-/datum/action/vote/Trigger(trigger_flags)
+/datum/action/vote/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -162,7 +162,7 @@
 
 /// Actually triggers the effects of the action.
 /// Called when the on-screen button is clicked, for example.
-/datum/action/proc/Trigger(trigger_flags)
+/datum/action/proc/Trigger(mob/clicker, trigger_flags)
 	if(!(trigger_flags & TRIGGER_FORCE_AVAILABLE) && !IsAvailable(feedback = TRUE))
 		return FALSE
 	if(SEND_SIGNAL(src, COMSIG_ACTION_TRIGGER, src) & COMPONENT_ACTION_BLOCK_TRIGGER)

--- a/code/datums/actions/cooldown_action.dm
+++ b/code/datums/actions/cooldown_action.dm
@@ -215,14 +215,14 @@
 	for(var/datum/action/cooldown/cd_action in owner.actions)
 		cd_action.disable()
 
-/datum/action/cooldown/Trigger(trigger_flags, atom/target)
+/datum/action/cooldown/Trigger(mob/clicker, trigger_flags, atom/target)
 	. = ..()
 	if(!.)
 		return FALSE
 	if(!owner)
 		return FALSE
 
-	var/mob/user = usr || owner
+	var/mob/user = clicker || owner
 
 	// If our cooldown action is a click_to_activate action:
 	// The actual action is activated on whatever the user clicks on -

--- a/code/datums/actions/innate_action.dm
+++ b/code/datums/actions/innate_action.dm
@@ -12,7 +12,7 @@
 	/// If we're a click action, the text shown on disable
 	var/disable_text
 
-/datum/action/innate/Trigger(trigger_flags)
+/datum/action/innate/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return FALSE
 	// We're a click action, trigger just sets it as active or not

--- a/code/datums/actions/item_action.dm
+++ b/code/datums/actions/item_action.dm
@@ -23,7 +23,7 @@
 		else
 			qdel(GetComponent(/datum/component/action_item_overlay))
 
-/datum/action/item_action/Trigger(trigger_flags)
+/datum/action/item_action/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/datums/actions/mobs/adjust_vision.dm
+++ b/code/datums/actions/mobs/adjust_vision.dm
@@ -30,7 +30,7 @@
 	UnregisterSignal(remove_from, COMSIG_MOB_UPDATE_SIGHT)
 	. = ..()
 
-/datum/action/adjust_vision/Trigger(trigger_flags)
+/datum/action/adjust_vision/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/datums/actions/mobs/personality_commune.dm
+++ b/code/datums/actions/mobs/personality_commune.dm
@@ -22,7 +22,7 @@
 
 	return ..()
 
-/datum/action/personality_commune/Trigger(trigger_flags)
+/datum/action/personality_commune/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -24,7 +24,7 @@
 	button_icon_state = "neckchop"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
 
-/datum/action/neck_chop/Trigger(trigger_flags)
+/datum/action/neck_chop/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
@@ -43,7 +43,7 @@
 	button_icon_state = "legsweep"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
 
-/datum/action/leg_sweep/Trigger(trigger_flags)
+/datum/action/leg_sweep/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
@@ -62,7 +62,7 @@
 	button_icon_state = "lungpunch"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
 
-/datum/action/lung_punch/Trigger(trigger_flags)
+/datum/action/lung_punch/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/datums/martial/wrestling.dm
+++ b/code/datums/martial/wrestling.dm
@@ -72,7 +72,7 @@ If you make a derivative work from this code, you must include this notification
 	button_icon_state = "wrassle_slam"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
 
-/datum/action/slam/Trigger(trigger_flags)
+/datum/action/slam/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
@@ -85,7 +85,7 @@ If you make a derivative work from this code, you must include this notification
 	button_icon_state = "wrassle_throw"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
 
-/datum/action/throw_wrassle/Trigger(trigger_flags)
+/datum/action/throw_wrassle/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
@@ -98,7 +98,7 @@ If you make a derivative work from this code, you must include this notification
 	button_icon_state = "wrassle_kick"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_CONSCIOUS // This is supposed to be usable while cuffed but it probably isn't
 
-/datum/action/kick/Trigger(trigger_flags)
+/datum/action/kick/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
@@ -111,7 +111,7 @@ If you make a derivative work from this code, you must include this notification
 	button_icon_state = "wrassle_strike"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED|AB_CHECK_CONSCIOUS
 
-/datum/action/strike/Trigger(trigger_flags)
+/datum/action/strike/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
@@ -124,7 +124,7 @@ If you make a derivative work from this code, you must include this notification
 	button_icon_state = "wrassle_drop"
 	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_HANDS_BLOCKED
 
-/datum/action/drop/Trigger(trigger_flags)
+/datum/action/drop/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/datums/mutations/tongue_spike.dm
+++ b/code/datums/mutations/tongue_spike.dm
@@ -159,7 +159,7 @@
 	if(!istype(target, /obj/item/hardened_spike/chem))
 		qdel(src)
 
-/datum/action/send_chems/Trigger(trigger_flags)
+/datum/action/send_chems/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -196,7 +196,7 @@ GLOBAL_LIST(admin_objective_list) //Prefilled admin assignable objective list
 	button_icon = 'icons/obj/devices/tracker.dmi'
 	button_icon_state = "beacon"
 
-/datum/action/special_equipment_fallback/Trigger(trigger_flags)
+/datum/action/special_equipment_fallback/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -681,7 +681,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	button_icon = 'icons/mob/actions/actions_mecha.dmi'
 	button_icon_state = "mech_cycle_equip_off"
 
-/datum/action/turret_toggle/Trigger(trigger_flags)
+/datum/action/turret_toggle/Trigger(mob/clicker, trigger_flags)
 	var/obj/machinery/porta_turret/P = target
 	if(!istype(P))
 		return
@@ -692,7 +692,7 @@ DEFINE_BITFIELD(turret_flags, list(
 	button_icon = 'icons/mob/actions/actions_mecha.dmi'
 	button_icon_state = "mech_eject"
 
-/datum/action/turret_quit/Trigger(trigger_flags)
+/datum/action/turret_quit/Trigger(mob/clicker, trigger_flags)
 	var/obj/machinery/porta_turret/P = target
 	if(!istype(P))
 		return

--- a/code/game/objects/structures/gym/weight_machine_action.dm
+++ b/code/game/objects/structures/gym/weight_machine_action.dm
@@ -15,7 +15,7 @@
 		return FALSE
 	return TRUE
 
-/datum/action/push_weights/Trigger(trigger_flags)
+/datum/action/push_weights/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/modules/admin/verbs/light_debug.dm
+++ b/code/modules/admin/verbs/light_debug.dm
@@ -357,7 +357,7 @@ GLOBAL_LIST_EMPTY(light_debugged_atoms)
 	SIGNAL_HANDLER
 	Grant(new_mob)
 
-/datum/action/spawn_light/Trigger(trigger_flags)
+/datum/action/spawn_light/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	ui_interact(usr)
 

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -123,8 +123,8 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 /datum/antagonist/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
-	if(. || isobserver(ui.user))
-		return
+	if(. || ui.user != owner.current)
+		return FALSE
 	switch(action)
 		if("change_objectives")
 			submit_player_objective()
@@ -155,12 +155,12 @@ GLOBAL_LIST_EMPTY(antagonists)
 	. = ..()
 	name = "Open [target] Information:"
 
-/datum/action/antag_info/Trigger(trigger_flags)
+/datum/action/antag_info/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
 
-	target.ui_interact(usr || owner)
+	target.ui_interact(clicker || owner)
 
 /datum/action/antag_info/IsAvailable(feedback = FALSE)
 	if(!target)

--- a/code/modules/antagonists/changeling/cellular_emporium.dm
+++ b/code/modules/antagonists/changeling/cellular_emporium.dm
@@ -99,7 +99,7 @@
 		stack_trace("cellular_emporium action created with non-emporium.")
 		qdel(src)
 
-/datum/action/cellular_emporium/Trigger(trigger_flags)
+/datum/action/cellular_emporium/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -44,7 +44,7 @@ the same goes for Remove(). if you override Remove(), call parent or else your p
 /datum/action/changeling/proc/on_purchase(mob/user, is_respec)
 	Grant(user)//how powers are added rather than the checks in mob.dm
 
-/datum/action/changeling/Trigger(trigger_flags)
+/datum/action/changeling/Trigger(mob/clicker, trigger_flags)
 	var/mob/user = owner
 	if(!user || !IS_CHANGELING(user))
 		return

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -2,7 +2,7 @@
 	name = "Tiny Prick"
 	desc = "Stabby stabby"
 
-/datum/action/changeling/sting/Trigger(trigger_flags)
+/datum/action/changeling/sting/Trigger(mob/clicker, trigger_flags)
 	var/mob/user = owner
 	if(!user || !user.mind)
 		return

--- a/code/modules/antagonists/heretic/heretic_living_heart.dm
+++ b/code/modules/antagonists/heretic/heretic_living_heart.dm
@@ -101,7 +101,7 @@
 
 	return TRUE
 
-/datum/action/cooldown/track_target/Trigger(trigger_flags, atom/target)
+/datum/action/cooldown/track_target/Trigger(mob/clicker, trigger_flags, atom/target)
 	right_clicked = !!(trigger_flags & TRIGGER_SECONDARY_ACTION)
 	return ..()
 

--- a/code/modules/antagonists/heretic/status_effects/buffs.dm
+++ b/code/modules/antagonists/heretic/status_effects/buffs.dm
@@ -35,7 +35,7 @@
 	button_icon = 'icons/obj/antags/eldritch.dmi'
 	button_icon_state = "crucible_soul"
 
-/datum/action/cancel_crucible_soul/Trigger(trigger_flags)
+/datum/action/cancel_crucible_soul/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/antagonists/malf_ai/malf_ai_modules.dm
+++ b/code/modules/antagonists/malf_ai/malf_ai_modules.dm
@@ -83,7 +83,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/ai_module/malf))
 		return FALSE
 	. = ..()
 
-/datum/action/innate/ai/Trigger(trigger_flags)
+/datum/action/innate/ai/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(auto_use_uses)
 		adjust_uses(-1)

--- a/code/modules/antagonists/spy/spy.dm
+++ b/code/modules/antagonists/spy/spy.dm
@@ -224,7 +224,7 @@
 		stack_trace("[type] created on invalid target [Target || "null"]")
 		qdel(src)
 
-/datum/action/backup_uplink/Trigger(trigger_flags)
+/datum/action/backup_uplink/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/bitrunning/abilities.dm
+++ b/code/modules/bitrunning/abilities.dm
@@ -31,7 +31,7 @@
 	. = ..()
 	name = "Open Domain Information"
 
-/datum/action/avatar_domain_info/Trigger(trigger_flags)
+/datum/action/avatar_domain_info/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/clothing/chameleon/_chameleon_outfit.dm
+++ b/code/modules/clothing/chameleon/_chameleon_outfit.dm
@@ -31,7 +31,7 @@
 
 	return standard_outfit_options
 
-/datum/action/chameleon_outfit/Trigger(trigger_flags)
+/datum/action/chameleon_outfit/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!. || applying)
 		return

--- a/code/modules/library/skill_learning/generic_skillchips/point.dm
+++ b/code/modules/library/skill_learning/generic_skillchips/point.dm
@@ -53,7 +53,7 @@
 	. = ..()
 	arrow_overlay = null
 
-/datum/action/change_pointer_color/Trigger(trigger_flags)
+/datum/action/change_pointer_color/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/mapfluff/ruins/spaceruin_code/hilbertshotel.dm
@@ -378,7 +378,7 @@ GLOBAL_VAR_INIT(hhMysteryRoomNumber, rand(1, 999999))
 	desc = "Stop looking through the bluespace peephole."
 	button_icon_state = "cancel_peephole"
 
-/datum/action/peephole_cancel/Trigger(trigger_flags)
+/datum/action/peephole_cancel/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	to_chat(owner, span_warning("You move away from the peephole."))
 	owner.reset_perspective()

--- a/code/modules/mining/lavaland/mining_loot/megafauna/colossus.dm
+++ b/code/modules/mining/lavaland/mining_loot/megafauna/colossus.dm
@@ -417,7 +417,7 @@
 /datum/action/exit_possession/IsAvailable(feedback = FALSE)
 	return ..() && isfloorturf(owner.loc)
 
-/datum/action/exit_possession/Trigger(trigger_flags)
+/datum/action/exit_possession/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/modules/mining/lavaland/mining_loot/megafauna/the_thing.dm
+++ b/code/modules/mining/lavaland/mining_loot/megafauna/the_thing.dm
@@ -4,7 +4,7 @@
 	button_icon = 'icons/mob/actions/actions_AI.dmi'
 	button_icon_state = "ai_core"
 
-/datum/action/innate/brain_undeployment/Trigger(trigger_flags)
+/datum/action/innate/brain_undeployment/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return FALSE
 	var/obj/item/organ/brain/cybernetic/ai/shell_to_disconnect = owner.get_organ_by_type(/obj/item/organ/brain/cybernetic/ai)

--- a/code/modules/mob/living/basic/bots/repairbot/repairbot_abilities.dm
+++ b/code/modules/mob/living/basic/bots/repairbot/repairbot_abilities.dm
@@ -53,7 +53,7 @@
 		/obj/item/stack/rods,
 	))
 
-/datum/action/repairbot_resources/Trigger(trigger_flags)
+/datum/action/repairbot_resources/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/living/basic/clown/clown.dm
+++ b/code/modules/mob/living/basic/clown/clown.dm
@@ -622,7 +622,7 @@
 	///If we are currently activating our ability.
 	var/activating = FALSE
 
-/datum/action/cooldown/exquisite_bunch/Trigger(trigger_flags, atom/target)
+/datum/action/cooldown/exquisite_bunch/Trigger(mob/clicker, trigger_flags, atom/target)
 	if(activating)
 		return
 	var/bunch_turf = get_step(owner.loc, owner.dir)

--- a/code/modules/mob/living/basic/guardian/guardian_types/standard.dm
+++ b/code/modules/mob/living/basic/guardian/guardian_types/standard.dm
@@ -54,7 +54,7 @@
 		return FALSE
 	return ..()
 
-/datum/action/select_guardian_battlecry/Trigger(trigger_flags)
+/datum/action/select_guardian_battlecry/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if (!.)
 		return

--- a/code/modules/mob/living/basic/pets/gondolas/gondolapod.dm
+++ b/code/modules/mob/living/basic/pets/gondolas/gondolapod.dm
@@ -70,7 +70,7 @@
 	button_icon_state = "arrow"
 	check_flags = AB_CHECK_PHASED
 
-/datum/action/innate/deliver_gondola_package/Trigger(trigger_flags)
+/datum/action/innate/deliver_gondola_package/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
@@ -90,7 +90,7 @@
 	button_icon_state = "storage"
 	check_flags = AB_CHECK_PHASED
 
-/datum/action/innate/check_gondola_contents/Trigger(trigger_flags)
+/datum/action/innate/check_gondola_contents/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/living/basic/trader/trader_actions.dm
+++ b/code/modules/mob/living/basic/trader/trader_actions.dm
@@ -34,7 +34,7 @@
 	src.shop_sound = sell_sound
 	src.opening_lines = opening_lines
 
-/datum/action/setup_shop/Trigger(trigger_flags)
+/datum/action/setup_shop/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -989,7 +989,7 @@
 	button_icon = 'icons/mob/actions/actions_AI.dmi'
 	button_icon_state = "ai_shell"
 
-/datum/action/innate/deploy_shell/Trigger(trigger_flags)
+/datum/action/innate/deploy_shell/Trigger(mob/clicker, trigger_flags)
 	var/mob/living/silicon/ai/AI = owner
 	if(!AI)
 		return
@@ -1002,7 +1002,7 @@
 	button_icon_state = "ai_last_shell"
 	var/mob/living/silicon/robot/last_used_shell
 
-/datum/action/innate/deploy_last_shell/Trigger(trigger_flags)
+/datum/action/innate/deploy_last_shell/Trigger(mob/clicker, trigger_flags)
 	if(!owner)
 		return
 	if(last_used_shell)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -908,7 +908,7 @@
 	button_icon = 'icons/mob/actions/actions_AI.dmi'
 	button_icon_state = "ai_core"
 
-/datum/action/innate/undeployment/Trigger(trigger_flags)
+/datum/action/innate/undeployment/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return FALSE
 	var/mob/living/silicon/robot/shell_to_disconnect = owner

--- a/code/modules/mob/living/silicon/robot/robot_model.dm
+++ b/code/modules/mob/living/silicon/robot/robot_model.dm
@@ -490,7 +490,7 @@
 		return FALSE
 	return ..()
 
-/datum/action/toggle_buffer/Trigger(trigger_flags)
+/datum/action/toggle_buffer/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/mob/living/simple_animal/hostile/ooze.dm
+++ b/code/modules/mob/living/simple_animal/hostile/ooze.dm
@@ -221,7 +221,7 @@
 	RegisterSignal(owner, COMSIG_LIVING_DEATH, PROC_REF(stop_consuming))
 
 ///Try to consume the pulled mob
-/datum/action/consume/Trigger(trigger_flags)
+/datum/action/consume/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/pai/actions.dm
+++ b/code/modules/pai/actions.dm
@@ -3,7 +3,7 @@
 	button_icon = 'icons/mob/actions/actions_silicon.dmi'
 	var/mob/living/silicon/pai/pai_owner
 
-/datum/action/innate/pai/Trigger(trigger_flags)
+/datum/action/innate/pai/Trigger(mob/clicker, trigger_flags)
 	if(!ispAI(owner))
 		return FALSE
 	pai_owner = owner
@@ -14,7 +14,7 @@
 	background_icon_state = "bg_tech"
 	overlay_icon_state = "bg_tech_border"
 
-/datum/action/innate/pai/software/Trigger(trigger_flags)
+/datum/action/innate/pai/software/Trigger(mob/clicker, trigger_flags)
 	..()
 	pai_owner.ui_act()
 
@@ -24,7 +24,7 @@
 	background_icon_state = "bg_tech"
 	overlay_icon_state = "bg_tech_border"
 
-/datum/action/innate/pai/shell/Trigger(trigger_flags)
+/datum/action/innate/pai/shell/Trigger(mob/clicker, trigger_flags)
 	..()
 	if(pai_owner.holoform)
 		pai_owner.fold_in(0)
@@ -37,7 +37,7 @@
 	background_icon_state = "bg_tech"
 	overlay_icon_state = "bg_tech_border"
 
-/datum/action/innate/pai/chassis/Trigger(trigger_flags)
+/datum/action/innate/pai/chassis/Trigger(mob/clicker, trigger_flags)
 	..()
 	pai_owner.choose_chassis()
 
@@ -47,7 +47,7 @@
 	background_icon_state = "bg_tech"
 	overlay_icon_state = "bg_tech_border"
 
-/datum/action/innate/pai/rest/Trigger(trigger_flags)
+/datum/action/innate/pai/rest/Trigger(mob/clicker, trigger_flags)
 	..()
 	pai_owner.toggle_resting()
 
@@ -58,7 +58,7 @@
 	background_icon_state = "bg_tech"
 	overlay_icon_state = "bg_tech_border"
 
-/datum/action/innate/pai/light/Trigger(trigger_flags)
+/datum/action/innate/pai/light/Trigger(mob/clicker, trigger_flags)
 	..()
 	pai_owner.toggle_integrated_light()
 
@@ -68,7 +68,7 @@
 	background_icon_state = "bg_tech"
 	overlay_icon_state = "bg_tech_border"
 
-/datum/action/innate/pai/messenger/Trigger(trigger_flags)
+/datum/action/innate/pai/messenger/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	var/obj/item/pai_card/pai_holder = owner.loc
 	if(!istype(pai_holder.loc, /obj/item/modular_computer))

--- a/code/modules/vehicles/mecha/combat/justice.dm
+++ b/code/modules/vehicles/mecha/combat/justice.dm
@@ -594,7 +594,7 @@
 	make_visible()
 	build_all_button_icons(UPDATE_BUTTON_STATUS)
 
-/datum/action/vehicle/sealed/mecha/invisibility/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/invisibility/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/vehicles/mecha/combat/marauder.dm
+++ b/code/modules/vehicles/mecha/combat/marauder.dm
@@ -58,7 +58,7 @@
 	name = "Smoke"
 	button_icon_state = "mech_smoke"
 
-/datum/action/vehicle/sealed/mecha/mech_smoke/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_smoke/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))
@@ -72,7 +72,7 @@
 	name = "Zoom"
 	button_icon_state = "mech_zoom_off"
 
-/datum/action/vehicle/sealed/mecha/mech_zoom/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_zoom/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!owner.client || !chassis || !(owner in chassis.occupants))

--- a/code/modules/vehicles/mecha/combat/phazon.dm
+++ b/code/modules/vehicles/mecha/combat/phazon.dm
@@ -41,7 +41,7 @@
 	name = "Reconfigure arm microtool arrays"
 	button_icon_state = "mech_damtype_brute"
 
-/datum/action/vehicle/sealed/mecha/mech_switch_damtype/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_switch_damtype/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))
@@ -66,7 +66,7 @@
 	name = "Toggle Phasing"
 	button_icon_state = "mech_phasing_off"
 
-/datum/action/vehicle/sealed/mecha/mech_toggle_phasing/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_toggle_phasing/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))

--- a/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
+++ b/code/modules/vehicles/mecha/combat/savannah_ivanov.dm
@@ -80,7 +80,7 @@
 	///skyfall builds up in charges every 2 seconds, when it reaches 5 charges the ability actually starts
 	var/skyfall_charge_level = 0
 
-/datum/action/vehicle/sealed/mecha/skyfall/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/skyfall/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!owner || !chassis || !(owner in chassis.occupants))
@@ -252,7 +252,7 @@
 		end_missile_targeting()
 	return ..()
 
-/datum/action/vehicle/sealed/mecha/ivanov_strike/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/ivanov_strike/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))

--- a/code/modules/vehicles/mecha/mecha_actions.dm
+++ b/code/modules/vehicles/mecha/mecha_actions.dm
@@ -23,7 +23,7 @@
 	name = "Eject From Mech"
 	button_icon_state = "mech_eject"
 
-/datum/action/vehicle/sealed/mecha/mech_eject/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_eject/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))
@@ -35,7 +35,7 @@
 	button_icon_state = "mech_cabin_open"
 	desc = "Airtight cabin preserves internal air and can be pressurized with a mounted air tank."
 
-/datum/action/vehicle/sealed/mecha/mech_toggle_cabin_seal/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_toggle_cabin_seal/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))
@@ -46,7 +46,7 @@
 	name = "Toggle Lights"
 	button_icon_state = "mech_lights_off"
 
-/datum/action/vehicle/sealed/mecha/mech_toggle_lights/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_toggle_lights/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))
@@ -57,7 +57,7 @@
 	name = "View Stats"
 	button_icon_state = "mech_view_stats"
 
-/datum/action/vehicle/sealed/mecha/mech_view_stats/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_view_stats/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))
@@ -73,7 +73,7 @@
 	. = ..()
 	RegisterSignal(chassis, COMSIG_MECH_SAFETIES_TOGGLE, PROC_REF(update_action_icon))
 
-/datum/action/vehicle/sealed/mecha/mech_toggle_safeties/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_toggle_safeties/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))
@@ -93,7 +93,7 @@
 	name = "Toggle Strafing. Disabled when Alt is held."
 	button_icon_state = "strafe"
 
-/datum/action/vehicle/sealed/mecha/strafe/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/strafe/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))
@@ -123,7 +123,7 @@
 	name = "Switch Seats"
 	button_icon_state = "mech_seat_swap"
 
-/datum/action/vehicle/sealed/mecha/swap_seat/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/swap_seat/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))

--- a/code/modules/vehicles/mecha/working/clarke.dm
+++ b/code/modules/vehicles/mecha/working/clarke.dm
@@ -120,7 +120,7 @@
 	button_icon = 'icons/obj/devices/mecha_equipment.dmi'
 	button_icon_state = "mecha_sleeper_miner"
 
-/datum/action/vehicle/sealed/mecha/clarke_scoop_body/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/clarke_scoop_body/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	var/obj/item/mecha_parts/mecha_equipment/sleeper/clarke/sleeper = locate() in chassis
@@ -139,7 +139,7 @@
 	button_icon_state = "mech_search_ruins"
 	COOLDOWN_DECLARE(search_cooldown)
 
-/datum/action/vehicle/sealed/mecha/mech_search_ruins/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/mecha/mech_search_ruins/Trigger(mob/clicker, trigger_flags)
 	if(!..())
 		return
 	if(!chassis || !(owner in chassis.occupants))

--- a/code/modules/vehicles/vehicle_actions.dm
+++ b/code/modules/vehicles/vehicle_actions.dm
@@ -209,7 +209,7 @@
 	desc = "Climb out of your vehicle!"
 	button_icon_state = "car_eject"
 
-/datum/action/vehicle/sealed/climb_out/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/climb_out/Trigger(mob/clicker, trigger_flags)
 	if(..() && istype(vehicle_entered_target))
 		vehicle_entered_target.mob_try_exit(owner, owner)
 
@@ -221,7 +221,7 @@
 	desc = "Take your key out of the vehicle's ignition."
 	button_icon_state = "car_removekey"
 
-/datum/action/vehicle/sealed/remove_key/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/remove_key/Trigger(mob/clicker, trigger_flags)
 	vehicle_entered_target.remove_key(owner)
 
 //CLOWN CAR ACTION DATUMS
@@ -231,7 +231,7 @@
 	button_icon_state = "car_horn"
 	var/hornsound = 'sound/items/carhorn.ogg'
 
-/datum/action/vehicle/sealed/horn/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/horn/Trigger(mob/clicker, trigger_flags)
 	if(TIMER_COOLDOWN_RUNNING(src, COOLDOWN_CAR_HONK))
 		return
 	TIMER_COOLDOWN_START(src, COOLDOWN_CAR_HONK, 2 SECONDS)
@@ -247,7 +247,7 @@
 	desc = "Turn on your brights!"
 	button_icon_state = "car_headlights"
 
-/datum/action/vehicle/sealed/headlights/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/headlights/Trigger(mob/clicker, trigger_flags)
 	to_chat(owner, span_notice("You flip the switch for the vehicle's headlights."))
 	vehicle_entered_target.headlights_toggle = !vehicle_entered_target.headlights_toggle
 	vehicle_entered_target.set_light_on(vehicle_entered_target.headlights_toggle)
@@ -259,7 +259,7 @@
 	desc = "Dump all objects and people in your car on the floor."
 	button_icon_state = "car_dump"
 
-/datum/action/vehicle/sealed/dump_kidnapped_mobs/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/dump_kidnapped_mobs/Trigger(mob/clicker, trigger_flags)
 	vehicle_entered_target.visible_message(span_danger("[vehicle_entered_target] starts dumping the people inside of it."))
 	vehicle_entered_target.dump_specific_mobs(VEHICLE_CONTROL_KIDNAPPED)
 
@@ -269,7 +269,7 @@
 	desc = "Press one of those colorful buttons on your display panel!"
 	button_icon_state = "car_rtd"
 
-/datum/action/vehicle/sealed/roll_the_dice/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/roll_the_dice/Trigger(mob/clicker, trigger_flags)
 	if(!istype(vehicle_entered_target, /obj/vehicle/sealed/car/clowncar))
 		return
 	var/obj/vehicle/sealed/car/clowncar/C = vehicle_entered_target
@@ -280,7 +280,7 @@
 	desc = "Destroy them with their own fodder!"
 	button_icon_state = "car_cannon"
 
-/datum/action/vehicle/sealed/cannon/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/cannon/Trigger(mob/clicker, trigger_flags)
 	if(!istype(vehicle_entered_target, /obj/vehicle/sealed/car/clowncar))
 		return
 	var/obj/vehicle/sealed/car/clowncar/C = vehicle_entered_target
@@ -294,7 +294,7 @@
 	COOLDOWN_DECLARE(thank_time_cooldown)
 
 
-/datum/action/vehicle/sealed/thank/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/thank/Trigger(mob/clicker, trigger_flags)
 	if(!istype(vehicle_entered_target, /obj/vehicle/sealed/car/clowncar))
 		return
 	if(!COOLDOWN_FINISHED(src, thank_time_cooldown))
@@ -317,7 +317,7 @@
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_INCAPACITATED
 	var/bell_cooldown
 
-/datum/action/vehicle/ridden/wheelchair/bell/Trigger(trigger_flags)
+/datum/action/vehicle/ridden/wheelchair/bell/Trigger(mob/clicker, trigger_flags)
 	if(TIMER_COOLDOWN_RUNNING(src, bell_cooldown))
 		return
 	TIMER_COOLDOWN_START(src, bell_cooldown, 0.5 SECONDS)
@@ -330,7 +330,7 @@
 	button_icon_state = "skateboard_ollie"
 	check_flags = AB_CHECK_CONSCIOUS
 
-/datum/action/vehicle/ridden/scooter/skateboard/ollie/Trigger(trigger_flags)
+/datum/action/vehicle/ridden/scooter/skateboard/ollie/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	if(!.)
 		return
@@ -375,7 +375,7 @@
 	button_icon_state = "skateboard_ollie"
 	check_flags = AB_CHECK_CONSCIOUS
 
-/datum/action/vehicle/ridden/scooter/skateboard/kickflip/Trigger(trigger_flags)
+/datum/action/vehicle/ridden/scooter/skateboard/kickflip/Trigger(mob/clicker, trigger_flags)
 	var/obj/vehicle/ridden/scooter/skateboard/board = vehicle_target
 	var/mob/living/rider = owner
 
@@ -424,7 +424,7 @@
 	var/sound_path = 'sound/items/carhorn.ogg'
 	var/sound_message = "makes a sound."
 
-/datum/action/vehicle/sealed/noise/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/noise/Trigger(mob/clicker, trigger_flags)
 	var/obj/vehicle/sealed/car/vim/vim_mecha = vehicle_entered_target
 	if(!COOLDOWN_FINISHED(vim_mecha, sound_cooldown))
 		vim_mecha.balloon_alert(owner, "on cooldown!")
@@ -441,7 +441,7 @@
 	sound_path = 'sound/machines/chime.ogg'
 	sound_message = "chimes!"
 
-/datum/action/vehicle/sealed/noise/chime/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/noise/chime/Trigger(mob/clicker, trigger_flags)
 	if(..())
 		SEND_SIGNAL(vehicle_entered_target, COMSIG_VIM_CHIME_USED)
 
@@ -452,13 +452,13 @@
 	sound_path = 'sound/machines/buzz/buzz-sigh.ogg'
 	sound_message = "buzzes."
 
-/datum/action/vehicle/sealed/noise/buzz/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/noise/buzz/Trigger(mob/clicker, trigger_flags)
 	if(..())
 		SEND_SIGNAL(vehicle_entered_target, COMSIG_VIM_BUZZ_USED)
 
 /datum/action/vehicle/sealed/headlights/vim
 	button_icon_state = "vim_headlights"
 
-/datum/action/vehicle/sealed/headlights/vim/Trigger(trigger_flags)
+/datum/action/vehicle/sealed/headlights/vim/Trigger(mob/clicker, trigger_flags)
 	. = ..()
 	SEND_SIGNAL(vehicle_entered_target, COMSIG_VIM_HEADLIGHTS_TOGGLED, vehicle_entered_target.headlights_toggle)

--- a/code/modules/wiremod/shell/brain_computer_interface.dm
+++ b/code/modules/wiremod/shell/brain_computer_interface.dm
@@ -250,7 +250,7 @@
 
 	return ..()
 
-/datum/action/innate/bci_charge_action/Trigger(trigger_flags)
+/datum/action/innate/bci_charge_action/Trigger(mob/clicker, trigger_flags)
 	var/obj/item/stock_parts/power_store/cell/cell = circuit_component.parent.cell
 
 	if (isnull(cell))


### PR DESCRIPTION
Original PR: 92354
-----
## About The Pull Request
Fixes the issue of usr pointing to admins by making Trigger pass down clicker, as usr is fucky and can be passed down by other unrelated procs. Fun.
Added the clicker arg to all usages of Trigger as well
Also changes isobserver check in antagonist ui_act code that prevents observers from clicking UI's instead to check if the ui.user is owner.current
## Why It's Good For The Game
Fixes admins giving heretic to people opening the heretic UI for the admin instead

## Changelog

:cl:
code: action's now pass down the clicker via the first arg of Trigger()
code: antagonist ui_act now ensures that the owners of the antag datum thesmelves can only do stuff in the UI
fix: admins giving out heretic antag no longer opens it for them.
/:cl:

