### PR TITLE
[TG Mirror] Reduces mood debuff from empath examining evil people [MDB IGNORE]

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -519,7 +519,7 @@
 
 /datum/mood_event/encountered_evil
 	description = "I didn't want to believe it, but there are people out there that are genuinely evil."
-	mood_change = -4
+	mood_change = -1
 	timeout = 1 MINUTES
 
 /datum/mood_event/smoke_in_face


### PR DESCRIPTION
Original PR: 92461
-----
## About The Pull Request

Reduces the mood debuff from empaths examining people with the fundamentally evil quirk 

## Why It's Good For The Game

The mood malus is too high for a quirk that's meant to be a major positive. This maintains the interaction but turns the mood hit low enough to be mostly just for flavor rather than an actual penalty, similarly to examinining someone that is sad.

## Changelog

:cl:
del: Reduces mood penalty from Empaths examining people with the Fundamentally Evil quirk
/:cl:
