### PR TITLE
[TG Mirror] Adds warning that you can't absorb people you've used DNA extract on, and makes some descriptions more consistent [MDB IGNORE]

### DIFF
--- a/code/modules/antagonists/changeling/powers/mimic_voice.dm
+++ b/code/modules/antagonists/changeling/powers/mimic_voice.dm
@@ -2,7 +2,7 @@
 	name = "Mimic Voice"
 	desc = "We shape our vocal glands to sound like a desired voice. Maintaining this power slows chemical production."
 	button_icon_state = "mimic_voice"
-	helptext = "Will turn your voice into the name that you enter. We must constantly expend chemicals to maintain our form like this."
+	helptext = "Will turn our voice into the name that we enter. We must constantly expend chemicals to maintain our form like this."
 	chemical_cost = 0//constant chemical drain hardcoded
 	dna_cost = 1
 	req_human = TRUE

--- a/code/modules/antagonists/changeling/powers/mmi_talk.dm
+++ b/code/modules/antagonists/changeling/powers/mmi_talk.dm
@@ -2,7 +2,7 @@
 	name = "MMI Talk"
 	desc = "Our decoy brain has been implanted into a Man-Machine Interface. \
 		In order to maintain our secrecy, we can speak through the decoy as if a normal brain. \
-		The decoy brain will relay speech it hears to you in purple."
+		The decoy brain will relay speech it hears to us in purple."
 	button_icon = 'icons/obj/devices/assemblies.dmi'
 	button_icon_state = "mmi_off"
 	dna_cost = CHANGELING_POWER_UNOBTAINABLE

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -166,7 +166,7 @@
 
 	var/obj/item/held = target.get_active_held_item()
 	if(held && !target.dropItemToGround(held))
-		to_chat(user, span_warning("[held] is stuck to [target.p_their()] hand, you cannot grow a false armblade over it!"))
+		to_chat(user, span_warning("[held] is stuck to [target.p_their()] hand, we cannot grow a false armblade over it!"))
 		return
 
 	..()
@@ -193,7 +193,7 @@
 /datum/action/changeling/sting/extract_dna
 	name = "Extract DNA Sting"
 	desc = "We stealthily sting a target and extract their DNA. Costs 25 chemicals."
-	helptext = "Will give you the DNA of your target, allowing you to transform into them."
+	helptext = "Will give us the DNA of our target, allowing us to transform into them. This will render us unable to absorb their body fully later."
 	button_icon_state = "sting_extract"
 	chemical_cost = 25
 	dna_cost = 0

--- a/code/modules/antagonists/changeling/powers/void_adaption.dm
+++ b/code/modules/antagonists/changeling/powers/void_adaption.dm
@@ -1,9 +1,9 @@
 /datum/action/changeling/void_adaption
 	name = "Void Adaption"
 	desc = "We prepare our cells to resist the hostile environment outside of the station. We may freely travel wherever we wish."
-	helptext = "This ability is passive, and will automatically protect you in situations of extreme cold or vacuum, \
-		as well as removing your need to breathe oxygen, although you will still be affected by hazardous gases. \
-		While it is actively protecting you from temperature or pressure it reduces your chemical regeneration rate."
+	helptext = "This ability is passive, and will automatically protect us in situations of extreme cold or vacuum, \
+		as well as removing our need to breathe oxygen, although we will still be affected by hazardous gases. \
+		While it is actively protecting us from temperature or pressure it reduces our chemical regeneration rate."
 	owner_has_control = FALSE
 	dna_cost = 2
 


### PR DESCRIPTION
Original PR: 92397
-----

## About The Pull Request

Adds a warning in the DNA Extract Sting helptext that you won't be able to absorb bodies you've stung with it.
Also changes several "you"s and "your"s in the descriptions into the proper "we"s and such.

## Why It's Good For The Game

closes #92373 

Most of them already use "we"s "us"s and "our"s, and its oddly inconsistent as is

## Changelog
:cl:
qol: informs changelings they can't absorb people they've already taken the DNA of
spellcheck: changelings refer to themselves in second-person less
/:cl:
